### PR TITLE
chore: add a yarn build for conformity with dapps

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "check-links": "vuepress check-md main",
     "test": "ava",
     "lint-fix": "yarn lint --fix",
-    "lint": "eslint 'snippets/**/*.js'"
+    "lint": "eslint 'snippets/**/*.js'",
+    "build": "exit 0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds a `yarn build` script that merely does `exit 0` so that we can use the same scripts for testing all dapps + documentation