### PR TITLE
chore: change type of installation in startInstance

### DIFF
--- a/main/zoe/api/zoe.md
+++ b/main/zoe/api/zoe.md
@@ -185,7 +185,7 @@ const installation = await E(zoe).getInstallation(invitation);
 ```
 
 ## E(zoe).startInstance(installation, issuerKeywordRecord, terms)
-- `installation` `{Installation}`
+- `installation` `{ERef<Installation>}`
 - `issuerKeywordRecord` `{IssuerKeywordRecord}`
 - `terms` `{Object}`
 - Returns: `{Promise<StartInstanceResult>}`


### PR DESCRIPTION
This changes the documentation to match the change in https://github.com/Agoric/agoric-sdk/pull/2116

#agoric-sdk-branch: 2113-zoe-installationP