### PR TITLE
Typo, copy and link fixes

### DIFF
--- a/main/guides/js-programming/agoric-js-overview.md
+++ b/main/guides/js-programming/agoric-js-overview.md
@@ -27,7 +27,7 @@ any IO objects that provide [*ambient authority*](https://en.wikipedia.org/wiki/
 more detailed explanation of SES and its functionality, see the [SES Guide](./ses/ses-guide.md) 
 and [SES Reference](./ses/ses-reference.md).
 
-As of SES-0.8.0/Fall 2020, [the SES source code](https://github.com/Agoric/SES-shim/blob/SES-v0.8.0/packages/ses/src/whitelist.js) 
+As of SES-0.8.0/Fall 2020, [the SES source code](https://github.com/endojs/endo/blob/SES-v0.8.0/packages/ses/src/whitelist.js) 
 defines a subset of the globals defined by the baseline JavaScript language specification. SES **includes** the globals:
 
 - `Object`
@@ -73,7 +73,7 @@ The vat environment has four significant objects not part of standard JavaScript
   A hardened object’s properties cannot be changed, so the only way to interact 
   with a hardened object is through its methods. `harden()` is similar to `Object.freeze()` 
   but more powerful. For more details, 
-  see [the details from the `ses` package](https://github.com/Agoric/SES-shim/blob/master/packages/ses/README.md#harden).
+  see [the details from the `ses` package](https://github.com/endojs/endo/blob/master/packages/ses/README.md#harden).
 
   `harden()` should be called on all objects that will be transferred
   across a trust boundary. The general rule is if you make a new object 
@@ -86,7 +86,7 @@ The vat environment has four significant objects not part of standard JavaScript
   can be imported as `import { E } from '@agoric/eventual-send`. These two 
   are defined by the TC39 [Eventual-Send Proposal](https://github.com/tc39/proposal-eventual-send). 
 
-- `Compartment` (a [part of SES](https://github.com/Agoric/SES-shim/tree/SES-v0.8.0/packages/ses#compartment)) 
+- `Compartment` (a [part of SES](https://github.com/endojs/endo/tree/SES-v0.8.0/packages/ses#compartment)) 
   is a global. Vat code runs inside a `Compartment` and can create sub-compartments 
   to host other code (with different globals or transforms).
 
@@ -165,7 +165,7 @@ SES environment. The most surprising removals include `atob`, `TextEncoder`, and
 
 ## Shim limitations
 
-The [*shim*](https://github.com/Agoric/SES-shim/) providing our SES environment is not as 
+The [*shim*](https://github.com/endojs/endo/tree/master/packages/ses) providing our SES environment is not as 
 fully-featured as a native implementation. As a result, you cannot use some forms of code 
 yet. The following restrictions should be lifted once your JS engine can provide SES natively.
 
@@ -282,7 +282,7 @@ compatible; you can use them if you don't invoke certain features.
 The same is true for NPM packages that use missing globals, or attempt to 
 modify frozen primordials.
 
-The [SES wiki](https://github.com/Agoric/SES-shim/wiki) tracks compatibility 
+The [SES wiki](https://github.com/endojs/endo/wiki) tracks compatibility 
 reports for NPM packages, including potential workarounds.
 
 ## Summary

--- a/main/guides/js-programming/agoric-js-overview.md
+++ b/main/guides/js-programming/agoric-js-overview.md
@@ -25,7 +25,7 @@ SES is a safe deterministic subset of "strict mode" JavaScript. This means it do
 any IO objects that provide [*ambient authority*](https://en.wikipedia.org/wiki/Ambient_authority) 
 (which is not “safe”). SES also removes non-determinism by modifying a few built-in objects. For a 
 more detailed explanation of SES and its functionality, see the [SES Guide](./ses/ses-guide.md) 
-and [SES Reference(./ses/ses-reference.md).
+and [SES Reference](./ses/ses-reference.md).
 
 As of SES-0.8.0/Fall 2020, [the SES source code](https://github.com/Agoric/SES-shim/blob/SES-v0.8.0/packages/ses/src/whitelist.js) 
 defines a subset of the globals defined by the baseline JavaScript language specification. SES **includes** the globals:
@@ -69,7 +69,7 @@ The vat environment has four significant objects not part of standard JavaScript
   for debug information only. The console is not obliged to write to the POSIX 
   standard output.
 
--`harden` is a global that freezes an object’s API surface (enumerable data properties). 
+- `harden` is a global that freezes an object’s API surface (enumerable data properties). 
   A hardened object’s properties cannot be changed, so the only way to interact 
   with a hardened object is through its methods. `harden()` is similar to `Object.freeze()` 
   but more powerful. For more details, 

--- a/main/guides/js-programming/ses/lockdown.md
+++ b/main/guides/js-programming/ses/lockdown.md
@@ -246,7 +246,7 @@ SES amplifies this and reveals much more information than the normal
 Also, the enhanced virtual `console` has a special relationship with
 error objects and the SES `assert` package. Errors can report 
 more diagnostic information that should be hidden from other objects. See
-the [error README](https://github.com/Agoric/SES-shim/blob/master/packages/ses/src/error/README.md) 
+the [error README](https://github.com/endojs/endo/blob/master/packages/ses/src/error/README.md) 
 for an in depth explanation of this
 relationship between errors, `assert` and the virtual `console`.
 
@@ -336,7 +336,7 @@ magic powers of the v8 `Error` constructor&mdash;those consistent with the
 discourse level of the proposed `getStack`. In all cases, the `Error`
 constructor shared by all other compartments is both safe and powerless.
 
-See the [error README](https://github.com/Agoric/SES-shim/blob/master/packages/ses/src/error/README.md) 
+See the [error README](https://github.com/endojs/endo/blob/master/packages/ses/src/error/README.md) 
 for an in depth explanation of the
 relationship between errors, `assert` and the virtual `console`.
 
@@ -479,7 +479,7 @@ JavaScript suffers from the so-called
 preventing `lockdown()` from _simply_ hardening all primordials. 
 
 Rather, `lockdown()` converts each of
-[these data properties](https://github.com/Agoric/SES-shim/blob/master/packages/ses/src/enablements.js) to an accessor
+[these data properties](https://github.com/endojs/endo/blob/master/packages/ses/src/enablements.js) to an accessor
 property whose getter and setter emulate [a data property without the override
 mistake](https://github.com/tc39/ecma262/pull/1320). For non-reflective code
 the illusion is perfect. But reflective code sees it is an accessor
@@ -501,7 +501,7 @@ Enablements have a further debugging cost. When single stepping *into* code,
 you step into every access to an enabled property. Every read steps into
 the enabling getter. This adds yet more noise to the debugging experience.
 
-[src/enablements.js](https://github.com/Agoric/SES-shim/blob/master/packages/ses/src/enablements.js) exports two different
+[src/enablements.js](https://github.com/endojs/endo/blob/master/packages/ses/src/enablements.js) exports two different
 whitelists defining which data properties to convert to enable override by
 assignment, `moderateEnablements` and `minEnablements`.
 

--- a/main/guides/js-programming/ses/ses-guide.md
+++ b/main/guides/js-programming/ses/ses-guide.md
@@ -109,7 +109,7 @@ import 'ses/lockdown';
 As mentioned, SES does not include any IO objects providing "unsafe" [*ambient authority*](https://en.wikipedia.org/wiki/Ambient_authority). 
 It also doesn't allow non-determinism from built-in JavaScript objects. 
 
-As of SES-0.8.0/Fall 2020, [Agoric's SES source code](https://github.com/Agoric/SES-shim/blob/SES-v0.8.0/packages/ses/src/whitelist.js) 
+As of SES-0.8.0/Fall 2020, [Agoric's SES source code](https://github.com/endojs/endo/blob/SES-v0.8.0/packages/ses/src/whitelist.js) 
 defines a subset of the globals defined by the baseline JavaScript language specification. SES includes these globals:
 
 - `Object`
@@ -202,7 +202,7 @@ makes those global objects available.
   thorough. See the individual [`lockdown()`](#lockdown) and [`harden()`](#harden) sections
   below. 
 
-- `[Compartment](https://github.com/Agoric/SES-shim/tree/SES-v0.8.0/packages/ses#compartment)` is 
+- `[Compartment](https://github.com/endojs/endo/tree/SES-v0.8.0/packages/ses#compartment)` is 
   a global. Code runs inside a `Compartment` and can create sub-compartments to host other 
   code (with different globals or transforms). Note that these child compartments get `harden()` and `Compartment`.
 
@@ -425,7 +425,7 @@ usable if you don't invoke certain features.
 
 The same is true for NPM packages that use missing globals, or attempt to modify frozen primordials.
 
-The [SES wiki](https://github.com/Agoric/SES-shim/wiki) tracks compatibility reports for NPM packages, 
+The [SES wiki](https://github.com/endojs/endo/wiki) tracks compatibility reports for NPM packages, 
 including potential workarounds.
 
 ## HTML comments

--- a/main/guides/js-programming/ses/ses-reference.md
+++ b/main/guides/js-programming/ses/ses-reference.md
@@ -211,7 +211,7 @@ lockdown({ localeTaming: 'unsafe' }); // Allow locale-specific behavior
 The default `'safe'` option actually expands what you would expect from `console`'s logging 
 output. It will show information from the `assert` package and error objects.
 Errors can report more diagnostic information that should be hidden from other objects. See
-the [error README](https://github.com/Agoric/SES-shim/blob/master/packages/ses/src/error/README.md) 
+the [error README](https://github.com/endojs/endo/blob/master/packages/ses/src/error/README.md) 
 for an in depth explanation of this.
 
 The `'unsafe'` setting leaves the original `console` in place. The `assert` package

--- a/main/guides/wallet/README.md
+++ b/main/guides/wallet/README.md
@@ -93,7 +93,7 @@ over the wallet bridge:
       petname: 'Instance',
       boardId: INSTANCE_BOARD_ID,
     });
-    // Our issuer will default to something like `FungibleFaucet.Assurance`.
+    // Our issuer will default to something like `FungibleFaucet.Token`.
     walletSend({
       type: 'walletSuggestIssuer',
       petname: 'Token',
@@ -108,7 +108,7 @@ lets users make data generally available. Users can obtain an Id by posting a va
 others can get the value just by knowing the Id. You can make Id(s) known by any 
 communication method you like; private email, an email blast to a mailing list 
 or many individuals, buying an ad on a website, tv program, or newspaper, 
-listing it on her website, etc.
+listing it on your website, etc.
 
 <<< @/snippets/ertp/guide/test-readme.js#getValue
 

--- a/main/guides/wallet/api.md
+++ b/main/guides/wallet/api.md
@@ -48,7 +48,7 @@ standard wallet-bridge.html.
 Adds a payment to the Wallet for deposit to the user-specified purse,
 either via an autodeposit or manually approved.
 
-### `getDepositFacet(brandBoardId)`
+### `getDepositFacetId(brandBoardId)`
 - `brandBoardId` `{String}`
 - Returns: `{Promise<string>}`
 

--- a/main/guides/wallet/api.md
+++ b/main/guides/wallet/api.md
@@ -42,7 +42,7 @@ This is available for completeness to provide the underlying API that's availabl
 standard wallet-bridge.html.
 
 ### `addPayment(payment)`
-- `id` `{ERef<Payment>}`
+- `payment` `{ERef<Payment>}`
 - Returns: `void`
 
 Adds a payment to the Wallet for deposit to the user-specified purse,

--- a/main/zoe/guide/contract-requirements.md
+++ b/main/zoe/guide/contract-requirements.md
@@ -23,7 +23,7 @@ A Zoe contract will be bundled up, so you should feel free to divide
 your contract into multiple files (perhaps putting helper functions in a
 separate file, for example) and import them.
 
-A Zoe contract needs to be able to run under [Agoric's SES](https://github.com/Agoric/ses-shim#secure-ecmascript-shim-ses-shim). Some legacy
+A Zoe contract needs to be able to run under [Agoric's SES](https://github.com/endojs/endo/tree/master/packages/ses). Some legacy
 JavaScript code is incompatible with SES, because SES freezes the
 JavaScript objects you start out with (the primordials, such as `Object`), and some legacy code tries to
 mutate these. 


### PR DESCRIPTION
While going through the documentation, I found a few issues:
- A couple missing characters in  the JS programming overview
- Outdated links to the `SES-Shim` repo
- A few words out of place, possibly the result of copy paste
- The Wallet API has a `getDepositFacetId` instead of a `getDepositFacet` (possible introduced in #390)

Each of these changes are in separate commits.