### PR TITLE
MathHelpers fix

### DIFF
--- a/main/ertp/api/math-helpers.md
+++ b/main/ertp/api/math-helpers.md
@@ -1,14 +1,31 @@
-# Math Helpers
-All of the differences in how digital asset amount are manipulated can
-be reduced to the behavior of the math on extents. We extract this
-custom logic into mathHelpers. MathHelpers are about extent
-arithmetic, whereas AmountMath is about amounts, which are the extents
-labeled with a brand. AmountMath use mathHelpers to do their extent
-arithmetic, and then brand the results, making a new amount.
+# MathHelpers
+AmountMath is about doing math operations on `amount`s, which are extents labeled with a brand.
+AmountMath uses MathHelpers to do its extent arithmatic operations. It then brands the results,
+creating a new `amount`. 
+
+There are three different types of MathHelpers, each of which implements all the methods shown 
+on this page. You only have to specify the MathHelper type when creating an `issuer`; it then knows
+which type's operations to use on itself. 
+
+There are three types of MathHelpers, each of which implements all of the same 
+set of API methods (i.e. MathHelpers are polymorphic):
+- `nat`: Used with fungible assests.
+- `strSet`: Used with non-fungible assets.
+- `set`: Used with sets of objects, primarily non-fungible assets.
+
+Use `produceIssuer(allegedName, mathHelpersName)` to specify which type of MathHelpers
+your contract uses. The second parameter, `mathHelpersName` is optional and defaults 
+to `nat` if not given. For example
+```js
+produceIssuer('quatloos`); // Defaults to 'nat'
+produceIssuer('quatloos', 'strSet');
+produceIssuer('quatloos, 'set');
+```
+For more details on the MathHelper types, see the [ERTP Guide's MathHelpers section](https://agoric.com/documentation/ertp/api/math-helpers.html)
 
 ::: warning MathHelpers versus AmountMath
-These MathHelpers should not be used on their own. Instead, a local
-version of AmountMath should be made (see below).
+MathHelper operations should not be used on their own. Instead, you 
+should first make a local version of AmountMath as shown below.
 :::
 
 

--- a/main/ertp/guide/math-helpers.md
+++ b/main/ertp/guide/math-helpers.md
@@ -20,17 +20,18 @@ See the [MathHelpers API documentation](https://agoric.com/documentation/ertp/ap
 
 ## MathHelpers Choices
 
-### 'nat'
-The default fungible asset case. For example, an amount you'd use `nat` MathHelpers with might look like:
+### nat
+The default fungible asset case, which works with natural number extents. 
+For example, an amount you'd use `nat` MathHelpers with might look like:
 
 ```js
 { brand: myBrand, extent: 40 }
 ```
 
-### 'strSet'
-High performance operations on sets of string IDs for a basic nonfungible asset
-case. An amount you'd use `strSet` with might look like the following. Note that
-the `extent` is not a numeric value, but an array specifying a specific `myBrand` object.
+### strSet
+Used for MathHelper operations on sets of string IDs for a basic nonfungible asset
+case. Note that the `extent` is not a numeric value, but an array specifying a 
+specific `myBrand` appropriate object. An amount you'd use `strSet` with might look like the following.
 
 ```js
 { brand: myBrand, extent: ['39283', 'bas029s'] }
@@ -40,13 +41,18 @@ Often, this ID can be looked up in an external or off-chain API to
 learn more about the digital assets. Note that what the API returns is
 up to the owner of the API and may not be trustworthy.
 
-### 'set'
-Lower performance operations on sets of objects representing more complex
-information. An amount might look like:
+### set
+Used for MathHelper operations on sets of objects representing more complex
+information. An amount that uses `set` might look like:
 
 ```js
 { brand: myBrand, extent: [{ seat: '16F', flight: '39DFK', date: '2020-06-08'}] }
 ```
 
-While the `set` mathHelpers are slower than the `strSet` equivalents, they are
-more trustworthy because all of the necessary information is in the extent.
+`set` operations are more trustworthy than `strSet` operations 
+because all of the necessary information is in the extent. In `strSet` extents,
+you often only get an ID (for example, a Vehicle Identification Number (VIN) 
+for a car), with other important information stored elsewhere (the car's make, model, color, etc.) 
+In `set` extents, the extent often has all the important information for a third party to know.
+Information in an immutable extent is more credible than information retrieved from an external source
+since that source could potentially manipulate the information.

--- a/main/ertp/guide/math-helpers.md
+++ b/main/ertp/guide/math-helpers.md
@@ -1,11 +1,27 @@
 # MathHelpers
-MathHelpers are the "arithmetic" operations on extents, used for actions like
-addition, subtraction, and greater than or equal to. There are currently three choices for mathHelpers.
+AmountMath uses MathHelpers to do their extent arithmetic. The results are branded, making
+a new amount (which consists of an extent and a brand). MathHelper operations include addition,
+subtraction, equality checking, greater than testing, and working with empty extents.
 
-## Choices of MathHelpers
+The MathHelper operations are polymorphic. There are three types of MathHelpers, each of which 
+implements all of the same set of API methods:
+- `nat`: Used with fungible assests.
+- `strSet`: Used with non-fungible assets.
+- `set`: Used with sets of objects, primarily non-fungible assets **tyg todo: Is the non-fungible part correct?**
+
+Use `produceIssuer(allegedName, mathHelpersName)` to specify which type of MathHelpers your contract uses. The second
+parameter, `mathHelpersName` is optional and defaults to `nat` if not given. For example
+```
+produceIssuer('quatloos`); // Defaults to 'nat'
+produceIssuer('quatloos', 'strSet');
+produceIssuer('quatloos, 'set');
+```
+See the [MathHelpers API documentation](https://agoric.com/documentation/ertp/api/math-helpers.html) for the set of operations all the above types implement.
+
+## MathHelpers Types
 
 ### 'nat'
-The default fungible asset case. For example, an amount might look like:
+The default fungible asset case. For example, an amount you'd use `nat` MathHelpers with might look like:
 
 ```js
 { brand: myBrand, extent: 40 }
@@ -13,7 +29,8 @@ The default fungible asset case. For example, an amount might look like:
 
 ### 'strSet'
 High performance operations on sets of string IDs for a basic nonfungible asset
-case. An amount might look like:
+case. An amount you'd use `strSet` with might look like the following. Note that
+the `extent` is not a numeric value, but an array specifying a specific `myBrand` object.
 
 ```js
 { brand: myBrand, extent: ['39283', 'bas029s'] }
@@ -31,6 +48,5 @@ information. An amount might look like:
 { brand: myBrand, extent: [{ seat: '16F', flight: '39DFK', date: '2020-06-08'}] }
 ```
 
-While the `set` mathHelpers are slower than the `strSet`, they are
-more trustworthy because all of the necessary information is in the
-extent.
+While the `set` mathHelpers are slower than the `strSet` equivalents, they are
+more trustworthy because all of the necessary information is in the extent.

--- a/main/ertp/guide/math-helpers.md
+++ b/main/ertp/guide/math-helpers.md
@@ -1,24 +1,24 @@
 # MathHelpers
-AmountMath uses MathHelpers to do their extent arithmetic. The results are branded, making
+AmountMath uses MathHelpers to do extent arithmetic. The results are branded, making
 a new amount (which consists of an extent and a brand). MathHelper operations include addition,
-subtraction, equality checking, greater than testing, and working with empty extents.
+subtraction, equality checking, comparison of two extents, and working with empty extents.
 
-The MathHelper operations are polymorphic. There are three types of MathHelpers, each of which 
+The MathHelper operations are polymorphic. You have your choice of three MathHelpers, each of which 
 implements all of the same set of API methods:
 - `nat`: Used with fungible assests.
-- `strSet`: Used with non-fungible assets.
-- `set`: Used with sets of objects, primarily non-fungible assets **tyg todo: Is the non-fungible part correct?**
+- `strSet`: Used with non-fungible assets, operates on an array of string identifiers
+- `set`: Used with non-fungible assets, operates on an array of records (objects) with keys and values
 
-Use `produceIssuer(allegedName, mathHelpersName)` to specify which type of MathHelpers your contract uses. The second
+Use `produceIssuer(allegedName, mathHelpersName)` to specify which MathHelpers choice your contract uses. The second
 parameter, `mathHelpersName` is optional and defaults to `nat` if not given. For example
 ```
-produceIssuer('quatloos`); // Defaults to 'nat'
+produceIssuer('quatloos'); // Defaults to 'nat'
 produceIssuer('quatloos', 'strSet');
 produceIssuer('quatloos, 'set');
 ```
-See the [MathHelpers API documentation](https://agoric.com/documentation/ertp/api/math-helpers.html) for the set of operations all the above types implement.
+See the [MathHelpers API documentation](https://agoric.com/documentation/ertp/api/math-helpers.html) for the set of operations all the above choices implement.
 
-## MathHelpers Types
+## MathHelpers Choices
 
 ### 'nat'
 The default fungible asset case. For example, an amount you'd use `nat` MathHelpers with might look like:


### PR DESCRIPTION
Revised ERTP Guide section on MathHelpers and intro to ERTP API MathHelpers doc to explain in both places about the three types of MathHelpers, what and why to use them, and how to specify in code which type to use.