### PR TITLE
Updates to JS programming overview page

### DIFF
--- a/main/guides/js-programming/agoric-js-overview.md
+++ b/main/guides/js-programming/agoric-js-overview.md
@@ -196,7 +196,7 @@ sneaky = import
 // tricky comment to obscure function invocation
 (modulename);
 ```
-There are also problems with “import” being near a parenthesis inside a comment. 
+There are also problems when “import” is near a parenthesis inside a comment. 
 
 ### Direct vs. indirect eval expressions
 

--- a/main/guides/js-programming/agoric-js-overview.md
+++ b/main/guides/js-programming/agoric-js-overview.md
@@ -33,8 +33,8 @@ defines a subset of the globals defined by the baseline JavaScript language spec
 - `Object`
 - `Array`
 - `Number`
-- `Map`
-- `WeakMap`
+- `Map` / `Set`
+- `WeakMap` / `WeakSet`
 - `Number`
 - `BigInt`
 - `Intl`

--- a/main/guides/js-programming/agoric-js-overview.md
+++ b/main/guides/js-programming/agoric-js-overview.md
@@ -176,11 +176,11 @@ containing either of the strings `<!--` or `-->`, even if neither marks a commen
 
 ### Dynamic import expressions
 
-The "dynamic import" feature (`import('path')`) enables code to load dependencies at runtime.
-While it takes the form of an expression returning a Promise, it's actually not a normal
-function call, but is instead JavaScript syntax. As such it would let vat code bypass the
-shim's `Compartment`'s module map. For safety, the SES shim rejects code that looks like it
-uses the dynamic import syntax.
+The "dynamic import expression" (`import('path')`) enables code to load dependencies at
+runtime. It returns a promise resolving to the module namespace object. While it takes
+the form of a function call, it's actually not a function call, but is instead JavaScript
+syntax. As such it would let vat code bypass the shim's `Compartment`'s module map.
+For safety, the SES shim rejects code that looks like it uses a dynamic import expression.
 
 The regular expression for this pattern is safe and should never allow any use of
 dynamic import, however obfuscated the usage is. Because of this, it may be confused

--- a/main/guides/js-programming/agoric-js-overview.md
+++ b/main/guides/js-programming/agoric-js-overview.md
@@ -107,13 +107,10 @@ additions and not part of JavaScript.
 Most Node.js-specific [global objects](https://nodejs.org/dist/latest-v14.x/docs/api/globals.html) 
 are unavailable within a vat including:
 
-* `queueMicrotask`
+* `queueMicrotask`: You can 
+  replace `queueMicrotask(fn)` with `Promise.resolve().then(_ => fn())`.
 * `Buffer` (consider using `TypedArray` instead, but see below)
-* `setImmediate`/`clearImmediate`: Not available, but you can generally 
-  replace `setImmediate(fn)` with `Promise.resolve().then(_ => fn())` to 
-  defer execution of `fn` until after the current event/callback finishes 
-  processing. But be aware it won't run until after all *other* ready 
-  Promise callbacks execute. 
+* `setImmediate`/`clearImmediate`: Not available
 
 There are two queues: the *IO queue* (accessed by `setImmediate`), and 
 the *Promise queue* (accessed by Promise resolution). SES code can only 

--- a/main/guides/js-programming/agoric-js-overview.md
+++ b/main/guides/js-programming/agoric-js-overview.md
@@ -219,16 +219,18 @@ authorities as you like.
 
 The most common way to invoke an indirect eval is `(1,eval)(code)`.
 
-The SES shim cannot correctly emulate a direct eval. If it tried, it would perform 
-an indirect eval. This could be pretty confusing, because the code might not actually 
-use objects from the local scope. You might not notice the problem until some later 
-change altered the behavior.
+The SES proposal does not change how direct and indirect eval work. However, the SES shim
+cannot correctly emulate a direct eval. If it tried, it would perform an indirect eval.
+This could be pretty confusing, because the evaluated code would not use objects from
+the local scope as expected. Furthermore, in the future when SES is natively implemented
+by JavaScript engines, the behavior would revert to direct eval, allowing access to
+anything in scope.
 
-To avoid this confusion, the shim uses a regular expression to reject code that 
-looks like it is performing a direct eval. This regexp is not complete (you can 
-trick it into allowing a direct eval), but that’s safe because it really performs
-an indirect eval. Our goal is just to guide people away from confusing behaviors
-early in their development process.
+To avoid this confusion and compatibility risk, the shim uses a regular expression to
+reject code that looks like it is performing a direct eval. This regexp is not complete
+(you can trick it into allowing a direct eval), but that’s safe because it really performs
+an indirect eval. Our goal is just to guide people away from confusing and non-compliant
+behaviors early in their development process.
 
 This regexp falsely rejects occurrences inside static strings and comments.
 

--- a/main/guides/js-programming/agoric-js-overview.md
+++ b/main/guides/js-programming/agoric-js-overview.md
@@ -181,22 +181,26 @@ While it takes the form of an expression returning a Promise, it's actually not 
 function call, but is instead JavaScript syntax. As such it would let vat code bypass the
 shim's `Compartment`'s module map. For safety, the SES shim rejects code that looks like it
 uses the dynamic import syntax.
-The regular expression for this pattern can be confused into falsely rejecting legitimate 
-code. For example, the word “import” at the end of a line in a comment, such as:
+
+The regular expression for this pattern is safe and should never allow any use of
+dynamic import, however obfuscated the usage is. Because of this, it may be confused
+into falsely rejecting legitimate code.
+
+For example, the word “import” near a parenthesis or at the end of a line inside a
+comment is identified as a disallowed use of `import()` and falsely rejected:
 ```js
 //
 // This function calculates the import
 // duties paid on the merchandise..
 //
 ```
-The regexp confuses the above with something like the following, and rejects it:
+
+But the following obfuscated dynamic import usage is rightly rejected:
 ```js
