### PR TITLE
WIP: Move over the documentation on mint configuration

### DIFF
--- a/main/ertp/guide/default-configuration.md
+++ b/main/ertp/guide/default-configuration.md
@@ -1,88 +1,149 @@
-# Mint Configuration
+# Custom Mints
 
-## What is a configuration?
+The `makeMint` function in `mint.js` takes in a configuration
+function that can change a number of things about how mints, assays,
+purses, and payments are made.
 
-Configurations add custom methods to payments, purses, and mints, defines the functions to make the "mintKeeper" (the actual holder of the mappings from purses/payments to amounts), and makes the "assay" (the object that describes the strategy of how amounts are withdrawn or deposited, among other things).
+By default, `makeBasicFungibleConfig` is used as the configuration.
+This creates a mint for a fungible token with no custom methods.
 
-## When is it used?
+But, imagine that we want to add a custom method to the `mint` object.
+Maybe we want to be able to know how much has been minted so far. To
+do so, we will need to create our own custom configuration.
 
-`makeMint` takes in a function to make a configuration. `makeMint` uses a basic fungible configuration if none is passed in. Fungible tokens (our default for mints) do not customize payments, purses, etc. They use the "basic" mintKeeper (the place where the amounts per purse and payment are recorded) and use the "Nat" assay, in which amounts are natural numbers and use subtraction and addition.
-
-## Basic make configuration function
-
-The function to make a configuration should return an object with the following properties:
-
-- `makePaymentTrait()`
-- `makePurseTrait()`
-- `makeMintTrait()`
-- `makeIssuerTrait()`
-- `makeMintKeeper()`
-- `strategy` - {Object}
+Our custom configuration will look like this:
 
 ```js
-import harden from '@agoric/harden';
+const makeTotalSupplyConfig = () => {
 
-function makeConfig() {
-  return harden({})
+  function* makePaymentTrait(_corePayment) {
+    yield harden({});
+  }
+
+  function* makePurseTrait(_corePurse) {
+    yield harden({});
+  }
+
+  function* makeMintTrait(_coreMint, _assay, _assay, mintKeeper) {
+    yield harden({
+      getTotalSupply: () => mintKeeper.getTotalSupply(),
+    });
+  }
+
+  function* makeAssayTrait(_coreAssay) {
+    yield harden({});
+  }
+
+  return harden({
+    makePaymentTrait,
+    makePurseTrait,
+    makeMintTrait,
+    makeAssayTrait,
+    makeMintKeeper: makeTotalSupplyMintKeeper,
+    extentOpsName: 'natExtentOps',
+    extentOpsArgs: [],
+  });
+};
+```
+In this custom configuration, we've done two things: we've added a
+method to `mint` called `getTotalSupply`, and we've changed the
+`mintKeeper` to a custom mintKeeper that keeps track of the total
+supply for us (more on this in separate documentation).
+
+Let's take a look into how we are able to add new methods to mints,
+assays, purses, and payments.
+
+In `makePaymentTrait`, we take `corePayment` as a parameter. The
+`corePayment` is constructed in `mint.js` and has all of the
+methods we are familiar with:
+
+```js
+const corePayment = harden({
+  getAssay() {
+    return assay;
+  },
+  getBalance() {
+    return paymentKeeper.getUnits(payment);
+  },
+  getName() {
+    return name;
+  },
+});
+```
+
+Our custom code, `makePaymentTrait`, returns an object with custom methods.
+These methods will be added to the `corePayment`. For this particular
+customization, we want to leave payments alone, so we will create a
+generator function that yields an empty object:
+
+```js
+function* makePaymentTrait(_corePayment) {
+  yield harden({});
 }
 ```
 
