### PR TITLE
Werent offerHandles retired an seats took their place?

### DIFF
--- a/main/zoe/api/zoe-contract-facet.md
+++ b/main/zoe/api/zoe-contract-facet.md
@@ -157,7 +157,7 @@ associated with the `issuer` value of the record:
 await zcf.saveIssuer(secondaryIssuer, keyword);
 ```
 ## zcf.makeInvitation(offerHandler, description, customProperties)
-- `offerHandler` `{OfferHandle => Object}`
+- `offerHandler` `{ZCFSeat => Object}`
 - `description` `{String}`
 - `customProperties` `{Object}`
 - Returns: <router-link to="/ertp/api/payment.html#payment">`{Promise<Invitation>}`</router-link>


### PR DESCRIPTION
Was using https://agoric.com/documentation/zoe/api/zoe-contract-facet when writing a smart contract and stumbled upon this small inconsistency.

Small fix.