### PR TITLE
Update mint.mint examples for clarity, add missing method

### DIFF
--- a/main/ertp/api/assay.md
+++ b/main/ertp/api/assay.md
@@ -85,8 +85,8 @@ Make an empty purse associated with this kind of right.
 ```js
 import { makeMint } from './core/mint';
 
-const mint = makeMint('fungible');
-const assay = mint.getAssay();
+const myNewMint = makeMint('fungible');
+const assay = myNewMint.getAssay();
 
 // After creating an assay you can create an empty purse:
 const targetPurse = assay.makeEmptyPurse();
@@ -105,9 +105,9 @@ Combine multiple payments into one payment.
 ```js
 import { makeMint } from './core/mint';
 
-const mint = makeMint('fungible');
-const assay = mint.getAssay();
-const purse = mint.mint(1000);
+const myNewMint = makeMint('fungible');
+const assay = myNewMint.getAssay();
+const purse = myNewMint.mint(1000);
 
 // Create a payments array. Each element, or payment, has a value of 1.
 const payments = [];
@@ -156,9 +156,9 @@ Make a new `Payment` that has exclusive rights to all the contents of `src`. If 
 ```js
 import { makeMint } from './core/mint';
 
-const mint = makeMint('fungible');
-const assay = mint.getAssay();
-const purse = mint.mint(1000);
+const myNewMint = makeMint('fungible');
+const assay = myNewMint.getAssay();
+const purse = myNewMint.mint(1000);
 
 const payment = await purse.withdraw(7);
 const newPayment = await assay.claimExactly(7, payment);
@@ -178,9 +178,9 @@ Make a new `Payment` that has exclusive rights to all the contents of `src`.
 ```js
 import { makeMint } from './core/mint';
 
-const mint = makeMint('fungible');
-const assay = mint.getAssay();
-const purse = mint.mint(1000);
+const myNewMint = makeMint('fungible');
+const assay = myNewMint.getAssay();
+const purse = myNewMint.mint(1000);
 
 const payment = await purse.withdraw(10);
 const newPayment = await assay.claimAll(payment);
@@ -199,9 +199,9 @@ Burn all of the rights from `src`. If `units` does not equal the balance of the 
 ```js
 import { makeMint } from './core/mint';
 
-const mint = makeMint('fungible');
-const assay = mint.getAssay();
-const purse = mint.mint(1000);
+const myNewMint = makeMint('fungible');
+const assay = myNewMint.getAssay();
+const purse = myNewMint.mint(1000);
 
 const payment = await purse.withdraw(10);
 
@@ -221,9 +221,9 @@ Burn all of the rights from `src`.
 ```js
 import { makeMint } from './core/mint';
 
-const mint = makeMint('fungible');
-const assay = mint.getAssay();
-const purse = mint.mint(1000);
+const myNewMint = makeMint('fungible');
+const assay = myNewMint.getAssay();
+const purse = myNewMint.mint(1000);
 
 const payment = await purse.withdraw(10);
 await assay.burnAll(payment);

--- a/main/ertp/api/mint.md
+++ b/main/ertp/api/mint.md
@@ -28,6 +28,26 @@ const happyTownBucks = makeMint('happyTownBucks');
 const sadTownBucks = makeMint('sadTownBucks');
 ```
 
+## mint.mint(initialBalance, name)
+- `initialBalance` `{Units}` - Initial balance for the purse
+- `name` `{String}` - Name for the purse. Default is 'a purse'.
+- Returns: `{Purse}`
+
+Since newly minted units need to be held somewhere, this method actually creates a new Purse containing the specified units.
+Units must be held in either a Payment or a Purse.
+
+```js
+import { makeMint } from '@agoric/ertp/core/mint';
+const happyTownBucks = makeMint('happyTownBucks');
+
+// Create a new purse with 100 happyTownBucks
+const myHappyTownBucks = happyTownBucks.mint(100, 'myHappyTownBucks');
+
+// Create you a purse with 200 happyTownBucks
+const yourHappyTownBucks = happyTownBucks.mint(200, 'yourHappyTownBucks');
+
+```
+
 ## mint.getAssay()
 - Returns: `{Assay}`
 

--- a/main/ertp/api/payment.md
+++ b/main/ertp/api/payment.md
@@ -27,9 +27,9 @@ Get the units contained in this payment, confirmed by the assay.
 ```js
 import { makeMint } from './core/mint';
 
-const mint = makeMint('fungible');
-const assay = mint.getAssay();
-const purse = mint.mint(1000);
+const myNewMint = makeMint('fungible');
+const assay = myNewMint.getAssay();
+const purse = myNewMint.mint(1000);
 
 const payments = [];
 payments.push(purse.withdraw(20));

--- a/main/ertp/api/purse.md
+++ b/main/ertp/api/purse.md
@@ -32,9 +32,9 @@ Get the `units` contained in this purse, confirmed by the assay.
 ```js
 import { makeMint } from './core/mint';
 
-const mint = makeMint('fungible');
-const assay = mint.getAssay();
-const purse = mint.mint(1000);
+const myNewMint = makeMint('fungible');
+const assay = myNewMint.getAssay();
+const purse = myNewMint.mint(1000);
 
 // Returns 1000
 purse.getBalance();
@@ -50,9 +50,9 @@ Deposit all the contents of `src` Payment into this purse, returning the `units`
 ```js
 import { makeMint } from './core/mint';
 
-const mint = makeMint('fungible');
-const assay = mint.getAssay();
-const purse = mint.mint(1000);
+const myNewMint = makeMint('fungible');
+const assay = myNewMint.getAssay();
+const purse = myNewMint.mint(1000);
 const targetPurse = assay.makeEmptyPurse();
 const payment = await purse.withdraw(7);
 
@@ -72,9 +72,9 @@ Deposit all the contents of `srcPayment` into this purse, returning the `units`.
 ```js
 import { makeMint } from './core/mint';
 
-const mint = makeMint('fungible');
-const assay = mint.getAssay();
-const purse = mint.mint(1000);
+const myNewMint = makeMint('fungible');
+const assay = myNewMint.getAssay();
+const purse = myNewMint.mint(1000);
 const targetPurse = assay.makeEmptyPurse();
 
 const payment = await purse.withdraw(22);
@@ -94,9 +94,9 @@ Withdraw `units` from this purse into a new Payment.
 ```js
 import { makeMint } from './core/mint';
 
-const mint = makeMint('fungible');
-const assay = mint.getAssay();
-const purse = mint.mint(1000);
+const myNewMint = makeMint('fungible');
+const assay = myNewMint.getAssay();
+const purse = myNewMint.mint(1000);
 
 const payment = purse.withdraw(20);
 
@@ -113,9 +113,9 @@ Withdraw entire content of this purse into a new Payment.
 ```js
 import { makeMint } from './core/mint';
 
-const mint = makeMint('fungible');
-const assay = mint.getAssay();
-const purse = mint.mint(1000);
+const myNewMint = makeMint('fungible');
+const assay = myNewMint.getAssay();
+const purse = myNewMint.mint(1000);
 
 const payment = purse.withdrawAll();
 


### PR DESCRIPTION
Updates examples so we don't have `mint.mint()` everywhere.

Add missing `mint.mint()` method in API. Added an explanation as to why the `.mint()` method creates a purse, which is a bit unintuitive at first.

Closes #36 