-```js
-import harden from '@agoric/harden';
+However, we do want to add an extra method to mints. So,
+`makeMintTrait` is defined as:
 
-function makeBasicFungibleConfig() {
-  return harden({
-    // no customization
-    makePaymentTrait(_superPayment) {
-      return harden({});
-    },
-    // no customization
-    makePurseTrait(_superPurse) {
-      return harden({});
-    },
-    // no customization
-    makeMintTrait(_superMint) {
-      return harden({});
-    },
-    // no customization
-    makeIssuerTrait(_superIssuer) {
-      return harden({});
-    },
-    makeMintKeeper: makeCoreMintKeeper,
-    strategy: natStrategy,
+```js
+function* makeMintTrait(_coreMint, _assay, _assay, mintKeeper) {
+  yield harden({
+    getTotalSupply: () => mintKeeper.getTotalSupply(),
   });
 }
 ```
 
-## Configuration Object defaults
+Back in `mints.js`, our custom methods will be combined with the
+"core" methods already present. Here's how that works for our custom
+mint methods:
 
-- `makePaymentTrait(_superPayment)` - default {}
-- `makePurseTrait(_superPurse)` - default {}
-- `makeMintTrait(_superMint)` - default {}
-- `makeIssuerTrait(_superIssuer)` - default {}
-- `makeMintKeeper` - default `makeCoreMintKeeper`
-- `strategy` - default `natStrategy`
+```js
+const makeMintTraitIter = makeMintTrait(coreMint, assay, assay, mintKeeper);
+const mintTrait = makeMintTraitIter.next().value;
+const mint = harden({
+  ...mintTrait,
+  ...coreMint,
+});
+makeMintTraitIter.next(mint);
+```
 
-### Core Mint Keeper
+## The Trait Pattern
 
-- `mintKeeper`
-- `mintKeeper.purseKeeper` - asset
-- `mintKeeper.paymentKeeper` - asset
-- `mintKeeper.isPurse(asset)`
-- `mintKeeper.isPayment(asset)`
+We want the core behavior of mints, assays, purses and payments to be
+consistent and reliable across different types of assets. On the other
+hand, we do know that there is a genuine need to have slightly
+different purposes expressed.
 
-`mintKeeper.purseKeeper` and `mintKeeper.paymentKeeper` are both asset keepers. An asset can either be a purse or payment. An asset keeper keeps track of either all of the purses (purseKeeper) or all of the payments (paymentKeeper) and their respective amounts. Asset keepers have the following properties:
-- `updateAmount(asset, newAmount)`
-- `recordeNew(asset, initialAmount)`
-- `getAmount(asset)`
-- `has(asset)`
-- `remove(asset)`
+This is why we've chosen to use the [Trait
+pattern](https://en.wikipedia.org/wiki/Trait_%28computer_programming%29),
+in which custom behavior can be defined and recombined easily.
+Furthermore, if we always combine the methods such that the "core"
+methods are last, they cannot be overridden by the custom methods.
 
-### Strategies
+## Why generator functions?
 
-ERTP comes with several strategies you can use in your project. The `natStrategy` is used in the default configuration.
+To use the trait pattern defensively, we must arrange for robust self-reference. In the examples above, the trait code does not refer to the object itself. But we also define traits like
 
-The following methods are defined in each strategy:
+```js
+function* makePaymentTrait(_corePayment, assay) {
+  const payment = yield harden({
+    // This creates a new use object which destroys the payment
+    unwrap: () => makeUseObjForPayment(assay, payment),
+  });
+}
+```
+
+Above, the `payment` object is the actual payment to which this trait contributes the `unwrap` method. We introduce this peculiar generator pattern to solve this self-reference problem. The `payment` variable refers to the object as a whole. However, the object-as-a-whole is not yet assembled, and will be assembled only by a distinct piece of code written in a distinct scope.
+
+In the generator function pattern shown above, the trait methods of a given layer are defined in the scope of the `payment` variable bound on the left of the yield. The `payment` variable is bound to the value that the yield returns. However, before that happens, the generator yields the argument to yield, which is the object containing the trait's methods, to be combined to make the object itself. The pattern above containing `makeMintTraitIter` first runs one step of the trait generator to obtain the trait methods, combining them into the overall object. Only when the object is complete does it go back to the generator, in order to bind that object to that trait's variable for the object itself, such as `payment`.
+
+This is an ad-hoc version of a special case for supporting trait composition. See [Making Layer Cakes](https://github.com/Agoric/layer-cake) for our draft of a reusable library for supporting such patterns of trait composition. When it is ready we expect to switch to it.
+
+### ExtentOps
+
+ERTP comes with several extentOps (logic for set operations) you can use in your project. The `natExtentOps` is used in the default configuration.
+
+The following methods are defined in each extentOps:
 - `insistKind`
 - `empty`
 - `isEmpty`
@@ -91,10 +152,8 @@ The following methods are defined in each strategy:
 - `with`
 - `without`
 
+### NatExtentOps
 
-`listStrategy`
-
-`natStrategy`
 The default kind of amount is a labeled natural number describing a quantity of fungible erights. The label describes what kinds of rights these are. This is a form of labeled unit, as in unit typing.
 
 Natural numbers are used for fungible erights such as money because rounding issues make floats problematic. All operations should be done with the smallest whole unit such that the NatAssay never deals with fractional parts.


### PR DESCRIPTION
This PR is moving over the documentation for the mint configuration from ERTP (now in the monorepo). I think it makes enough sense in this format to be better than what exists, but there is a lot of work still to do to explain mint configurations. 

@DavidBruant would you be able to take it from here? 

Closes #63 