### PR TITLE
Arrange tutorials and add nav links

### DIFF
--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -21,36 +21,6 @@ module.exports = {
     // Links must be absolute with trailing slash '/guide/'
     // Trailing slash implies it is looking for a .md file
     sidebar: {
-      '/zoe/': [
-        {
-          title: 'Zoe',
-          path: '/zoe/guide/',
-          collapsable: false,
-          sideBarDepth: 5,
-          children: [
-            '/zoe/guide/',
-            '/zoe/guide/offer-safety'
-          ]
-        },
-        {
-          title: 'Zoe Contracts',
-          path: '/zoe/guide/contracts/',
-          collapsable: false,
-          sideBarDepth: 3,
-          children: [
-            '/zoe/guide/contracts/',
-            '/zoe/guide/contracts/autoswap',
-            '/zoe/guide/contracts/public-auction',
-            '/zoe/guide/contracts/public-swap'
-          ]
-        },
-        {
-          title: 'Zoe API',
-          path: '/zoe/api/',
-          collapsable: false
-        }
-      ],
-
       '/ertp/': [
         {
           title: 'ERTP Guide',
@@ -77,6 +47,48 @@ module.exports = {
               title: 'DescOps',
               path: '/ertp/api/descOps'
             }
+          ]
+        }
+      ],
+
+      '/zoe/': [
+        {
+          title: 'Zoe',
+          path: '/zoe/guide/',
+          collapsable: false,
+          sideBarDepth: 5,
+          children: [
+            '/zoe/guide/',
+            '/zoe/guide/offer-safety'
+          ]
+        },
+        {
+          title: 'Zoe Contracts',
+          path: '/zoe/guide/contracts/autoswap',
+          collapsable: false,
+          sideBarDepth: 3,
+          children: [
+            '/zoe/guide/contracts/autoswap',
+            '/zoe/guide/contracts/public-auction',
+            '/zoe/guide/contracts/public-swap'
+          ]
+        },
+        {
+          title: 'Zoe API',
+          path: '/zoe/api/',
+          collapsable: false
+        }
+      ],
+
+      '/smart-contracts-tutorials/': [
+        {
+          title: 'Smart Contracts Tutorials',
+          path: '/smart-contracts-tutorials/guess37-one',
+          collapsable: false,
+          sideBarDepth: 3,
+          children: [
+            '/smart-contracts-tutorials/guess37-one',
+            '/smart-contracts-tutorials/guess37-multiple'
           ]
         }
       ]

--- a/main/.vuepress/themeConfig/nav.js
+++ b/main/.vuepress/themeConfig/nav.js
@@ -8,6 +8,7 @@ module.exports = [
   {
     text: 'ERTP   ', // spaces to add some distance to next link
     ariaLabel: 'ERTP Menu',
+    link: '/ertp/guide/',
     items: [
       {
         text: 'Guide',
@@ -29,6 +30,7 @@ module.exports = [
   {
     text: 'Zoe',
     ariaLabel: 'Zoe Menu',
+    link: '/zoe/guide',
     items: [
       {
         text: 'Guide',
@@ -38,7 +40,7 @@ module.exports = [
       {
         text: 'Contracts',
         ariaLabel: 'Zoe Contracts Link',
-        link: '/zoe/guide/contracts'
+        link: '/zoe/guide/contracts/autoswap'
       },
       {
         text: 'API',
@@ -51,6 +53,23 @@ module.exports = [
         link: 'https://github.com/Agoric/Zoe'
       }
     ],
+  },
+  {
+    text: 'Tutorials',
+    ariaLabel: 'Tutorials Menu',
+    link: '/smart-contracts-tutorials/guess37-one',
+    items: [
+      {
+        text: 'Guess 37 - One Participant',
+        ariaLabel: 'Guess 37 - One Participant',
+        link: '/smart-contracts-tutorials/guess37-one'
+      },
+      {
+        text: 'Guess37 - Multiple Participants',
+        ariaLabel: 'Guess37 Multiple Participants',
+        link: '/smart-contracts-tutorials/guess37-multiple'
+      }
+    ]
   },
   {
     text: 'Learn More',

--- a/main/smart-contracts-tutorials/guess37-multiple.md
+++ b/main/smart-contracts-tutorials/guess37-multiple.md
@@ -1,4 +1,4 @@
-# Guess37 multiple participants
+# Guess37 - Multiple Participants
 
 In the [previous step](./first-contract), we set up a contract and ran it and played the guess37 game
 

--- a/main/smart-contracts-tutorials/guess37-one.md
+++ b/main/smart-contracts-tutorials/guess37-one.md
@@ -1,4 +1,6 @@
-# Tutorial on creating and running the simplest Smart Contract
+# Guess37 - One Participant
+
+## Tutorial on creating and running the simplest Smart Contract
 
 This first contract will be a one-player game where the player tries to guess a number. If they guess right, they win, otherwise, they lose. The game can be played any number of times and there is no actual stake. For the purpose of keeping things simple, the number is hardcoded to be `37`
 
@@ -119,7 +121,7 @@ seat~.guess(14)
 seat~.guess(37)
 ```
 
-### Commands breakdown 
+### Commands breakdown
 
 The first `home` command shows what was defined in `lib/ag-solo/vats/vat-pixel.js` as return value of `createPixelBundle`
 It is an object containing the properties `contractHost`, `handoffService` and `guess37ContractSource`

--- a/main/zoe/guide/contracts/README.md
+++ b/main/zoe/guide/contracts/README.md
@@ -1,3 +1,0 @@
-# Zoe Contracts
-
-Here you can find several contracts written with Zoe.


### PR DESCRIPTION
- Moves `/smart-contract-tutorials` into `/main`
- Renames `h1` in tutorials
- Fixes broken links
- Rearranges links for order
