### PR TITLE
Issuer deploy script

### DIFF
--- a/main/ertp/api/issuer.md
+++ b/main/ertp/api/issuer.md
@@ -12,6 +12,9 @@ An `issuer` has an unchangeable one-to-one relationship with the `mint` and
 You can then rely on that `issuer` as the authority to 
 validate an untrusted `payment` of that `brand`.
 
+**Note**: You should not create an Issuer in a deploy script. Deploy scripts 
+are ephemeral, so any object created there dies as soon as the script stops.
+
 ## makeIssuerKit(allegedName, amountMathKind)
 - `allegedName` `{String}` 
 - `amountMathKind` `{MathKind}` - optional

--- a/main/ertp/guide/issuers-and-mints.md
+++ b/main/ertp/guide/issuers-and-mints.md
@@ -3,6 +3,9 @@
 ## Issuers
 ![Issuer structure](./assets/issuers-and-assets.svg)
 
+**Note**: You should not create an Issuer in a deploy script. Deploy scripts are ephemeral, so any object 
+created there dies as soon as the script stops.
+
 Behind the scenes, an `issuer` maps minted digital assets to their location in a `purse`
 or `payment`. An `issuer` verifies, moves, and manipulates digital assets. 
 Its special admin facet is a `mint` which it has a one-to-one


### PR DESCRIPTION
Closes out [#171](https://github.com/Agoric/documentation/issues/171) via notes in the relevant places warning not to create issuers in deploy scripts.