### PR TITLE
Update wallet-api.md

### DIFF
--- a/main/wallet-api.md
+++ b/main/wallet-api.md
@@ -353,7 +353,7 @@ This ID is not stored in the Board.
 Returns the Board ID to use to receive payments of the specified by its Board ID brand.
 
 ### `getPursesNotifier()`
-- Returns: `{Promise<Notifier<Array<PursesFullState>>>}`
+- Returns: `{Promise<Notifier<Array<PursesJSONState>>>}`
 
 Returns a notifier that follows changes the purses in the Wallet.
 


### PR DESCRIPTION
Change to reflect that an wallet bridge facet .getPursesNotifier() only gets attenuated purses state.

Just one word change btw.

(This is due to the authority leakage fix I made in svelte-wallet-dapp in agoricSDK)