### PR TITLE
chore: update for Nat 4.0.0

### DIFF
--- a/main/distributed-programming.md
+++ b/main/distributed-programming.md
@@ -3,6 +3,10 @@
 Agoric's platform lets you write secure smart contracts in JavaScript. The platform itself is mainly written in JavaScript. However, we've made several Agoric-specific additions to general JavaScript programming that you should know about and understand before programming on the platform. Some are *concepts*, others are *Agoric library additions*, and some are at the *syntax level*. All changes at the language level are in process to become official standards.
 
 Extensions covered in this document are:
+- **[`BigInt`](#bigint)**: JavaScript's `Number` primitive only represents
+  numbers up to 2<sup>53</sup> - 1. `BigInt` is a built-in object that can be used for
+  arbitrarily large integers. Agoric uses `BigInts` for times and amount `values`.
+
 - **[Vats](#vats)**: Objects and functions in the same JavaScript vat can
   communicate synchronously. Communication with objects outside the
   vat can only be done asynchronously. 
@@ -32,6 +36,46 @@ using `E` (`E(remoteObj).myMethod()`), or the "tildot" operator `remoteObj~.myMe
 - **[Notifiers](#notifiers):** The Agoric platform uses Notifiers to distribute state change
 updates. Notifiers rely on promises to deliver a stream of messages as a publish-subscribe system
 might, without requiring explicit management of lists of subscribers.
+
+## `BigInt`
+
+JavaScript's `Number` primitive only represents numbers up to 2<sup>53</sup> - 1. `BigInt` is 
+a built-in object that can be used for arbitrarily large integers. Agoric uses `BigInts` for times 
+and amount `values`.
+
+You create a `BigInt` by appending `n` to an integer. For example, `10n` is a BigInt equal to
+the `Number` `10`. You can also call the method `BigInt()`.
+```js
+const previouslyMaxSafeInteger = 9007199254740991n
+
+const alsoHuge = BigInt(9007199254740991)
+// alsoHuge has the value 9007199254740991n
+
+const hugeString = BigInt("9007199254740991")
+// hugeString has the value 9007199254740991n
+```
+
+`BigInt` cannot be used with the `Math` object's methods. It cannot be mixed with `Numbers` in operations; 
+they must be coerced to the same type. Coercing a `BigInt` to a `Number` may lose precision.
+
+`typeof` returns `'bigint'` for `BigInts`. When wrapped in an `Object`, a `BigInt` is a normal "object" type.
+
+```js
+typeof 1n === 'bigint'           // true
+typeof BigInt('1') === 'bigint'  // true
+typeof Object(1n) === 'object'  // true
+```
+
+Note that JSON does not serialize `BigInt` values by default. You must first implement your
+own `toJSON()` method. Otherwise `JSON.stringify()` will raise a `TypeError`.
+```js
+BigInt.prototype.toJSON = function() { return this.toString()  }
+// Instead of throwing, JSON.stringify now produces a string like this:
+
+JSON.stringify(BigInt(1))
+// '"1"'
+```
+For full reference information about `BigInt`, go [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt).
 
 ## Vats
 

--- a/main/ertp/api/amount-math.md
+++ b/main/ertp/api/amount-math.md
@@ -15,7 +15,7 @@ There are three different kinds of `amountMath`, each of which implements all th
 
 The three kinds of `amountMath` each implement all of the same set of API methods (i.e. `amountMath` methods are polymorphic). We recommend you import the `MathKind` values from `@agoric/ERTP` instead of making the strings yourself. 
 
-- `MathKind.NAT` (`nat`): Used with fungible assets. `amount` `values` are natural numbers (non-negative integers).
+- `MathKind.NAT` (`nat`): Used with fungible assets. `amount` `values` are natural numbers (non-negative BigInts).
 - `MathKind.STRING_SET` (`strSet`): Used with non-fungible assets. `amount` `values` are strings.
 - `MathKind.SET` (`set`): Used with non-fungible assets. `amount` `values` are objects or records with multiple properties.
 
@@ -47,7 +47,13 @@ someAmount: {
 
 ## Value
 
-`values` describe how much of something can be owned or shared. A fungible `value` is normally represented by a natural number. Other `values` may be represented as strings naming a particular right, or an arbitrary object that sensibly represents the rights at issue.
+`values` describe how much of something can be owned or shared. A fungible `value` is
+normally represented by a natural number BigInt. Other `values` may be represented as strings
+naming a particular right, or an arbitrary object that sensibly represents the rights at issue.
+
+Note that numbers in a value are represented as type `BigInt`, which allows for arbitrarily 
+large numbers. BigInts are depicted as an integer with an appended "n"; e.g. 10n, 137n. 
+See the [BigInt section in the JavaScript Distributed Programming Guide](/distributed-programming.md#bigint) for details. 
 
 ## makeLocalAmountMath(issuer)
 - `issuer`: `{issuer}`
@@ -95,9 +101,20 @@ quatloosAmountMath.getAmountMathKind(); // For example, returns MathKind.NAT
 Make an `amount` from a `value` by adding the `brand` associated with
 the `amountMath`.
 
+Remember that numbers in `values` are represented as `BigInts`; integers
+with an appended "n". As seen in the below example, we strongly encourage
+using BigInts as the argument to `amountMath.make()`. While `amountMath.make()`
+does coerce a `Number` argument to a `BigInt`, so both `4` and `4n` return an
+amount with a value of `4n`, using Numbers is likely to confuse later viewers
+of your code. 
+
+See the [BigInt section in the JavaScript Distributed Programming Guide](/distributed-programming.md#bigint) for 
+details about `BigInts`. 
+
+
 ```js
-//amount837 = { value: 837, brand: quatloos }
-const amount837 = quatloosAmountMath.make(837);
+//amount837 = { value: 837n, brand: quatloos }
+const amount837 = quatloosAmountMath.make(837n);
 ```
 
 ## amountMath.coerce(allegedAmount)
@@ -109,7 +126,7 @@ If not valid, throws an exception. This checks if
 an `amount` coming from elsewhere is for the expected `brand`.
 
 ```js
-const quatloos50 = quatloosAmountMath.make(50);
+const quatloos50 = quatloosAmountMath.make(50n);
 // Returns the same amount as quatloos50
 const verifiedAmount = quatlooAmountMath.coerce(allegedAmount); 
 ```
@@ -118,12 +135,13 @@ const verifiedAmount = quatlooAmountMath.coerce(allegedAmount);
 - `amount` `{Amount}`
 - Returns: `{Value}`
 
-Returns the `value` from the given `amount`.
+Returns the `value` from the given `amount`. Remember, numeric values
+are represented as `BigInts`, not `Numbers`.
 
 ```js
-const quatloos123 = quatloosAmountMath.make(123);
+const quatloos123 = quatloosAmountMath.make(123n);
 
-// returns 123
+// returns 123n
 const myValue = quatloosAmountMath.getValue(quatloos123);
 ```
 
@@ -139,7 +157,7 @@ or `MathKind.STRING_SET` (`[]`).
 ```js
 // Returns an empty amount for this amountMath.
 // Since this is a fungible amount it returns an amount
-// with 0 as its value.
+// with 0n as its value.
 const empty = quatloosAmountMath.getEmpty();
 ```
 
@@ -151,7 +169,7 @@ Returns `true` if the `amount` is empty. Otherwise returns `false`.
 
 ```js
 const empty = quatloosAmountMath.getEmpty();
-const quatloos1 = quatloosAmountMath.make(1);
+const quatloos1 = quatloosAmountMath.make(1n);
 
 // returns true
 quatloosAmountMath.isEmpty(empty)
@@ -176,8 +194,8 @@ contents and has additional elements.
 
 ```js
 const empty = quatloosAmountMath.getEmpty();
-const quatloos5 = quatloosAmountMath.make(5);
-const quatloos10 = quatloosAmountMath.make(10);
+const quatloos5 = quatloosAmountMath.make(5n);
+const quatloos10 = quatloosAmountMath.make(10n);
 
 // Returns true
 quatloosAmountMath.isGTE(quatloos5, empty);
@@ -208,9 +226,9 @@ are considered unequal because the latter has elements that are not contained in
 
 ```js
 const empty = quatloosAmountMath.getEmpty();
-const quatloos10 = quatloosAmountMath.make(10);
-const quatloos5 = quatloosAmountMath.make(5);
-const quatloos5b = quatloosAmountMath.make(5);
+const quatloos10 = quatloosAmountMath.make(10n);
+const quatloos5 = quatloosAmountMath.make(5n);
+const quatloos5b = quatloosAmountMath.make(5n);
 
 // Returns true
 quatloosAmountMath.isEqual(quatloos10, quatloos10);

--- a/main/ertp/api/issuer.md
+++ b/main/ertp/api/issuer.md
@@ -31,7 +31,7 @@ The optional `amountMathKind` specifies the kind of math to use with the digital
 Each implements all of the same set of API methods (i.e. `amountMath` methods are 
 polymorphic). We recommend you import and use the `MathKind` values from `@agoric/ERTP` 
 instead of using strings. 
-- `MathKind.NAT` (`nat`): Used with fungible assets. `amount` values are natural numbers (non-negative integers). Default value.
+- `MathKind.NAT` (`nat`): Used with fungible assets. `amount` values are natural numbers (non-negative BigInts). Default value.
 - `MathKind.STRING_SET` (`strSet`): Used with non-fungible assets. `amount` values are strings.
 - `MathKind.SET` (`set`): Used with non-fungible assets. `amount` values are objects or records with multiple properties.
 
@@ -46,13 +46,13 @@ makeIssuerKit('kitties', MathKind.SET);
 const { issuer: quatloosIssuer, mint: quatloosMint, brand: quatloosBrand, amountMath: quatloosAmountMath } = 
       makeIssuerKit('quatloos');
 // This is merely an amount, describing assets.
-const quatloos2 = quatloosAmountMath.make(2);
+const quatloos2 = quatloosAmountMath.make(2n);
 
 const { mint: titleMint, issuer: titleIssuer amountMath: titleAmountMath } = makeIssuerKit('alamedaCountyPropertyTitle', MathKind.STRING_SET);
 // These are merely amounts describing digital assets, not minting assets.
-const cornerProperty = titleLocalAmountMath.make(harden['1292826']);
-const adjacentProperty = titleLocalAmountMath.make(harden['1028393']);
-const combinedProperty = titleLocalAmountMath.make(harden['1292826', '1028393']);
+const cornerProperty = titleLocalAmountMath.make(harden['1292826n']);
+const adjacentProperty = titleLocalAmountMath.make(harden['1028393n']);
+const combinedProperty = titleLocalAmountMath.make(harden['1292826n', '1028393n']);
 ```
 
 ## issuer.getAllegedName()
@@ -87,7 +87,7 @@ Get the kind of this `issuer`'s `amountMath`. It returns one of
 The `amountMathKind` value specifies which of three kinds an `amountMath` is,
 and what kind of values it is used on. Each kind implements all of the same set 
 of API methods (i.e. `amountMath` methods are polymorphic). 
-- `MathKind.NAT` (`nat`): Used with fungible assets. `amount` values are natural numbers (non-negative integers). Default value.
+- `MathKind.NAT` (`nat`): Used with fungible assets. `amount` values are natural numbers (non-negative BigInts). Default value.
 - `MathKind.STRING_SET` (`strSet`): Used with non-fungible assets. `amount` values are strings.
 - `MathKind.SET` (`set`): Used with non-fungible assets. `amount` values are objects or records with multiple properties.
 
@@ -107,7 +107,7 @@ the `payment`'s `brand`  and tell us how much it contains.
 
 ```js
 const { issuer: quatloosIssuer, mint: quatloosMint } = makeIssuerKit('quatloos');
-const quatloosPayment = quatloosMint.mintPayment(quatloosAmountMath.make(100));
+const quatloosPayment = quatloosMint.mintPayment(quatloosAmountMath.make(100n));
 quatloosIssuer.getAmountOf(quatloosPayment); // returns an amount of 100 Quatloos 
 ```
 
@@ -153,7 +153,7 @@ If `payment` is a `promise` for a `payment`, the operation proceeds after the
 ```js
 const { issuer: quatloosIssuer, mint: quatloosMint } = 
       makeIssuerKit('quatloos');     
-const amountToBurn = quatloosAmountMath.make(10);
+const amountToBurn = quatloosAmountMath.make(10n);
 const paymentToBurn = quatloosMint.mintPayment(amountToBurn);
 
 // burntAmount should equal 10 Quatloos
@@ -181,7 +181,7 @@ it might take a bit of time for the whole operation to resolve.
 
 ```js
 const { mint: quatloosMint, issuer: quatloosIssuer } = makeIssuerKit('quatloos');
-const amountExpectedToTransfer = quatloosAmountMath.make(2);
+const amountExpectedToTransfer = quatloosAmountMath.make(2n);
 const originalPayment = quatloosMint.mintPayment(amountExpectedToTransfer);
 
 const newPayment = quatloosIssuer.claim(originalPayment, amountToTransfer);
@@ -209,7 +209,7 @@ const quatloosLocalAmountMath = makeLocalAmountMath(quatloosIssuer);
 // create an array of 100 payments of 1 quatloo each
 const payments = [];
 for (let i = 0; i < 100; i += 1) {
-  payments.push(quatloosMint.mintPayment(quatloosAmountMath.make(1)));
+  payments.push(quatloosMint.mintPayment(quatloosAmountMath.make(1n)));
 }
 
 // combinedPayment equals 100
@@ -220,7 +220,7 @@ const combinedPayment = quatloosIssuer.combine(payments);
 
 ```js
 const { mint: otherMint, issuer: otherIssuer } = makeIssuerKit('other');
-const otherPayment = otherMint.mintPayment(otherAmountMath.make(10));
+const otherPayment = otherMint.mintPayment(otherAmountMath.make(10n));
 payments.push(otherPayment); // using the payments array from the above code
 
 // throws error
@@ -244,9 +244,9 @@ it might take a bit of time for the whole operation to resolve.
 
 ```js
 const { mint: quatloosMint, issuer: quatloosIssuer } = makeIssuerKit('quatloos');
-const oldPayment = quatloosMint.mintPayment(quatloosAmountMath.make(20));
+const oldPayment = quatloosMint.mintPayment(quatloosAmountMath.make(20n));
 // After the split, paymentA has 5 quatloos and paymentB has 15.
-const [paymentA, paymentB] = quatloosIssuer.split(oldPayment, quatloosAmountMath.make(5));
+const [paymentA, paymentB] = quatloosIssuer.split(oldPayment, quatloosAmountMath.make(5n));
 ```
 
 ## issuer.splitMany(payment, amountArray)
@@ -263,19 +263,19 @@ of the `amountArray` `amounts` must all be the same as the `payment` `brand`.
 
 ```js
 const { mint: quatloosMint, issuer: quatloosIssuer} = makeIssuerKit('quatloos');
-const oldPayment = quatloosMint.mintPayment(quatloosAmountMath.make(100));
-const goodAmounts = Array(10).fill(quatloosAmountMath.make(10));
+const oldPayment = quatloosMint.mintPayment(quatloosAmountMath.make(100n));
+const goodAmounts = Array(10).fill(quatloosAmountMath.make(10n));
 
 const arrayOfNewPayments = quatloos.Issuer.splitMany(oldPayment, goodAmounts);
 
 // The total amount in the amountArray must equal the original payment amount
-// Set original amount to 1000
-const payment = quatloosMint.mintPayment(quatloosAmountMath.make(1000));
+// Set original amount to 1000n
+const payment = quatloosMint.mintPayment(quatloosAmountMath.make(1000n));
 
-// Total amounts in badAmounts equal 20, when it should equal 1000
-const badAmounts = Array(2).fill(quatloosAmountMath.make(10));
+// Total amounts in badAmounts equal 20n, when it should equal 1000n
+const badAmounts = Array(2).fill(quatloosAmountMath.make(10n));
 
-// 20 does not equal 1000, so throws error
+// 20n does not equal 1000n, so throws error
 quatloosIssuer.splitMany(payment, badAmounts);
 ```
 

--- a/main/ertp/api/mint.md
+++ b/main/ertp/api/mint.md
@@ -46,7 +46,7 @@ Returns a `payment` containing the newly minted assets.
 const { issuer: quatloosIssuer, mint: quatloosMint
         amountMath: quatloosAmountMath } = makeIssuerKit('quatloos');
 
-const quatloos1000 = quatloosAmountMath.make(1000);
+const quatloos1000 = quatloosAmountMath.make(1000n);
 // newPayment will have a balance of 1000 Quatloos
 const newPayment = quatloosMint.mintPayment(quatloos1000);
 ```

--- a/main/ertp/api/payment.md
+++ b/main/ertp/api/payment.md
@@ -32,7 +32,7 @@ with it. Because `payments` are not trusted, any method calls on `payments`
 should be treated with suspicion and verified elsewhere.
 
 ```js
-const payment = quatloosMint.mintPayment(quatloosAmountMath.make(10));
+const payment = quatloosMint.mintPayment(quatloosAmountMath.make(10n));
 //Should return 'quatloos'
 const allegedBrand = payment.getAllegedBrand();
 ```

--- a/main/ertp/api/purse.md
+++ b/main/ertp/api/purse.md
@@ -93,13 +93,13 @@ deposit still works on an empty `purse`.
 const { issuer: quatloosIssuer, mint: quatloosMint, amountMath: quatloosAmountMath } = 
       makeIssuerKit('quatloos');
 const quatloosPurse = quatloosIssuer.makeEmptyPurse();
-const payment = quatloosMint.mintPayment(quatloosAmountMath.make(123));
-const quatloos123 = quatloosAmountMath.make(123);
+const payment = quatloosMint.mintPayment(quatloosAmountMath.make(123n));
+const quatloos123 = quatloosAmountMath.make(123n);
 
 // Deposit a payment for 123 Quatloos into the purse. 
 const depositAmountA = quatloosPurse.deposit(payment, quatloos123);
 
-const secondPayment = quatloosMint.mintPayment(quatloosAmountMath.make(100));
+const secondPayment = quatloosMint.mintPayment(quatloosAmountMath.make(100n));
 // Throws error
 const depositAmountB = quatloosPurse.deposit(secondPayment, quatloos123);
 
@@ -144,12 +144,12 @@ But as soon as the message is processed, the value is gone from the `purse`.
 // Create a purse and give it a balance of 10 Quatloos
 const { issuer, mint } = makeIssuerKit('quatloos');
 const purse = issuer.makeEmptyPurse();
-const payment = mint.mintPayment(amountMath.make(10));
-const quatloos10 = amountMath.make(10);
+const payment = mint.mintPayment(amountMath.make(10n));
+const quatloos10 = amountMath.make(10n);
 purse.deposit(payment, quatloos10);
 
 // Withdraw an amount of 3 from the purse
-const quatloos3 = amountMath.make(3);
+const quatloos3 = amountMath.make(3n);
 const withdrawalPayment = purse.withdraw(quatloos3);
 
 // The balance of the withdrawal payment is 3 Quatloos

--- a/main/ertp/guide/README.md
+++ b/main/ertp/guide/README.md
@@ -45,8 +45,8 @@ A record consisting of a `value` and a `brand`. It is a description of an asset,
   as it has no economic scarcity or economic value.
   
 So, using the fictional currency Quatloos, you could have an asset described as being "400 Quatloos",
-where `400` is the `value` and `Quatloos` is the `brand`. For now, we'll just look at fungible assets
-whose values have to be non-negative integers. 
+where `400n` is the `value` and `Quatloos` is the `brand`. For now, we'll just look at fungible assets
+whose values have to be non-negative integers represented as BigInts (thus the appended "n" on that `value`). 
 
 The `brand` is a very important component. Most ERTP objects work with or on one specific `brand`.
 In fact, instances of these next three components all only work on one `brand`. Note also that their

--- a/main/ertp/guide/amount-math.md
+++ b/main/ertp/guide/amount-math.md
@@ -14,7 +14,7 @@ An `amountMath` is one of three different kinds, each of which
 implements the same methods. Which kind is used for a particular `brand` depends
 on what was specified when the `brand` and its `issuer` were 
 created. The kinds are: 
-- `MathKind.NAT` (`nat`): Used with fungible assets. `amount` `values` are natural numbers (non-negative integers).
+- `MathKind.NAT` (`nat`): Used with fungible assets. `amount` `values` are natural numbers (non-negative BigInts).
 - `MathKind.STRING_SET` (`strSet`): Used with non-fungible assets. `amount` `values` are strings.
 - `MathKind.SET` (`set`): Used with non-fungible assets. `amount` `values` are objects or records with multiple properties.
 
@@ -47,7 +47,7 @@ API Reference](../api/).
     - For this `amountMath`, return the `brand` it can operate on..
     - <<< @/snippets/ertp/guide/test-amount-math.js#getBrand
   - [amountMath.getValue(amount)](../api/amount-math.md#amountmath-getvalue-amount)
-    - Returns the `value` of the `amount` argument. 
+    - Returns the `value` of the `amount` argument. For fungible assets, this will be a `BigInt`.
     - <<< @/snippets/ertp/guide/test-amount-math.js#getValue
   - [amountMath.getAmountMathKind()](../api/amount-math.md#amountmath-getamountmathkind)
     - Returns a string of either `'nat'`, `'str'`, or `'strSet'`,
@@ -94,7 +94,8 @@ API Reference](../api/).
 - **Amount Creation Methods**
   - [amountMath.make(allegedValue)](../api/amount-math.md#amountmath-make-allegedvalue)	
     - Takes a `value` argument and returns an `amount` by making a record
-      with the `value` and the `brand` associated with the `amountMath`.
+      with the `value` and the `brand` associated with the `amountMath`. The `value`
+      argument should be represented as a `BigInt` e.g. 10n rather than 10.
     - <<< @/snippets/ertp/guide/test-amount-math.js#make
   - [amountMath.getEmpty()](../api/amount-math.md#amountmath-getempty)
     - Returns an `amount` representing an empty `amount` (which is the identity

--- a/main/ertp/guide/amounts.md
+++ b/main/ertp/guide/amounts.md
@@ -19,7 +19,7 @@ a `brand` and a `value`. While `amountMath.make()` is recommended for proper obj
 - **Brand**: The kind of digital asset, such as our imaginary `Quatloos` currency or,
   in a game, a powerful magic sword with a brand of `Plus3Sword-ABCGames` or similar.
 - **Value**: How much/many of the asset. Fungible values are natural
-numbers. Non-fungible values may be represented as strings naming a
+numbers represented as BigInts. Non-fungible values may be represented as strings naming a
 particular right, or an arbitrary object representing the rights at
 issue (e.g., a theatre ticket's date, time, row and seat positions).
 
@@ -89,7 +89,13 @@ return a `brand`.
 
 ![Value methods](./assets/value.svg) 
 
-Values are the "how many" part of an `amount`. There are no `value`
+Values are the "how many" part of an `amount`. 
+
+Note that numberic values (for fungible assets) are represented as `BigInts` and
+not `Numbers`. So a value of "10" is written "10n" to show it is a `BigInt` 10.
+See [here](/distributed-programming.md#bigint) for more information about `BigInt`.
+
+There are no `value`
 methods, but two `amountMath` methods use or return them. 
 - [`amountMath.getValue(amount)`](../api/amount-math.md#amountmath-getvalue-amount)
   - Return the `amount` argument's `value`

--- a/main/getting-started/ertp-introduction.md
+++ b/main/getting-started/ertp-introduction.md
@@ -103,7 +103,7 @@ convey no underlying value. They have two parts:
 - **Brand**: An unforgeable object identity for the digital asset's kind,
   such as an object that represents Quatloos.
 - **Value**: How much/many of the asset. Fungible `values` are natural
-  numbers. Non-fungible `values` are strings or objects representing
+  numbers and represented as `BigInts`. Non-fungible `values` are strings or objects representing
   attributes of the asset (say, a theater ticket's row and seat positions).
 
 Note: *fungible* means any item in a set can be used. For example, for 

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -68,6 +68,12 @@ and the [ERTP API's AmountMath section](/ertp/api/amount-math.md).
 [Purses](#purse) and [payments](#payment) are AssetHolders. These are objects that contain
 digital assets in the quantity specified by an [amount](#amounts).
 
+## BigInt
+
+JavaScript's `Number` primitive only represents numbers up to 253 - 1. `BigInt` is a built-in 
+object that can be used for arbitrarily large integers. Agoric uses `BigInts` for times 
+and `Amount` `values`. See [here](/distributed-programming.md#bigint) for more information.
+
 ## Board (Agoric Board)
 
 The Board is a shared, on-chain location where users can post a value and make it 

--- a/main/zoe/api/zoe-contract-facet.md
+++ b/main/zoe/api/zoe-contract-facet.md
@@ -103,8 +103,8 @@ quatloosPurse.deposit(payout.Asset);
 
 For example:
 ```js
-const quatloos5 = quatloosAmountMath.make(5);
-const quatloos9 = quatloosAmountMath.make(9);
+const quatloos5 = quatloosAmountMath.make(5n);
+const quatloos9 = quatloosAmountMath.make(9n);
 const myAmountKeywordRecord =
 {
   Asset: quatloos5,
@@ -255,8 +255,8 @@ to manipulate the offer. The queries and operations are as follows:
     An `Allocation` example:
     - ```js
       {
-        Asset: quatloosAmountMath.make(5),
-        Price: moolaAmountMath.make(9)
+        Asset: quatloosAmountMath.make(5n),
+        Price: moolaAmountMath.make(9n)
       }
       ```
  - `exit(completion)`

--- a/main/zoe/api/zoe-helpers.md
+++ b/main/zoe/api/zoe-helpers.md
@@ -302,7 +302,7 @@ defaults to `Deposit and reallocation successful.`
 import {
   depositToSeat,
 } from '@agoric/zoe/src/contractSupport';
-await depositToSeat(zcf, zcfSeat, { Dep: quatloos(2) }, { Dep: quatloosPayment });
+await depositToSeat(zcf, zcfSeat, { Dep: quatloos(2n) }, { Dep: quatloosPayment });
 ```
 
 ## withdrawFromSeat(zcf, seat, amounts)
@@ -322,7 +322,7 @@ Unlike `depositToSeat()`, a `PaymentKeywordRecord` is returned, not a success me
 import {
   withdrawFromSeat,
 } from '@agoric/zoe/src/contractSupport';
-const paymentKeywordRecord = await withdrawFromSeat(zcf, zcfSeat, { With: quatloos(2) });
+const paymentKeywordRecord = await withdrawFromSeat(zcf, zcfSeat, { With: quatloos(2n) });
 ```
 
 ## saveAllIssuers(zcf, issuerKeywordRecord)

--- a/main/zoe/api/zoe.md
+++ b/main/zoe/api/zoe.md
@@ -282,7 +282,7 @@ const myProposal = harden({
   want: { Price: moola(15) },
   exit: { afterDeadline: {
     timer,
-    deadline: 100,
+    deadline: 100n,
   }}
 })
 ```

--- a/main/zoe/api/zoe.md
+++ b/main/zoe/api/zoe.md
@@ -213,7 +213,7 @@ It returns a promise for a `StartInstanceResult` object. The object consists of:
 - `creatorInvitation` `{Payment | undefined}`
 
 The `adminFacet` has two methods:
-- `getVatShutdownPromise()    
+- `getVatShutdownPromise()`    
   - Returns a promise that resolves to reason (the value passed to `fail(reason)`) or 
     completion (the value passed to `exit(completion)`) when this newly started instance terminates. 
 - `getVatStats()`
@@ -273,13 +273,15 @@ The optional `exit`'s value should be an `exitRule`, an object with three possib
 key:value pairs:
 - `onDemand:null`:  (Default) The user can cancel on demand.
 - `waived:null`: The user can't cancel and relies entirely on the smart contract to promptly finish their offer.
-- `afterDeadline`: The offer is automatically cancelled after a deadline, as determined by its `timer` and `deadline` properties. The timer is a timer,
-and the `deadline` is with respect to the timer. Some example timers use Unix epoch time, while others count block height.
+- `afterDeadline`: The offer is automatically cancelled after a deadline, as determined 
+   by its `timer` and `deadline` properties. The timer is a timer, and the `deadline` is with respect to the 
+   timer. Some example timers use Unix epoch time, while others count block height. Note that `deadline`'s
+   value is a `BigInt`, not a `Number` (just append an "n" to the number you want to use to get its `BigInt`)
 
 ```js
 const myProposal = harden({
-  give: { Asset: quatloos(4)},
-  want: { Price: moola(15) },
+  give: { Asset: quatloos(4n)},
+  want: { Price: moola(15n) },
   exit: { afterDeadline: {
     timer,
     deadline: 100n,
@@ -333,8 +335,8 @@ and an operation to request that the offer exit, as follows:
     An `Allocation` example:
     - ```js
       {
-        Asset: quatloosAmountMath.make(5),
-        Price: moolaAmountMath.make(9)
+        Asset: quatloosAmountMath.make(5n),
+        Price: moolaAmountMath.make(9n)
       }
       ```
 - `getProposal()`

--- a/main/zoe/guide/contracts/covered-call.md
+++ b/main/zoe/guide/contracts/covered-call.md
@@ -108,7 +108,7 @@ const threeMoola = moolaAmountMath.make(3);
 const aliceProposal = harden({
   give: { UnderlyingAsset: threeMoola },
   want: { StrikePrice: simoleanAmountMath.make(7) },
-  exit: { afterDeadline: { deadline: 1599856578, timer: chainTimer } },
+  exit: { afterDeadline: { deadline: 1599856578n, timer: chainTimer } },
 });
 
 const alicePayment = { UnderlyingAsset: aliceMoolaPurse.withdraw(threeMoola) };

--- a/main/zoe/guide/contracts/fundedCallSpread.md
+++ b/main/zoe/guide/contracts/fundedCallSpread.md
@@ -78,7 +78,7 @@ The options returned by the contract are Zoe invitations, so their values and te
 by asking for the contract terms.  This makes it possible to sell the options because a prospective
 purchaser will be able to inspect the value. The prospective purchaser can see that the
 priceAuthority is one they are willing to rely on and can verify the underlying amount.  They can
-check that the expiration matches their expectations (here `3` is a small integer suitable for a
+check that the expiration matches their expectations (here `3n` is a small integer suitable for a
 manual timer in a test; in actual use, it might represent block height or wall clock time.) The
 strike prices and settlement amount are likewise visible.
 

--- a/main/zoe/guide/contracts/pricedCallSpread.md
+++ b/main/zoe/guide/contracts/pricedCallSpread.md
@@ -60,7 +60,7 @@ strikePrice2, settlementAmount }`.
 ## Creating the Option Invitations
 
 The terms specify all the details of the options. A call to `creatorFacet.makeInvitationPair()` is
-required to specify the share (as a whole number percentage) that will be contributed for the long
+required to specify the share (as a whole number percentage in BigInt form) that will be contributed for the long
 position. It returns a pair of invitations.
 
 <<< @/snippets/zoe/contracts/test-callSpread.js#makeInvitationPriced

--- a/main/zoe/guide/price-authority.md
+++ b/main/zoe/guide/price-authority.md
@@ -73,7 +73,8 @@ requested.
 - `amountIn`: `{ Amount }`
 - `brandOut`: `{ Brand }`
 - Returns: `{ Promise<PriceQuote> }`
-- Resolves after `deadline` passes on the `priceAuthority`’s `timerService` with the price quote of `amountIn` at that time. 
+- Resolves after `deadline` passes on the `priceAuthority`’s `timerService` with the price 
+  quote of `amountIn` at that time. Note that `deadline`'s value is a `BigInt`.
 
 ### quoteGiven(amountIn, brandOut)
 - `amountIn: `{ Amount }`

--- a/main/zoe/guide/proposal.md
+++ b/main/zoe/guide/proposal.md
@@ -26,8 +26,8 @@ Proposals are records with `give`, `want`, and `exit` keys.
 
 ```js
 const myProposal = harden({
-  give: { Asset: quatloosAmountMath.make(4)},
-  want: { Price: moolaAmountMath.make(15) },
+  give: { Asset: quatloosAmountMath.make(4n)},
+  want: { Price: moolaAmountMath.make(15n) },
   exit: { 'onDemand'
 })
 ```
@@ -37,8 +37,10 @@ payments to be escrowed, and payouts to the user.
 In the example above, `Asset` and `Price` are the keywords. However, in an auction contract,
 the keywords might be `Asset` and `Bid`.
 
-The `quatloosAmountMath.make(4)` is just making an ERTP `amount`, or description of digital assets.
-In this case, 4 of our imaginary Quatloos currency. `moolaAmountMath.make(15)` is making an `amount` of 15 of our imaginary Moola currency. 
+The `quatloosAmountMath.make(4n)` is just making an ERTP `amount`, or description of digital assets.
+In this case, 4 of our imaginary Quatloos currency. `moolaAmountMath.make(15n)` is making 
+an `amount` of 15 of our imaginary Moola currency. (The appended "n" indicates that the numbers are
+represented as `BigInts` rather than `Numbers`)
 
 **Note**: It's important to understand that `amounts` are just descriptions of assets with no
 intrinsic value. `payments` hold actual digital assets.

--- a/main/zoe/guide/proposal.md
+++ b/main/zoe/guide/proposal.md
@@ -49,7 +49,7 @@ intrinsic value. `payments` hold actual digital assets.
 - `'onDemand'`: (Default) Whenever the user wants.
 - `'waived'`: The user cannot cancel, relying on the contract to finish the offer.
 - `'afterDeadline'`: Cancelled automatically after a deadline. This requires two
-  more properties, a `timer` object and a deadline value.
+  more properties, a `timer` object and a deadline BigInt value.
 
 ## Escrowed Payments
 

--- a/snippets/ertp/guide/test-amount-math.js
+++ b/snippets/ertp/guide/test-amount-math.js
@@ -18,7 +18,7 @@ test('ertp guide amountMath localAmountMath', async t => {
   // #region localAmountMath
   const quatloosLocalAmountMath = await makeLocalAmountMath(quatloosIssuer);
   // #endregion localAmountMath
-  t.is(quatloosLocalAmountMath.make(2).value, 2);
+  t.is(quatloosLocalAmountMath.make(2).value, 2n);
 });
 
 test('ertp guide amountMath methods getBrand', async t => {
@@ -38,7 +38,7 @@ test('ertp guide amountMath methods getValue', async t => {
   // returns 123
   const value = quatloosAmountMath.getValue(quatloos123);
   // #endregion getValue
-  t.is(value, 123);
+  t.is(value, 123n);
 });
 
 test('ertp guide amountMath methods getAmountMathKind', async t => {
@@ -154,7 +154,7 @@ test('ertp guide amountMath methods make', async t => {
   } = makeIssuerKit('quatloos');
   /// An `amount` with `value` = 837 and `brand` = Quatloos
   const quatloos837 = quatloosAmountMath.make(837);
-  const anotherQuatloos837 = harden({ brand: quatloosBrand, value: 837 });
+  const anotherQuatloos837 = harden({ brand: quatloosBrand, value: 837n });
   t.deepEqual(quatloos837, anotherQuatloos837);
   // #endregion make
 });

--- a/snippets/ertp/guide/test-amounts.js
+++ b/snippets/ertp/guide/test-amounts.js
@@ -11,7 +11,7 @@ test('ertp guide amounts', async t => {
     issuer: quatloosIssuer,
   } = quatloosKit;
   // #region manualMake
-  const newAmount = { brand: quatloosBrand, value: 5 };
+  const newAmount = { brand: quatloosBrand, value: 5n };
   // #endregion manualMake
   t.deepEqual(newAmount, quatloosAmountMath.make(5));
 
@@ -54,11 +54,11 @@ test('ertp guide amounts', async t => {
   const value = quatloosAmountMath.getValue(quatloos123);
   // #endregion getValue
 
-  t.is(value, 123);
+  t.is(value, 123n);
 
   // #region make
   const quatloos837 = quatloosAmountMath.make(837);
   // #endregion make
 
-  t.deepEqual(quatloos837, { brand: quatloosBrand, value: 837 });
+  t.deepEqual(quatloos837, { brand: quatloosBrand, value: 837n });
 });

--- a/snippets/ertp/guide/test-issuers-and-mints.js
+++ b/snippets/ertp/guide/test-issuers-and-mints.js
@@ -28,7 +28,7 @@ test('ertp guide issuers and mints makeIssuerKit', async t => {
   t.truthy(quatloosIssuer);
   t.truthy(quatloosMint);
   t.truthy(quatloosBrand);
-t.deepEqual(quatloos2, { brand: quatloosBrand, value: 2n });
+  t.deepEqual(quatloos2, { brand: quatloosBrand, value: 2n });
   t.truthy(titleMint);
   t.truthy(titleIssuer);
   t.truthy(titleAmountMath);

--- a/snippets/ertp/guide/test-issuers-and-mints.js
+++ b/snippets/ertp/guide/test-issuers-and-mints.js
@@ -28,7 +28,7 @@ test('ertp guide issuers and mints makeIssuerKit', async t => {
   t.truthy(quatloosIssuer);
   t.truthy(quatloosMint);
   t.truthy(quatloosBrand);
-  t.deepEqual(quatloos2, { brand: quatloosBrand, value: 2 });
+t.deepEqual(quatloos2, { brand: quatloosBrand, value: 2n });
   t.truthy(titleMint);
   t.truthy(titleIssuer);
   t.truthy(titleAmountMath);
@@ -71,7 +71,7 @@ test('ertp guide issuers and mints makeEmptyPurse', async t => {
   // #endregion makeEmptyPurse
   t.deepEqual(await quatloosPurse.getCurrentAmount(), {
     brand: quatloosIssuer.getBrand(),
-    value: 0,
+    value: 0n,
   });
 });
 
@@ -123,7 +123,7 @@ test('ertp guide issuers and mints payment methods', async t => {
 
   t.deepEqual(await quatloosIssuer.getAmountOf(combinedPayment), {
     brand: quatloosBrand,
-    value: 100,
+    value: 100n,
   });
 
   // #region split
@@ -168,7 +168,7 @@ test('ertp guide issuers and mints payment methods', async t => {
 
   t.is(arrayOfNewPayments.length, 10);
   t.deepEqual(await quatloosIssuer.getAmountOf(arrayOfNewPayments[0]), {
-    value: 10,
+    value: 10n,
     brand: quatloosBrand,
   });
 

--- a/snippets/zoe/contracts/test-callSpread.js
+++ b/snippets/zoe/contracts/test-callSpread.js
@@ -47,17 +47,17 @@ test('callSpread, mid-strike', async t => {
   // Setup Carol
   const carolBucksPurse = bucksIssuer.makeEmptyPurse();
 
-  const manualTimer = buildManualTimer(console.log, 0);
+  const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = makeTestPriceAuthority(
     amountMaths,
-    [20, 45],
+    [20n, 45n],
     manualTimer,
   );
 
   // #region startInstance
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
-    expiration: 3,
+    expiration: 3n,
     underlyingAmount: simoleans(2),
     priceAuthority,
     strikePrice1: moola(60),
@@ -129,7 +129,7 @@ test('callSpread, mid-strike', async t => {
   const optionValue = shortOptionAmount.value[0];
   const carolTerms = await zoe.getTerms(optionValue.instance);
   t.is('short', optionValue.position);
-  t.is(3, carolTerms.expiration);
+  t.is(3n, carolTerms.expiration);
   t.is(manualTimer, carolTerms.timer);
   t.is(priceAuthority, carolTerms.priceAuthority);
   t.truthy(simoleanMath.isEqual(simoleans(2), carolTerms.underlyingAmount));
@@ -168,17 +168,17 @@ test('pricedCallSpread, mid-strike', async t => {
   const carolBucksPurse = bucksIssuer.makeEmptyPurse();
   const carolBucksPayment = bucksMint.mintPayment(bucks(75));
 
-  const manualTimer = buildManualTimer(console.log, 0);
+  const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = await makeTestPriceAuthority(
     amountMaths,
-    [20, 45, 45, 45, 45, 45, 45],
+    [20n, 45n, 45n, 45n, 45n, 45n, 45n],
     manualTimer,
   );
 
   // #region startInstancePriced
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
-    expiration: 3,
+    expiration: 3n,
     underlyingAmount: simoleans(2),
     priceAuthority,
     strikePrice1: moola(60),
@@ -200,7 +200,7 @@ test('pricedCallSpread, mid-strike', async t => {
   // #endregion startInstancePriced
 
   // #region makeInvitationPriced
-  const invitationPair = await E(creatorFacet).makeInvitationPair(75);
+  const invitationPair = await E(creatorFacet).makeInvitationPair(75n);
   const { longInvitation, shortInvitation } = invitationPair;
   // #endregion makeInvitationPriced
 
@@ -215,7 +215,7 @@ test('pricedCallSpread, mid-strike', async t => {
 
   t.is(installation, longOptionValue.installation);
   t.is('long', longOptionValue.position);
-  t.is(225, longOptionValue.collateral);
+  t.is(225n, longOptionValue.collateral);
   // endregion validatePricedInvitation
 
   // region checkTerms-priced


### PR DESCRIPTION
This PR updates the documentation for agoric-sdk using Nat 4.0.0 (https://github.com/Agoric/agoric-sdk/pull/2475).

Things changed in https://github.com/Agoric/agoric-sdk/pull/2475:
* Nat values such as `moola3` are [BigInts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) rather than Numbers: `{ brand, value: 3n}` 
* Expiration dates and deadlines are also BigInts. E.g:
```
const myProposal = harden({
  give: { Asset: quatloos(4)},
  want: { Price: moola(15) },
  exit: { afterDeadline: {
    timer,
    deadline: 100n,
  }}
})
```

Still to do:
- [ ] Although the snippet tests have been updated, we should check any code that is written as text for the above changes.
- [ ] An short upgrade guide for anyone who has already made a dapp
- [ ] An explanation of what BigInts are, their benefits, and how to use them. (A good start is here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)

#agoric-sdk-branch: 325-nat-4.0.0-zoe