### PR TITLE
docs: How to review a zipped up bundle

### DIFF
--- a/main/getting-started/intro-zoe.md
+++ b/main/getting-started/intro-zoe.md
@@ -109,6 +109,14 @@ code directly by calling:
 
 <<< @/snippets/test-intro-zoe.js#inspectCode
 
+In many cases, the bundled source is a single reviewable string.
+In others, the bundle contains to base 64 encoded zip file that you can
+extract for review.
+```
+jq -r .endoZipBase64 bundle.json | base64 -d > bundle.zip
+unzip bundle.zip
+```
+
 Contracts can add their own specific information to invitations. In
 this case, the Atomic Swap contract adds information about what is
 being traded: the `asset`, the amount Alice has escrowed, and the

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -105,6 +105,14 @@ const atomicSwapBundle = await bundleSource(
 The installation operation returns
 an `installation`, which is an object with one method; `getBundle()`. You can access an installed contract's source
 code via `const { source } = await E(installation).getBundle();`.
+In many cases, the bundled source is a single reviewable string.
+In others, the bundle contains to base 64 encoded zip file that you can
+extract for review.
+```
+jq -r .endoZipBase64 bundle.json | base64 -d > bundle.zip
+unzip bundle.zip
+```
+
 
 ## Burn
 


### PR DESCRIPTION
With the imminent change to bundle contracts as base64 encoded Zip files, this prepares the documentation so folks can extract the contract source for review.
