### PR TITLE
Update docs (with questions) for SDK PR Vat shutdown patch 1798

### DIFF
--- a/main/zoe/api/zoe-contract-facet.md
+++ b/main/zoe/api/zoe-contract-facet.md
@@ -259,11 +259,19 @@ to manipulate the offer. The queries and operations are as follows:
         Price: moolaAmountMath.make(9)
       }
       ```
- - `exit()`
+ - `exit(completion)`
    - Returns: `void`
    - Causes the `seat` to exit, concluding its existence. All `payouts`, if any,
-     are made, and the `seat` object can no longer interact with the contract. .
- - `kickOut(msg)` (`msg` is optional)
+     are made, and the `seat` object can no longer interact with the contract.
+     The `completion` argument is usually a string, but this is not required. **tyg todo:
+     What else can it be and what is it used for/does it do?**
+ - `fail(msg)` (`msg` is optional)
+   - Returns: `void`
+   - The `seat` exits, displaying the `msg` string, if there is one, on the console.
+     This is equivalent to exiting, except that `exit` is for a successful transaction while
+     `fail()` aborts the transaction attempt and signals an error. The contract
+     still gets its current `allocation` and the `seat` can no longer interact with the contract.     
+ - `kickOut(msg)` (`msg` is optional) **Renamed fail(msg) as of 4-OCT-2020. DO NOT USE**
    - Returns: `void`
    - The `seat` exits, displaying the `msg` string, if there is one, on the console.
      This is equivalent to exiting, except that `exit` is for a successful transaction while
@@ -313,9 +321,14 @@ Returns the `amountMath` object associated with the `brand` argument.
 ```js
 const assetAmountMath = zcf.getAmountMath(assetAmount.brand);
 ```
-## zcf.shutdown()
+## zcf.stopAcceptingOffers()
+- The contract requests Zoe to not accept offers for this contract instance. **tyg todo: No way of 
+starting it back up and accepting again?** It can't be called from outside the contract 
+unless the contract explicitly makes it accessible.
 
-**Note**: Still in development, use at your own risk.
+## zcf.shutdown(completion)
+
+**Note**: Still in development, use at your own risk. **tyg todo: Is this warning still valid?**
 
 Shuts down the entire vat and gives payouts.
 
@@ -325,6 +338,9 @@ giving them their payouts.
 Call when:
 - You want nothing more to happen in the contract, and
 - You don't want to take any more offers
+
+The `completion` argument is usually a string, but this 
+is not required. **tyg todo: What else can it be and what is it used for/does it do?**
 
 ```js
 zcf.shutdown();

--- a/main/zoe/api/zoe-contract-facet.md
+++ b/main/zoe/api/zoe-contract-facet.md
@@ -265,14 +265,14 @@ to manipulate the offer. The queries and operations are as follows:
      are made, and the `seat` object can no longer interact with the contract.
      The `completion` argument is usually a string, but this is not required. Its
      only use is for the notification sent to the contract instance's `done()` function. 
-     Any still open seats or other outstanding promises are closed with a generic 'vat terminated' 
-     message.
+     Any other still open seats or outstanding promises and the contract instance continue.
  - `fail(msg)`
    - Returns: `void`
    - The `seat` exits, displaying the optional `msg` string, if there is one, on the console.
      This is equivalent to exiting, except that `exit` is successful while
      `fail()` signals an error occured while processing the offer. The contract
-     still gets its current `allocation` and the `seat` can no longer interact with the contract. 
+     still gets its current `allocation` and the `seat` can no longer interact with the contract.
+     Any other still open seats or outstanding promises and the contract instance continue.
  - `kickOut(msg)` **Renamed fail(msg) as of 4-OCT-2020. DO NOT USE**
    - Returns: `void`
    - The `seat` exits, displaying the optional `msg` string, if there is one, on the console.