-foo = bar(argument);
 sneaky = import
-// tricky comment to obscure function invocation
+// comment to hide invocation
 (modulename);
 ```
-There are also problems when “import” is near a parenthesis inside a comment. 
 
 ### Direct vs. indirect eval expressions
 

--- a/main/guides/js-programming/agoric-js-overview.md
+++ b/main/guides/js-programming/agoric-js-overview.md
@@ -226,8 +226,9 @@ change altered the behavior.
 
 To avoid this confusion, the shim uses a regular expression to reject code that 
 looks like it is performing a direct eval. This regexp is not complete (you can 
-trick it into performing a direct eval anyway), but that’s safe. Our goal is 
-just to guide people away from confusing behaviors early in their development process.
+trick it into allowing a direct eval), but that’s safe because it really performs
+an indirect eval. Our goal is just to guide people away from confusing behaviors
+early in their development process.
 
 This regexp falsely rejects occurrences inside static strings and comments.
 

--- a/main/guides/js-programming/agoric-js-overview.md
+++ b/main/guides/js-programming/agoric-js-overview.md
@@ -179,10 +179,7 @@ containing either of the strings `<!--` or `-->`, even if neither marks a commen
 
 ### Dynamic import expressions
 
-One active JS feature proposal would add a "dynamic import" expression: `await import('path')`. 
-If implemented (or if someone decides to be an early adopter and adds it to an engine), 
-and your JS engine has this, vat code might be able to bypass the `Compartment`'s module 
-map. For safety, the SES shim already rejects code that looks like it uses this feature. 
+The "dynamic import" feature (`await import('path')`) is not a function call but JavaScript syntax. As such it would allow vat code to bypass the shim's `Compartment`'s module map. For safety, the SES shim rejects code that looks like it uses this feature. 
 The regular expression for this pattern can be confused into falsely rejecting legitimate 
 code. For example, the word “import” at the end of a line in a comment, such as:
 ```js

--- a/main/guides/js-programming/agoric-js-overview.md
+++ b/main/guides/js-programming/agoric-js-overview.md
@@ -176,7 +176,11 @@ containing either of the strings `<!--` or `-->`, even if neither marks a commen
 
 ### Dynamic import expressions
 
-The "dynamic import" feature (`await import('path')`) is not a function call but JavaScript syntax. As such it would allow vat code to bypass the shim's `Compartment`'s module map. For safety, the SES shim rejects code that looks like it uses this feature. 
+The "dynamic import" feature (`import('path')`) enables code to load dependencies at runtime.
+While it takes the form of an expression returning a Promise, it's actually not a normal
+function call, but is instead JavaScript syntax. As such it would let vat code bypass the
+shim's `Compartment`'s module map. For safety, the SES shim rejects code that looks like it
+uses the dynamic import syntax.
 The regular expression for this pattern can be confused into falsely rejecting legitimate 
 code. For example, the word “import” at the end of a line in a comment, such as:
 ```js

--- a/main/guides/js-programming/ses/ses-guide.md
+++ b/main/guides/js-programming/ses/ses-guide.md
@@ -443,22 +443,26 @@ While it takes the form of an expression returning a Promise, it's actually not 
 function call, but is instead JavaScript syntax. As such it would let vat code bypass the
 shim's `Compartment`'s module map. For safety, the SES shim rejects code that looks like it
 uses the dynamic import syntax.
-The regular expression for this pattern can be confused into falsely rejecting legitimate 
-code. For example, the word “import” at the end of a line in a comment, such as:
+
+The regular expression for this pattern is safe and should never allow any use of
+dynamic import, however obfuscated the usage is. Because of this, it may be confused
+into falsely rejecting legitimate code.
+
+For example, the word “import” near a parenthesis or at the end of a line inside a
+comment is identified as a disallowed use of `import()` and falsely rejected:
 ```js
 //
 // This function calculates the import
 // duties paid on the merchandise..
 //
 ```
-The regexp confuses the above with something like the following, and rejects it:
+
+But the following obfuscated dynamic import usage is rightly rejected:
 ```js
