### PR TITLE
chore: update documentation to match changes in 2114-loan-period-notifier on agoric-sdk

### DIFF
--- a/main/zoe/guide/contracts/loan.md
+++ b/main/zoe/guide/contracts/loan.md
@@ -33,9 +33,10 @@ loaned amount and interest must be of the same (separate) brand.
    Autoswap](./multipoolAutoswap.md) installation. The `publicFacet`
    of the instance is used to make an invitation to sell the
    collateral on liquidation.
-* `periodAsyncIterable` - the [asyncIterable](https://javascript.info/async-iterators-generators) used for notifications
+* `periodNotifier` - the [notifier](/distributed-programming.md#notifiers) used for notifications
    that a period has passed, on which compound interest will be
-   calculated using the `interestRate`.
+   calculated using the `interestRate`. Note that currently this is
+   lossy, but will be [fixed to be non-lossy soon](https://github.com/Agoric/agoric-sdk/issues/2108). 
 * `interestRate` - the rate in [basis points](https://www.investopedia.com/terms/b/basispoint.asp) that will be multiplied
    with the debt on every period to compound interest.
 

--- a/main/zoe/guide/contracts/loan.md
+++ b/main/zoe/guide/contracts/loan.md
@@ -108,7 +108,7 @@ The contract shuts down under any one of 3 conditions:
 ## Debt and Interest Calculation 
 
 Interest is calculated and compounded when the
-`periodAsyncIterable` pushes a new value. The interest rate per period
+`periodNotifier` pushes a new value. The interest rate per period
 is defined by the `interestRate` parameter.
 
 ## Scheduling Liquidation

--- a/snippets/zoe/contracts/test-loan.js
+++ b/snippets/zoe/contracts/test-loan.js
@@ -9,7 +9,7 @@ import test from 'ava';
 import { E } from '@agoric/eventual-send';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer';
 import { makeFakePriceAuthority } from '@agoric/zoe/tools/fakePriceAuthority';
-import { makeSubscriptionKit } from '@agoric/notifier';
+import { makeNotifierKit } from '@agoric/notifier';
 
 test('loan contract', async t => {
   const zoe = makeZoe(makeFakeVatAdmin().admin);
@@ -65,7 +65,7 @@ test('loan contract', async t => {
     .then(priceQuote => doAddCollateral(priceQuote));
   // #endregion customMarginCall
 
-  const { subscription: periodAsyncIterable } = makeSubscriptionKit();
+  const { notifier: periodNotifier } = makeNotifierKit();
 
   const loanPayment = loanMint.mintPayment(loanMath.make(1000));
 
@@ -74,7 +74,7 @@ test('loan contract', async t => {
     mmr: 150,
     autoswapInstance,
     priceAuthority,
-    periodAsyncIterable,
+    periodNotifier,
     interestRate: 5,
   };
 


### PR DESCRIPTION
Update documentation to match changes in 2114-loan-period-notifier on agoric-sdk. 

Replaces `periodAsyncIterable` with `periodNotifier` in the terms.

#agoric-sdk-branch: 2114-loan-period-notifier