@@ -291,8 +291,8 @@ to manipulate the offer. The queries and operations are as follows:
      same `amounts`. All keywords mentioned in the `newAllocation` have their `amounts`
      replaced with the corresponding `amount` from `newAllocation`.
 
-     Note that ZoeHelpers [`trade()`](./zoe-helpers.md#trade-zcf-left-right-lefthasexitedmsg-righthasexitedmsg) and [`swap()`](./zoe-helpers.md#swap-zcf-leftseat-rightseat-lefthasexitedmsg-righthasexitedmsg) might be easier to use for simple
-     cases.
+     Note that ZoeHelpers [`trade()`](./zoe-helpers.md#trade-zcf-left-right-lefthasexitedmsg-righthasexitedmsg) and [`swap()`](./zoe-helpers.md#swap-zcf-leftseat-rightseat-lefthasexitedmsg-righthasexitedmsg) might
+     be easier to use for simple cases.
  - `isOfferSafe(newAllocation)`
    - Returns `{ Boolean }`
    - Takes an `allocation` as an argument and returns `true` if that `allocation`
@@ -328,11 +328,11 @@ const assetAmountMath = zcf.getAmountMath(assetAmount.brand);
 It can't be called from outside the contract unless the contract explicitly makes it accessible.
 
 ## zcf.shutdown(completion)
+     
+Shuts down the entire vat and contract instance and gives payouts.
 
-Shuts down the entire vat and gives payouts.
-
-This exits all `seats` associated with the current `instance`,
-giving them their payouts.
+All open `seats` associated with the current `instance` have `fail()`
+called on them.
 
 Call when:
 - You want nothing more to happen in the contract, and

--- a/main/zoe/api/zoe-contract-facet.md
+++ b/main/zoe/api/zoe-contract-facet.md
@@ -263,17 +263,19 @@ to manipulate the offer. The queries and operations are as follows:
    - Returns: `void`
    - Causes the `seat` to exit, concluding its existence. All `payouts`, if any,
      are made, and the `seat` object can no longer interact with the contract.
-     The `completion` argument is usually a string, but this is not required. **tyg todo:
-     What else can it be and what is it used for/does it do?**
- - `fail(msg)` (`msg` is optional)
+     The `completion` argument is usually a string, but this is not required. Its
+     only use is for the notification sent to the contract instance's `done()` function. 
+     Any still open seats or other outstanding promises are closed with a generic 'vat terminated' 
+     message.
+ - `fail(msg)`
    - Returns: `void`
-   - The `seat` exits, displaying the `msg` string, if there is one, on the console.
-     This is equivalent to exiting, except that `exit` is for a successful transaction while
-     `fail()` aborts the transaction attempt and signals an error. The contract
-     still gets its current `allocation` and the `seat` can no longer interact with the contract.     
- - `kickOut(msg)` (`msg` is optional) **Renamed fail(msg) as of 4-OCT-2020. DO NOT USE**
+   - The `seat` exits, displaying the optional `msg` string, if there is one, on the console.
+     This is equivalent to exiting, except that `exit` is successful while
+     `fail()` signals an error occured while processing the offer. The contract
+     still gets its current `allocation` and the `seat` can no longer interact with the contract. 
+ - `kickOut(msg)` **Renamed fail(msg) as of 4-OCT-2020. DO NOT USE**
    - Returns: `void`
-   - The `seat` exits, displaying the `msg` string, if there is one, on the console.
+   - The `seat` exits, displaying the optional `msg` string, if there is one, on the console.
      This is equivalent to exiting, except that `exit` is for a successful transaction while
      `kickOut()` aborts the transaction attempt and signals an error. The contract
      still gets its current `allocation` and the `seat` can no longer interact with the contract.
@@ -322,13 +324,10 @@ Returns the `amountMath` object associated with the `brand` argument.
 const assetAmountMath = zcf.getAmountMath(assetAmount.brand);
 ```
 ## zcf.stopAcceptingOffers()
-- The contract requests Zoe to not accept offers for this contract instance. **tyg todo: No way of 
-starting it back up and accepting again?** It can't be called from outside the contract 
-unless the contract explicitly makes it accessible.
+- The contract requests Zoe to not accept offers for this contract instance. 
+It can't be called from outside the contract unless the contract explicitly makes it accessible.
 
 ## zcf.shutdown(completion)
-
-**Note**: Still in development, use at your own risk. **tyg todo: Is this warning still valid?**
 
 Shuts down the entire vat and gives payouts.
 
@@ -340,8 +339,10 @@ Call when:
 - You don't want to take any more offers
 
 The `completion` argument is usually a string, but this 
-is not required. **tyg todo: What else can it be and what is it used for/does it do?**
-
+is not required. It is used for the notification sent to the
+contract instance's `done()` function. Any still open seats or
+other outstanding promises are closed with a generic 'vat terminated' 
+message.
 ```js
 zcf.shutdown();
 ```

--- a/main/zoe/api/zoe.md
+++ b/main/zoe/api/zoe.md
@@ -202,7 +202,8 @@ It returns a promise for a `StartInstanceResult` object. The object consists of:
 
 The `adminFacet` has two methods:
 - `getVatShutdownPromise()
-  - Returns a promise that resolves (to reason or completion) when this newly started instance terminates. **tyg todo: Not sure what "resolves to reason" does? Thrown error?**
+  - Returns a promise that resolves to reason (the Error generated with `fail(reason)`) or 
+    completion (the name passed with `exit(completion)`) when this newly started instance terminates. 
 - `getVatStats()`
   - Returns statistics about vat activity. These are the number of different types
     of items in the vat's C-List, which tracks what this vat can reach on other vats

--- a/main/zoe/api/zoe.md
+++ b/main/zoe/api/zoe.md
@@ -201,9 +201,9 @@ It returns a promise for a `StartInstanceResult` object. The object consists of:
 - `creatorInvitation` `{Payment | undefined}`
 
 The `adminFacet` has two methods:
-- `getVatShutdownPromise()
-  - Returns a promise that resolves to reason (the Error generated with `fail(reason)`) or 
-    completion (the name passed with `exit(completion)`) when this newly started instance terminates. 
+- `getVatShutdownPromise()    
+  - Returns a promise that resolves to reason (the value passed to `fail(reason)`) or 
+    completion (the value passed to `exit(completion)`) when this newly started instance terminates. 
 - `getVatStats()`
   - Returns statistics about vat activity. These are the number of different types
     of items in the vat's C-List, which tracks what this vat can reach on other vats

--- a/main/zoe/api/zoe.md
+++ b/main/zoe/api/zoe.md
@@ -171,6 +171,7 @@ An `installation` is an object with one property:
 ```js
 const installation = await E(zoe).getInstallation(invitation);
 ```
+
 ## E(zoe).startInstance(installation, issuerKeywordRecord, terms)
 - `installation` `{Installation}`
 - `issuerKeywordRecord` `{IssuerKeywordRecord}`
@@ -193,10 +194,26 @@ be different for different instances of the same contract, but the contract
 defines what variables need their values passed in as `terms`.
 
 It returns a promise for a `StartInstanceResult` object. The object consists of:
+- `adminFacet` `{any}`
 - `creatorFacet` `{any}`
 - `publicFacet` `{any}`
 - `instance` `{Instance}`
 - `creatorInvitation` `{Payment | undefined}`
+
+The `adminFacet` has two methods:
+- `getVatShutdownPromise()
+  - Returns a promise that resolves (to reason or completion) when this newly started instance terminates. **tyg todo: Not sure what "resolves to reason" does? Thrown error?**
+- `getVatStats()`
+  - Returns statistics about vat activity. These are the number of different types
+    of items in the vat's C-List, which tracks what this vat can reach on other vats
+    and how many entries are in the vat's transcript. The last gives an idea of
+    how many messages this vat has executed. A vat's transcript of messages it has 
+    executed lets it replay those messages if restarted and restore its pre-shutdown
+    state.
+    - `objectCount`
+    - `promiseCount`
+    - `deviceCount`
+    - `transcriptCount`
 
 A `publicFacet` is an object available via Zoe to anyone knowing
 the instance they are associated with. The `publicFacet` is used for general queries

--- a/snippets/test-intro-zoe.js
+++ b/snippets/test-intro-zoe.js
@@ -11,9 +11,7 @@ import bundleSource from '@agoric/bundle-source';
 import { makeFakeVatAdmin } from './tools/fakeVatAdmin';
 
 test('intro to zoe', async t => {
-  const fakeVatAdmin = makeFakeVatAdmin();
-
-  const zoe = makeZoe(fakeVatAdmin);
+  const zoe = makeZoe(makeFakeVatAdmin().admin);
 
   const moolaKit = makeIssuerKit('moola');
   const simoleanKit = makeIssuerKit('simoleans');
@@ -123,8 +121,7 @@ test('intro to zoe', async t => {
 });
 
 test('intro to zoe - contract-format', async t => {
-  const fakeVatAdmin = makeFakeVatAdmin();
-  const zoe = makeZoe(fakeVatAdmin);
+  const zoe = makeZoe(makeFakeVatAdmin().admin);
   const atomicSwapBundle = await bundleSource(`${__dirname}/contract-format`);
   const atomicSwapInstallation = await E(zoe).install(atomicSwapBundle);
   const { creatorInvitation } = await E(zoe).startInstance(

--- a/snippets/tools/fakeVatAdmin.js
+++ b/snippets/tools/fakeVatAdmin.js
@@ -4,6 +4,24 @@ import { makePromiseKit } from '@agoric/promise-kit';
 import { evalContractBundle } from '@agoric/zoe/src/contractFacet/evalContractCode';
 
 function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
+  // FakeVatPowers isn't intended to support testing of vat termination, it is
+  // provided to allow unit testing of contracts that call zcf.shutdown()
+  let exitMessage;
+  let hasExited = false;
+  let exitWithFailure;
+  const fakeVatPowers = {
+    exitVat: completion => {
+      exitMessage = completion;
+      hasExited = true;
+      exitWithFailure = false;
+    },
+    exitVatWithFailure: reason => {
+      exitMessage = reason;
+      hasExited = true;
+      exitWithFailure = true;
+    },
+  };
+
   // This is explicitly intended to be mutable so that
   // test-only state can be provided from contracts
   // to their tests.
@@ -12,7 +30,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
       return harden({
         root: makeRemote(
           E(evalContractBundle(bundle)).buildRootObject(
-            undefined,
+            fakeVatPowers,
             undefined,
             testContextSetter,
           ),
@@ -24,7 +42,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
             kit.promise.catch(_ => {});
             return kit.promise;
           },
-          terminate: () => {},
+          terminateWithFailure: () => {},
           adminData: () => {},
         },
       });
@@ -33,10 +51,15 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
       throw Error(`createVatByName not supported in fake mode`);
     },
   });
-  return admin;
+  const vatAdminState = {
+    getExitMessage: () => exitMessage,
+    getHasExited: () => hasExited,
+    getExitWithFailure: () => exitWithFailure,
+  };
+  return { admin, vatAdminState };
 }
 
-const fakeVatAdmin = makeFakeVatAdmin();
+const fakeVatAdmin = makeFakeVatAdmin().admin;
 
 export default fakeVatAdmin;
 export { makeFakeVatAdmin };


### PR DESCRIPTION
Per Chris' request, updated docs to account for agoric-sdk changes in PR 1798. There are some questions that need answering for me to make the final small additions. See also [Agoric/agoric-sdk#1798](https://github.com/Agoric/agoric-sdk/pull/1798)