### PR TITLE
Document passable records

### DIFF
--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -413,6 +413,10 @@ episode [The Gamesters of Triskelion](https://en.wikipedia.org/wiki/The_Gamester
 A transfer of [amounts](#amounts) between [seats](#seat) within Zoe; i.e. a change in their [allocations](#allocation). When a seat exits, it gets its
 current allocation as a [payout](#payout). 
 
+## Record and Tuple
+
+Records and tuples are immutable objects which can be passed by copy. They only contain values which can be passed by copy such as numbers, strings, or other records and tuples. 
+For more details, see [Passable objects documentation](/guides/js-programming/far.md#rules-for-creating-passable-objects).
 ## Seat
 
 Zoe uses a seat to represent an [offer](#offer) in progress, and has two seat [facets](#facet) representing

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -112,13 +112,9 @@ Destroy all digital assets in a payment. See [`issuer.burn(payment, optAmount)`]
 
 ## Comparable
 
-A *passable* is something that can be marshalled. A *comparable* is a
-passable whose leaves contain no promises. Two comparables can be
-synchronously compared for structural equivalence.
-
-A comparable is a JavaScript object containing no promises, and can
-thus be locally compared for equality with another object. If either object
-contains Promises, equality is indeterminable. If both are fulfilled down
+A *comparable* is a [passable](#passable) whose leaves contain no promises. Two 
+comparables can be synchronously compared for structural equivalence. If either passable
+object contains Promises, equality is indeterminable. If both are fulfilled down
 to Presences and local state, then either they're the same all the way
 down, or they represent different objects.
 
@@ -354,6 +350,18 @@ the user either gets what they said they wanted, or gets back (gets a refund) wh
 escrowed. One reason this is possible is if a [proposal](#proposal) doesn't match what the contract expects to do, it
 can immediately cause the [seat](#seat) to exit, getting back the amount it offered.
 
+
+## Passable
+
+A *passable* is something that can be marshalled.
+
+There are three kinds of passables:
+   * Remotables, objects with methods that can be called remotely using `E()`, and their remote Presence.
+   * Pass-by-copy data, such as numbers or hardened records.
+   * Promises for passables.
+
+For more information, see the [Remotable and passable objects documentation](/guides/js-programming/far.md#remotable-and-passable-objects).
+
 ## Payment
 
 Payments hold assets created by [Mints](#mint). Specifically assets intended for transfer 
@@ -415,7 +423,7 @@ current allocation as a [payout](#payout).
 
 ## Record and Tuple
 
-Records and tuples are immutable objects which can be passed by copy. They only contain values which can be passed by copy such as numbers, strings, or other records and tuples. 
+Records and tuples are immutable objects which can be passed by copy. They only contain values which are [passables](#passable). 
 For more details, see [Passable objects documentation](/guides/js-programming/far.md#rules-for-creating-passable-objects).
 ## Seat
 

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -425,6 +425,22 @@ current allocation as a [payout](#payout).
 
 Records and tuples are immutable objects which can be passed by copy. They only contain values which are [passables](#passable). 
 For more details, see [Passable objects documentation](/guides/js-programming/far.md#rules-for-creating-passable-objects).
+
+## Remotable
+
+Remotables are objects intended to be used from other vats. Remote messages sent to remotables must only contain [passable](#passable)
+arguments and return passable results. 
+
+All of a remotable's property values must be functions, and cannot be accessors. Its methods are called by wrapping 
+the remotable object with [`E`](#e), such as `E(issuer).getBrand()`. As with all calls to `E()`, it results in a Promise.
+
+Every object returned from a smart contract, such a publicFacet or creatorFacet, must be passable. All objects used in 
+your contract's external API must be passable.
+
+ERTP objects, such as `Purses`, are automatically created as `Remotable`, as are `UserSeats` and `ZCFSeats`.
+
+For more information, see the [Remotable and passable objects documentation](/guides/js-programming/far.md#remotable-and-passable-objects).
+
 ## Seat
 
 Zoe uses a seat to represent an [offer](#offer) in progress, and has two seat [facets](#facet) representing

--- a/main/guides/js-programming/agoric-js-overview.md
+++ b/main/guides/js-programming/agoric-js-overview.md
@@ -69,7 +69,7 @@ The vat environment has four significant objects not part of standard JavaScript
   for debug information only. The console is not obliged to write to the POSIX 
   standard output.
 
-- `harden` is a global that freezes an object’s API surface (enumerable data properties). 
+- `harden` is a global that freezes an object’s API surface. 
   A hardened object’s properties cannot be changed, so the only way to interact 
   with a hardened object is through its methods. `harden()` is similar to `Object.freeze()` 
   but more powerful. For more details, 

--- a/main/guides/js-programming/far.md
+++ b/main/guides/js-programming/far.md
@@ -28,13 +28,39 @@ In particular, note that every object returned from a smart contract, such a `pu
 `creatorFacet`, must be passable. All objects used in your contract's external API must
 be passable.
 
+### Rules for creating passable objects
+Record and tuples are hardened acyclical objects which can be passed-by-copy if they satisfy some constraints.
+
+#### Record
+A plain object where:
+- All properties must have pass-by-copy values, such as numbers, strings, or other records and tuples.
+  - Properties cannot be accessors.
+- All properties must be own and enumerable, with string names.
+  - Symbols are not allowed.
+  - The prototype must be `Object.prototype` or `null`.
+- Nested values cannot form a cycle.
+- It must be hardened with `harden()`.
+
+#### Record
+A plain array where:
+- All properties must have pass-by-copy values, such as numbers, strings, or other records and tuples.
+  - Properties cannot be accessors.
+- All properties must be own and enumerable, where names are the integers indexes or `length`.
+  - The array cannot have holes.
+  - The prototype must be `Array.prototype`.
+- Nested values cannot form a cycle.
+- It must be hardened with `harden()`.
+
 ### Rules for creating remotables
 - All property values must be functions. 
   - They cannot be accessors.
 - You must wrap the object with `Far()`.
 
 **Note**: ERTP objects, such as `Purses`, are automatically created as `Remotable`, as are
-`UserSeats` and `ZCFSeats`. 
+`UserSeats` and `ZCFSeats`.
+
+**Note**: A hardened empty object can be made remotable instead of passable by copy when
+wrapped with `Far()`. This allows making an unforgeable [Handle](/glossary/#handle).
 
 ### Using remotables
 - Call a remotable's method by first wrapping the remotable object with `E`, such as `E(issuer).getBrand();`

--- a/main/guides/js-programming/far.md
+++ b/main/guides/js-programming/far.md
@@ -33,22 +33,22 @@ Record and tuples are hardened acyclical objects which can be passed-by-copy if 
 
 #### Record
 A plain object where:
-- All properties must have pass-by-copy values, such as numbers, strings, or other records and tuples.
+- All property values must be passables.
   - Properties cannot be accessors.
 - All properties must be own and enumerable, with string names.
   - Symbols are not allowed.
   - The prototype must be `Object.prototype` or `null`.
-- Nested values cannot form a cycle.
+- Nested records and tuples cannot form a cycle.
 - It must be hardened with `harden()`.
 
-#### Record
+#### Tuple
 A plain array where:
-- All properties must have pass-by-copy values, such as numbers, strings, or other records and tuples.
+- All property values must be passables.
   - Properties cannot be accessors.
-- All properties must be own and enumerable, where names are the integers indexes or `length`.
+- All properties must be own, and be all the integers indexes or `length`.
   - The array cannot have holes.
   - The prototype must be `Array.prototype`.
-- Nested values cannot form a cycle.
+- Nested records and tuples cannot form a cycle.
 - It must be hardened with `harden()`.
 
 ### Rules for creating remotables


### PR DESCRIPTION
Clarify what are passable objects, add glossary entry for record and tuple.
Fix harden description to remove enumerable constraint.
Add a note on making remotable handles.