### PR TITLE
Markdown links don't work when in HTML code. Fixed.

### DIFF
--- a/main/README.md
+++ b/main/README.md
@@ -24,7 +24,7 @@ footer: Apache-2.0 Licensed | Copyright © 2020 - Agoric
 
 <div class="flex flex--column flex--center">
   <p>
-    Learn about [ERTP](/ertp/guide/), a uniform way of transferring tokens and other digital assets in JavaScript.
+    Learn about <a href="/getting-started/ertp-introduction.html">ERTP</a>, a uniform way of transferring tokens and other digital assets in JavaScript.
   </p>
   <Button-Action-Link
     text="Get Started with ERTP"
@@ -33,7 +33,7 @@ footer: Apache-2.0 Licensed | Copyright © 2020 - Agoric
 </div>
 <br>
 <div class="flex flex--column flex--center">
-  <p>Ready for more? Check out [Zoe](/zoe/guide/). Zoe is responsible for enforcing what we call "offer safety", and the smart contract that runs on top of Zoe is responsible for figuring out a proposed reallocation of resources.
+  <p>Ready for more? Check out <a href="/getting-started/intro-zoe.html">Zoe</a>. Zoe is responsible for enforcing what we call "offer safety", and the smart contract that runs on top of Zoe is responsible for figuring out a proposed reallocation of resources.
   </p>
   <Button-Action-Link
     text="Build on Zoe"


### PR DESCRIPTION
Also redirected the links to the Intros to ERTP and Zoe instead of the much more overwhelming Guides to each.