### PR TITLE
Addressed missing dependency

### DIFF
--- a/main/getting-started/before-using-agoric.md
+++ b/main/getting-started/before-using-agoric.md
@@ -77,7 +77,7 @@ software, you need to install the following.
     <tr>
       <td>7</td>
       <td><code>yarn install</code></td>
-      <td>Install NPM dependencies.</td>
+      <td>Install NPM dependencies. <b>Note:</b> If you run into errors during install or build, make sure you have build-essential installed. <code>gcc --version</code></td>
     </tr>
     <tr>
       <td>8</td>


### PR DESCRIPTION
I ran into this issue when I setup the env several months ago and it happened again while I was helping a friend who is not versed in the JS-ecosystem. We both run Ubuntu 20.04 LTS.

Please let me know if you rather have an issue rather than a PR.