-foo = bar(argument);
 sneaky = import
-// tricky comment to obscure function invocation
+// comment to hide invocation
 (modulename);
 ```
-There are also problems when “import” is near a parenthesis inside a comment. 
 
 ## Direct vs. indirect eval expressions
 

--- a/main/guides/js-programming/ses/ses-guide.md
+++ b/main/guides/js-programming/ses/ses-guide.md
@@ -438,12 +438,13 @@ even if neither marks a comment.
 
 ### Dynamic import expressions
 
-One active JavaScript feature proposal adds a "dynamic import" expression: `await import('path')`. 
-If implemented (or if someone decides to be an early adopter and adds it to an engine), and your engine 
-has this, code might be able to bypass the `Compartment`'s module map. For safety, the Agoric SES shim already 
-rejects code that looks like it uses this feature. The regular expression for this pattern can be 
-confused into falsely rejecting legitimate code. For example, the word “import” at the end of a line 
-in a comment, such as:
+The "dynamic import" feature (`import('path')`) enables code to load dependencies at runtime.
+While it takes the form of an expression returning a Promise, it's actually not a normal
+function call, but is instead JavaScript syntax. As such it would let vat code bypass the
+shim's `Compartment`'s module map. For safety, the SES shim rejects code that looks like it
+uses the dynamic import syntax.
+The regular expression for this pattern can be confused into falsely rejecting legitimate 
+code. For example, the word “import” at the end of a line in a comment, such as:
 ```js
 //
 // This function calculates the import
@@ -481,13 +482,17 @@ as many or as few authorities as you like.
 
 The most common way to invoke an indirect eval is `(1,eval)(code)`.
 
-The Agoric SES shim cannot correctly emulate a direct eval. If it tried, it would perform an indirect eval. 
-This could be pretty confusing, because the code might not actually use objects from the local scope. 
-You might not notice the problem until some later change altered the behavior.
+The SES proposal does not change how direct and indirect eval work. However, the SES shim
+cannot correctly emulate a direct eval. If it tried, it would perform an indirect eval.
+This could be pretty confusing, because the evaluated code would not use objects from
+the local scope as expected. Furthermore, in the future when SES is natively implemented
+by JavaScript engines, the behavior would revert to direct eval, allowing access to
+anything in scope.
 
-To avoid this confusion, the shim uses a regular expression to reject code that looks like it is 
-performing a direct eval. This regexp is not complete (you can trick it into performing a direct 
-eval anyway), but  that’s safe. Our goal is just to guide people away from confusing behaviors 
-early in their development process.
+To avoid this confusion and compatibility risk, the shim uses a regular expression to
+reject code that looks like it is performing a direct eval. This regexp is not complete
+(you can trick it into allowing a direct eval), but that’s safe because it really performs
+an indirect eval. Our goal is just to guide people away from confusing and non-compliant
+behaviors early in their development process.
 
 This regexp falsely rejects occurrences inside static strings and comments.

--- a/main/guides/js-programming/ses/ses-guide.md
+++ b/main/guides/js-programming/ses/ses-guide.md
@@ -438,11 +438,11 @@ even if neither marks a comment.
 
 ### Dynamic import expressions
 
-The "dynamic import" feature (`import('path')`) enables code to load dependencies at runtime.
-While it takes the form of an expression returning a Promise, it's actually not a normal
-function call, but is instead JavaScript syntax. As such it would let vat code bypass the
-shim's `Compartment`'s module map. For safety, the SES shim rejects code that looks like it
-uses the dynamic import syntax.
+The "dynamic import expression" (`import('path')`) enables code to load dependencies at
+runtime. It returns a promise resolving to the module namespace object. While it takes
+the form of a function call, it's actually not a function call, but is instead JavaScript
+syntax. As such it would let vat code bypass the shim's `Compartment`'s module map.
+For safety, the SES shim rejects code that looks like it uses a dynamic import expression.
 
 The regular expression for this pattern is safe and should never allow any use of
 dynamic import, however obfuscated the usage is. Because of this, it may be confused


### PR DESCRIPTION
- Dynamic import is now stage 4
- Make clear that dynamic `import` would bypass compartment shim because of its syntax status
- Microtask and task queuing nits
- Add Set and WeakSet as allowed globals for completeness
- Clarify why incomplete eval regex is safe