### PR TITLE
chore: sidebar shows h3 by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -399,7 +399,12 @@ Below is an abridged version of the ERTP sidebar. Each item entry has five prope
   will change to `.html` during its processing).
 - `collapsible`: Can this item be collapsed? So far, we don't have any collapsible items, so 
   always give this property the value `false`.
-- `sideBarDepth`: How many levels can the sidebar show? So far, we've not gone deeper than 3.
+- `sideBarDepth`: How many levels can the sidebar show? The site-level
+  default is 2, which displays h3 and is the max, but if fewer levels
+  are desired, the setting can be overridden at the sidebar item
+  level. More information
+  [here](https://vuepress.vuejs.org/theme/default-theme-config.html#nested-header-links).
+  
 - `children`: An array of submenu items for this sidebar menu item. You just need to specify
   the file paths to where you want to go when the submenu item is clicked. VuePress uses the
   file's (including default README.md files for folders) H1 level header text for the sidebar text.
@@ -411,7 +416,6 @@ Below is an abridged version of the ERTP sidebar. Each item entry has five prope
           title: 'ERTP Introduction',
           path: '/getting-started/ertp-introduction.md',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
           ]
         },
@@ -419,7 +423,6 @@ Below is an abridged version of the ERTP sidebar. Each item entry has five prope
           title: 'ERTP Guide',
           path: '/ertp/guide/',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
             '/ertp/guide/',
             '/ertp/guide/amounts',

--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -46,6 +46,7 @@ module.exports = {
 
   /* --- DEFAULT THEME CONFIG --- */
   themeConfig: {
+    sidebarDepth: 2,
     lastUpdated: 'Last Updated', 
     logo: '/logo.svg',
     /* --- NAVBAR (top) --- */
@@ -65,7 +66,6 @@ module.exports = {
           title: 'Agoric Alpha',
           path: '/getting-started/alpha.html',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
           ]
         },
@@ -73,7 +73,6 @@ module.exports = {
           title: 'Documentation Guide',
           path: '/getting-started/',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
           ]
         },
@@ -81,7 +80,6 @@ module.exports = {
           title: 'Before Using Agoric',
           path: '/getting-started/before-using-agoric.html',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
           ]
         },
@@ -89,7 +87,6 @@ module.exports = {
           title: 'Starting A Project',
           path: '/getting-started/start-a-project.html',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
           ]
         },
@@ -97,7 +94,6 @@ module.exports = {
           title: 'Development Cycle',
           path: '/getting-started/development-cycle.html',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
           ]
         },
@@ -105,7 +101,6 @@ module.exports = {
           title: 'Deploying Smart Contracts',
           path: '/getting-started/deploying.html',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
           ]
         },
@@ -113,7 +108,6 @@ module.exports = {
           title: 'ERTP Introduction',
           path: '/getting-started/ertp-introduction.md',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
           ]
         },
@@ -121,7 +115,6 @@ module.exports = {
           title: 'Zoe Introduction',
           path: '/getting-started/intro-zoe.md',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
           ]
         },
@@ -129,7 +122,6 @@ module.exports = {
           title: 'Agoric CLI Guide',
           path: '/getting-started/agoric-cli-guide.html',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
           ]
         },
@@ -139,7 +131,6 @@ module.exports = {
           title: 'ERTP Introduction',
           path: '/getting-started/ertp-introduction.md',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
           ]
         },
@@ -147,7 +138,6 @@ module.exports = {
           title: 'ERTP Guide',
           path: '/ertp/guide/',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
             '/ertp/guide/',
             '/ertp/guide/amounts',
@@ -160,7 +150,6 @@ module.exports = {
           title: 'ERTP API',
           path: '/ertp/api/',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
             '/ertp/api/issuer',
             '/ertp/api/mint',
@@ -176,7 +165,6 @@ module.exports = {
           title: 'Zoe Introduction',
           path: '/getting-started/intro-zoe.md',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
           ]
         },
@@ -184,7 +172,6 @@ module.exports = {
           title: 'Zoe Guide',
           path: '/zoe/guide/',
           collapsible: false,
-          sideBarDepth: 5,
           children: [
             '/zoe/guide/',
             '/zoe/guide/offer-safety',
@@ -197,7 +184,6 @@ module.exports = {
           title: 'Zoe Contracts',
           path: '/zoe/guide/contracts/',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
             '/zoe/guide/contracts/automatic-refund',
             '/zoe/guide/contracts/atomic-swap',
@@ -223,7 +209,6 @@ module.exports = {
           title: 'Zoe API',
           path: '/zoe/api/',
           collapsible: false,
-          sideBarDepth: 3,
           children: [
             '/zoe/api/zoe',
             '/zoe/api/zoe-contract-facet',


### PR DESCRIPTION
This PR changes the themeConfig settings to show h3 by default. The individual settings for each sidebar item are unnecessary and are removed. CONTRIBUTING.md is updated.
<img width="334" alt="Screen Shot 2021-02-22 at 11 22 59 AM" src="https://user-images.githubusercontent.com/2441069/108758792-60d5b480-7500-11eb-8ddb-2fce3c76b7c7.png">
