### PR TITLE
Edit pass on Atomic Swap contract text 

### DIFF
--- a/main/zoe/guide/contracts/atomic-swap.md
+++ b/main/zoe/guide/contracts/atomic-swap.md
@@ -2,26 +2,22 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/atomicSwap.js) (Last updated: 9/12/2020)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/atomicSwap.js) (Last updated: 12-SEP-2020)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
-
-::: tip Out-of-date status
-Zoe's master branch is currently an Alpha release candidate. This doc and its underlying contract are in the process of being updated, and should be current with the release candidate in another few days. What you see here is out of date. We apologize for any inconvenience this may cause.
-:::
 
 If I want to trade one kind of asset for another kind, I could send
 you the asset and ask you to send me the other kind back. But, you
-could choose to behave opportunistically: receive my asset and give
-nothing back. To solve this problem, swap contracts allow users to
-securely trade one kind of digital asset for another kind, leveraging Zoe for
-escrow and offer safety. At no time does any user have the ability to
-behave opportunistically.
+might behave opportunistically and receive my asset then give
+nothing back. To solve this problem, swap contracts let users trade
+one kind of digital asset for another kind, using Zoe for
+escrow and offer safety. No user can ever behave opportunistically.
 
-In the `atomicSwap` contract, anyone can securely swap with a counterparty by escrowing digital assets with Zoe and sending an invitation to the counterparty.
+In the `atomicSwap` contract, anyone can securely swap with a counterparty
+by escrowing digital assets with Zoe and sending an invitation to the counterparty.
 
-Let's say that Alice wants to swap with Bob as the counterparty. She
-already has access to the installation of the contract, so she
-can create a swap instance:
+Let's say Alice wants to swap with Bob as the counterparty. She
+already has access to the contract installation, so she
+creates a swap instance:
 
 ```js
 const issuerKeywordRecord = harden({
@@ -32,13 +28,15 @@ const { creatorInvitation } =
   await E(zoe).startInstance(installation, issuerKeywordRecord);
 ```
 
-Then she escrows her offer with Zoe. When she escrows, she passes in two
-things, the actual ERTP payments that are part of her offer, and a
-`proposal`. The proposal will be used by Zoe to protect Alice from the
-smart contract and other participants. The proposal has three parts:
-`give` and `want`, which are used for enforcing offer safety, and `exit`,
-which is used to enforce exit safety. In this case, Alice's exit rule is
-`onDemand`, meaning that she can exit at any time.
+Next she escrows her offer with Zoe. She passes in a `proposal`
+and the actual ERTP payments that are part of her offer. 
+Zoe uses the proposal to protect Alice from the
+smart contract and other participants. 
+
+The proposal has three parts;
+`give` and `want`, which enforce offer safety, and `exit`,
+which enforces exit safety. Here, Alice's exit rule is
+`onDemand`, so she can exit at any time.
 
 ```js
 const threeMoola = moolaAmountMath.make(3);
@@ -52,21 +50,21 @@ const aliceMoola = await E(aliceMoolaPurse).withdraw(threeMoola);
 const alicePayment = { Asset: aliceMoola };
 ```
 
-In order for Alice to escrow with Zoe she needs to use her invite.  Once
-Alice uses her invite and makes her offer she will receive a `seat`, which
-gives her access to the outcome of the offer and to her payouts.
+For Alice to escrow with Zoe, she needs to use her invitation.  After
+using her invitation and making her offer, she receives a `seat`, 
+giving her access to the offer's outcome and her payouts.
 
 ```js
 const aliceSeat = await E(zoe).offer(aliceInvite, aliceProposal, alicePayments);
 ```
 
-The outcome of the first offer is an invite Alice can send to Bob:
+The first offer's outcome is an `invitation` Alice sends to Bob:
 
 ```js
 const invitationP = aliceSeat.getOfferResult();
 ```
 
-She then sends the invite to Bob and he examines the invite to see if it
+Bob receives the invitation and checks to see if it
 matches Alice's claims.
 
 ```js
@@ -85,13 +83,11 @@ assert(bobIssuers.Asset === moolaIssuer, details`unexpected Asset issuer`);
 assert(bobIssuers.Price === simoleanIssuer, details`unexpected Price issuer`);
 assert(moolaAmountMath.isEqual(bobInvitationValue.asset, moola(3)), details`wrong asset`);
 assert(simoleanAmountMath.isEqual(bobInvitationValue.price, simoleans(7)), details`wrong price`);
-
 ```
 
-Bob decides to exercise the invitation. He escrows his payments and uses
-his invite to make an offer in the same way as Alice, but his `Proposal` is
-designed to match Alice's (notice that the `give` and `want` clauses are
-reversed from Alice's proposal):
+Bob exercises the invitation. He escrows his payments and uses
+his invitation to make an offer the same way as Alice, but his `Proposal` matches
+Alice's (note that the `give` and `want` clauses are reversed from Alice's proposal):
 
 ```js
 const sevenSimoleans = simoleanAmountMath.make(7);
@@ -111,8 +107,8 @@ const bobSeat = await E(zoe).offer(
 ```
 
 Now that Bob has made his offer, the contract executes and Alice's payouts
-resolve. She can retrieve them using the seat. She deposits the moola
-payout to find out if zoe returned some of it.
+resolve. She can retrieve them using her seat. She deposits the moola
+payout to find out if Zoe returned some of it.
 
 ```js
 const aliceAssetPayout = await aliceSeat.getPayout('Asset');
@@ -121,7 +117,8 @@ const moolaRefundAmount = aliceMoolaPurse.deposit(alicePricePayout);
 const simoleanGainAmount = aliceSimPurse.deposit(aliceAssetPayout);
 ```
 
-Bob's payout is also available. Since he already knows what Alice's offer was, he doesn't have to look for a simolean refund.
+Bob's payout is also available. Since he already knows what Alice's offer was, 
+he doesn't need to look for a simolean refund.
 
 ```js
 const bobAssetPayout = await bobSeat.getPayout('Asset');

--- a/main/zoe/guide/contracts/atomic-swap.md
+++ b/main/zoe/guide/contracts/atomic-swap.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/atomicSwap.js) (Last updated: 12-SEP-2020)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/atomicSwap.js) (Last updated: 2020-9-12)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 If I want to trade one kind of asset for another kind, I could send
@@ -86,8 +86,8 @@ assert(simoleanAmountMath.isEqual(bobInvitationValue.price, simoleans(7)), detai
 ```
 
 Bob exercises the invitation. He escrows his payments and uses
-his invitation to make an offer the same way as Alice, but his `Proposal` matches
-Alice's (note that the `give` and `want` clauses are reversed from Alice's proposal):
+his invitation to make an offer the same way as Alice, but he designs his `Proposal` 
+to match Alice's (note that the `give` and `want` clauses are reversed from Alice's proposal):
 
 ```js
 const sevenSimoleans = simoleanAmountMath.make(7);


### PR DESCRIPTION
Removed out of date Tip, changed last mod date to new day-month-year format used in the version date tag, tightened text.