### PR TITLE
fix: Add language hint for Endo archive generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "engines": {
     "node": ">=11.0"
   },
+  "parsers": {
+    "js": "mjs"
+  },
   "scripts": {
     "docs:dev": "vuepress dev main",
     "docs:build": "vuepress build main",


### PR DESCRIPTION
This adds a parsers declaration to package.json, which Endo's compartment mapper recognizes that a `.js` file is a JavaScript module and not a CommonJS module, but unlike `"type": "module"`, does not confuse `node -r esm`.
