### PR TITLE
Agoric CLI updates

### DIFF
--- a/main/getting-started/README.md
+++ b/main/getting-started/README.md
@@ -22,64 +22,50 @@ ability to run contracts on chain to the Agoric CLI, but you can find
 
 ## Quick Overview
 
-To create and start a project, run:
+First, see the [prerequisites](#Prerequisites) below for how to set up your Agoric CLI.
+
+Then, to create and start a project, run:
 
 ```sh
-npx agoric init demo
+agoric init demo
 cd demo
-npx agoric install
-npx agoric start
+agoric install
+agoric start
 ```
 
 In another shell, from the same project directory:
 
 ```sh
 cd demo
-npx agoric deploy ./contract/deploy.js ./api/deploy.js
+agoric deploy ./contract/deploy.js ./api/deploy.js
 cd ui
-npm install
-npm run start
+yarn install
+yarn start
 ```
-
-_([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher)_
 
 Then open:
 - [http://localhost:3000](http://localhost:3000) to see our demo DApp.<br>
 - [http://localhost:8000/wallet](http://localhost:8000/wallet) to see the Simple Wallet.<br>
-- [http://localhost:8000/](http://localhost:8000/) to see your the REPL.<br>
+- [http://localhost:8000/](http://localhost:8000/) to see your REPL (Read-Eval-Print Loop).<br>
 
 ## Prerequisites
 
-### Vagrant
+First, install [Node.js](http://nodejs.org/), and [Yarn 1](https://legacy.yarnpkg.com/en/docs/install).  You’ll need to have **Node 10.16.0 or later**.
 
-To run a standardized Linux distribution with all the required development tools, you can use [Vagrant](https://www.vagrantup.com/docs/):
-
-```sh
-vagrant up --provider=docker
-# or
-vagrant up --provider=virtualbox
-# then
-vagrant ssh
-```
-
-The Vagrant setup has synchronized filesystem access with the workspace directory on your host system, so you can use your favourite IDE to modify the files, and just run Linux commands on the SSH connection.
-
-### Developing on the current OS
-
-If you don't use Vagrant, you can develop on your own local operating system.
-
-First, install [Node.js](http://nodejs.org/), [npm](https://npmjs.com/), and [go](https://golang.org/). You’ll need to have **Node 10.16.0 or later**, and **Go 1.12 or later**.
-
-You can install the Agoric CLI globally:
+For now, you will need to set up the Agoric CLI as part of a checked-out Agoric SDK.  Run:
 
 ```sh
-npm install -g agoric
-```
-
-or invoke it on demand without installing it using via `npx`:
-
-```sh
-npx agoric [...options]
+# Get the latest Agoric SDK in the agoric-sdk directory.
+git clone https://github.com/Agoric/agoric-sdk
+# Change to the agoric-sdk directory.
+cd agoric-sdk
+# Install NPM dependencies.
+yarn install
+# Build sources that need compiling.
+yarn build
+# You can install the agoric CLI anywhere in your $PATH,
+# here is how to do it as /usr/local/bin/agoric
+yarn link-cli /usr/local/bin/agoric
 ```
 
 ## Your First Agoric Dapp
@@ -101,13 +87,11 @@ cd demo
 the files you might need.
 
 ### 2. Installing the dependencies
-Next, let's install the necessary JavaScript packages and Go
-dependencies. This step might take a while. We use Go on our testnet,
-so this step is preparing for the near future in which we use this
-tutorial to run on our testnet.
+Next, let's install the necessary JavaScript packages. This step might
+take a while.
 
 ```sh
-# Install Javascript/Go dependencies.
+# Install Javascript dependencies.
 agoric install
 ```
 
@@ -134,8 +118,8 @@ Now let's start up the Autoswap frontend, our demo DApp:
 
 ```sh
 cd ui
-npm install
-npm run start  
+yarn install
+yarn start  
 ```
 
 This launches the React development server and opens a tab in your default browser, and will allow you to

--- a/package-lock.json
+++ b/package-lock.json
@@ -969,9 +969,9 @@
       }
     },
     "@vue/component-compiler-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.0.0.tgz",
-      "integrity": "sha512-am+04/0UX7ektcmvhYmrf84BDVAD8afFOf4asZjN84q8xzxFclbk5x0MtxuKGfp+zjN5WWPJn3fjFAWtDdIGSw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.1.1.tgz",
+      "integrity": "sha512-+lN3nsfJJDGMNz7fCpcoYIORrXo0K3OTsdr8jCM7FuqdI4+70TY6gxY6viJ2Xi1clqyPg7LpeOWwjF31vSMmUw==",
       "dev": true,
       "requires": {
         "consolidate": "^0.15.1",
@@ -979,18 +979,12 @@
         "lru-cache": "^4.1.2",
         "merge-source-map": "^1.1.0",
         "postcss": "^7.0.14",
-        "postcss-selector-parser": "^5.0.0",
-        "prettier": "1.16.3",
+        "postcss-selector-parser": "^6.0.2",
+        "prettier": "^1.18.2",
         "source-map": "~0.6.1",
         "vue-template-es2015-compiler": "^1.9.0"
       },
       "dependencies": {
-        "cssesc": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
-          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
-          "dev": true
-        },
         "lru-cache": {
           "version": "4.1.5",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -999,17 +993,6 @@
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
-          }
-        },
-        "postcss-selector-parser": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
-          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
-          "dev": true,
-          "requires": {
-            "cssesc": "^2.0.0",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
           }
         },
         "source-map": {
@@ -7509,9 +7492,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
-      "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "pretty-error": {
@@ -9521,9 +9504,9 @@
       "dev": true
     },
     "vue": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
-      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
+      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==",
       "dev": true
     },
     "vue-hot-reload-api": {
@@ -9533,12 +9516,12 @@
       "dev": true
     },
     "vue-loader": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.7.1.tgz",
-      "integrity": "sha512-fwIKtA23Pl/rqfYP5TSGK7gkEuLhoTvRYW+TU7ER3q9GpNLt/PjG5NLv3XHRDiTg7OPM1JcckBgds+VnAc+HbA==",
+      "version": "15.8.3",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.8.3.tgz",
+      "integrity": "sha512-yFksTFbhp+lxlm92DrKdpVIWMpranXnTEuGSc0oW+Gk43M9LWaAmBTnfj5+FCdve715mTHvo78IdaXf5TbiTJg==",
       "dev": true,
       "requires": {
-        "@vue/component-compiler-utils": "^3.0.0",
+        "@vue/component-compiler-utils": "^3.1.0",
         "hash-sum": "^1.0.2",
         "loader-utils": "^1.1.0",
         "vue-hot-reload-api": "^2.3.0",
@@ -9611,9 +9594,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
-      "integrity": "sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz",
+      "integrity": "sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "homepage": "https://github.com/Agoric/documentation#readme",
   "dependencies": {},
   "devDependencies": {
+    "vue": "^2.6.11",
+    "vue-loader": "^15.8.3",
+    "vue-template-compiler": "^2.6.11",
     "vuepress": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
   "homepage": "https://github.com/Agoric/documentation#readme",
   "dependencies": {},
   "devDependencies": {
-    "vue": "^2.6.11",
-    "vue-loader": "^15.8.3",
-    "vue-template-compiler": "^2.6.11",
     "vuepress": "^1.1.0"
   }
 }


### PR DESCRIPTION
Modify the getting started instructions to use only the `agoric-sdk` version of `agoric-cli`.  We hope to make `npx agoric` also work in the future, but this has fewer dependencies and is more efficient.
