### PR TITLE
chore: enable edit links on pages for easy PRs from external editors

### DIFF
--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -224,7 +224,7 @@ module.exports = {
         }
       ],
     },
-    repo: 'Agoric/documentation',
+    docsRepo: 'Agoric/documentation',
     // if your docs are not at the root of the repo:
     docsDir: 'main',
     // defaults to false, set to true to enable

--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -224,6 +224,13 @@ module.exports = {
         }
       ],
     },
+    repo: 'Agoric/documentation',
+    // if your docs are not at the root of the repo:
+    docsDir: 'main',
+    // defaults to false, set to true to enable
+    editLinks: true,
+    // custom text for edit link. Defaults to "Edit this page"
+    editLinkText: 'Help us improve this page!',
 
     zoeVersion: 'Alpha Release v0.8.1',
     zoeDocsUpdated: '2020-9-15'


### PR DESCRIPTION
Adds a link like this to the bottom of each page:

<img width="751" alt="Screen Shot 2020-09-22 at 2 46 13 PM" src="https://user-images.githubusercontent.com/2441069/93941190-bbb17880-fce2-11ea-8572-1727445dca06.png">

Which goes to an edit page like this:
<img width="1110" alt="Screen Shot 2020-09-22 at 2 46 19 PM" src="https://user-images.githubusercontent.com/2441069/93941184-b94f1e80-fce2-11ea-9411-da03aadfff78.png">

