### PR TITLE
Add plugin to check internal links

### DIFF
--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -42,6 +42,8 @@ module.exports = {
     ]
   ],
 
+  plugins: ['check-md'],
+
   /* --- DEFAULT THEME CONFIG --- */
   themeConfig: {
     lastUpdated: 'Last Updated', 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1098,6 +1098,16 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sindresorhus/slugify": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-0.8.0.tgz",
+      "integrity": "sha512-Y+C3aG0JHmi4nCfixHgq0iAtqWCjMCliWghf6fXbemRKSGzpcrHdYxGZGDt8MeFg+gH7ounfMbz6WogqKCWvDg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "lodash.deburr": "^4.1.0"
+      }
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -2756,6 +2766,27 @@
         "supports-color": "^5.3.0"
       }
     },
+    "check-md": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/check-md/-/check-md-1.0.0.tgz",
+      "integrity": "sha512-H9LS+TDB6ix4QZQFiTp2TVIL+24zKutOKDqxIxAxnvkx3phpzrwPINaykD8RSeynxIVp3s0PecR2GEA3KLbziQ==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/slugify": "^0.8.0",
+        "chalk": "^2.4.2",
+        "commander": "^2.19.0",
+        "diacritics": "^1.3.0",
+        "globby": "^9.1.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        }
+      }
+    },
     "chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -3827,6 +3858,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+      "dev": true
+    },
+    "diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha1-PvqHMj67hj5mls67AILUj/PW96E=",
       "dev": true
     },
     "diffie-hellman": {
@@ -6006,6 +6043,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.deburr": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
+      "integrity": "sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=",
       "dev": true
     },
     "lodash.kebabcase": {
@@ -10116,6 +10159,15 @@
             "object.getownpropertydescriptors": "^2.0.3"
           }
         }
+      }
+    },
+    "vuepress-plugin-check-md": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-check-md/-/vuepress-plugin-check-md-0.0.2.tgz",
+      "integrity": "sha512-XwA/IiMNvR42L3ajmkr+6JY3JRnhDN+uluh1wLYl0VAI8VqTkXT7Ng4xlxgebfLPChEFPnJgcydGv8E52Zdpig==",
+      "dev": true,
+      "requires": {
+        "check-md": "1.0.0"
       }
     },
     "vuepress-plugin-container": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "docs:dev": "vuepress dev main",
-    "docs:build": "vuepress build main"
+    "docs:build": "vuepress build main",
+    "check-links": "vuepress check-md main"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/Agoric/documentation#readme",
   "dependencies": {},
   "devDependencies": {
-    "vuepress": "^1.5.4"
+    "vuepress": "^1.5.4",
+    "vuepress-plugin-check-md": "0.0.2"
   }
 }


### PR DESCRIPTION
Links can be checked with `npm run check-links`, giving output below. Some may be false positives. Eventually, it would be nice to have this be part of CI before merging.

<img width="1500" alt="Screen Shot 2020-09-22 at 4 59 42 PM" src="https://user-images.githubusercontent.com/2441069/93949176-253a8280-fcf5-11ea-9b2f-b7235d8caf8a.png">
<img width="1598" alt="Screen Shot 2020-09-22 at 4 59 33 PM" src="https://user-images.githubusercontent.com/2441069/93949183-28ce0980-fcf5-11ea-9e25-82e78bdd4454.png">
