### PR TITLE
refactor: Use import extensions

### DIFF
--- a/main/zoe/api/zoe-helpers.md
+++ b/main/zoe/api/zoe-helpers.md
@@ -3,14 +3,15 @@
 ZoeHelpers are functions that extract common contract code and
 patterns into reusable helpers.
 
-All of the ZoeHelper methods are described below. To use any of them, import
-it directly from `@agoric/zoe/src/contractSupport/`. For example, the following 
-imports the two ZoeHelpers `assertIssuerKeywords()` and `assertProposalShape()`:
+All of the ZoeHelper methods are described below. To use any of them, import it
+directly from `@agoric/zoe/src/contractSupport/index.js`. For example, the
+following imports the two ZoeHelpers `assertIssuerKeywords()` and
+`assertProposalShape()`:
 ```js
 import {
   assertIssuerKeywords,
   assertProposalShape,
-} from '@agoric/zoe/src/contractSupport';
+} from '@agoric/zoe/src/contractSupport/index.js';
 ```
 Note that almost all ZoeHelpers require `zcf`, a `ContractFacet` as a first argument.
 ZoeHelpers are contract helpers, in that they are useful to contract code. Contracts are started up by Zoe, 
@@ -29,7 +30,7 @@ missing or extra keywords. The keywords order is irrelevant.
 ```js
 import {
   assertIssuerKeywords,
-} from '@agoric/zoe/src/contractSupport';
+} from '@agoric/zoe/src/contractSupport/index.js';
 
 // proposals for this contract instance use keywords 'Asset' and 'Price'
 assertIssuerKeywords(zcf, harden(['Asset', 'Price']));
@@ -49,7 +50,7 @@ If `false` throws with message `brand must be AssetKind.NAT`.
 ```js
 import {
   assertNatAssetKind,
-} from '@agoric/zoe/src/contractSupport';
+} from '@agoric/zoe/src/contractSupport/index.js';
 
  assertNatAssetKind(zcf, quatloosBrand);
  ```
@@ -79,7 +80,7 @@ it does a swap on them.
 ```js
 import {
   satisfies,
-} from '@agoric/zoe/src/contractSupport';
+} from '@agoric/zoe/src/contractSupport/index.js';
 
 const satisfiedBy = (xSeat, ySeat) =>
         satisfies(zcf, xSeat, ySeat.getCurrentAllocation());
@@ -116,7 +117,7 @@ If the swap fails, no assets transfer, and both left and right `seats` are exite
 ```js
 import {
   swap,
-} from '@agoric/zoe/src/contractSupport';
+} from '@agoric/zoe/src/contractSupport.js';
 
 swap(zcf, firstSeat, secondSeat);
 ```
@@ -154,7 +155,7 @@ If the swap fails, no assets transfer, and both left and right `seats` are exite
 ```js
 import {
   swapExact,
-} from '@agoric/zoe/src/contractSupport';
+} from '@agoric/zoe/src/contractSupport/index.js';
 
 const swapMsg = swapExact(zcf, zcfSeatA, zcfSeatB);
 ```
@@ -181,7 +182,7 @@ these expectations, that `proposal` is rejected (and refunded).
 ```js
 import {
   assertProposalShape,
-} from '@agoric/zoe/src/contractSupport';
+} from '@agoric/zoe/src/contractSupport/index.js';
 
 const sellAssetForPrice = harden({
     give: { Asset: null },
@@ -211,7 +212,7 @@ defaults to `Deposit and reallocation successful.`
 ```js
 import {
   depositToSeat,
-} from '@agoric/zoe/src/contractSupport';
+} from '@agoric/zoe/src/contractSupport/index.js';
 await depositToSeat(zcf, zcfSeat, { Dep: quatloos(2n) }, { Dep: quatloosPayment });
 ```
 
@@ -231,7 +232,7 @@ Unlike `depositToSeat()`, a `PaymentKeywordRecord` is returned, not a success me
 ```js
 import {
   withdrawFromSeat,
-} from '@agoric/zoe/src/contractSupport';
+} from '@agoric/zoe/src/contractSupport/index.js';
 const paymentKeywordRecord = await withdrawFromSeat(zcf, zcfSeat, { With: quatloos(2n) });
 ```
 
@@ -249,7 +250,7 @@ already present, it is ignored.
 ```js
 import {
   saveAllIssuers,
-} from '@agoric/zoe/src/contractSupport';
+} from '@agoric/zoe/src/contractSupport/index.js';
 await saveAllIssuers(zcf, { G: gIssuer, D: dIssuer, P: pIssuer });
 ```
 

--- a/main/zoe/guide/contract-requirements.md
+++ b/main/zoe/guide/contract-requirements.md
@@ -17,7 +17,7 @@ code, including:
   smartly resolving promises rather than polling
 * [@agoric/zoe](https://www.npmjs.com/package/@agoric/zoe): Zoe has
   helpers that contracts can use by importing
-  `@agoric/zoe/src/contractSupport/zoeHelpers`
+  `@agoric/zoe/src/contractSupport/zoeHelpers.js`
 
 A Zoe contract will be bundled up, so you should feel free to divide
 your contract into multiple files (perhaps putting helper functions in a

--- a/package.json
+++ b/package.json
@@ -119,6 +119,10 @@
       "jsdoc/require-param-description": "off",
       "jsdoc/require-returns": "off",
       "jsdoc/require-returns-description": "off",
+      "import/extensions": [
+        "error",
+        "always"
+      ],
       "import/no-extraneous-dependencies": [
         "error",
         {

--- a/snippets/contract-format.js
+++ b/snippets/contract-format.js
@@ -4,11 +4,12 @@
 
 // Add imports here
 
-// Optional: you may wish to use the Zoe helpers in @agoric/zoe/src/contractSupport
-import { swap as _ } from '@agoric/zoe/src/contractSupport';
+// Optional: you may wish to use the Zoe helpers in
+// @agoric/zoe/src/contractSupport/index.js
+import { swap as _ } from '@agoric/zoe/src/contractSupport/index.js';
 
 // Import the Zoe types
-import '@agoric/zoe/exported';
+import '@agoric/zoe/exported.js';
 
 /**
  * [Contract Description Here]

--- a/snippets/ertp/guide/test-amount-math.js
+++ b/snippets/ertp/guide/test-amount-math.js
@@ -1,7 +1,7 @@
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
 
-import { setupZCFTest } from '../../tools/setupZcfTest';
+import { setupZCFTest } from '../../tools/setupZcfTest.js';
 
 test('ertp guide AmountMath allAssetKinds', async t => {
   // #region allAssetKinds

--- a/snippets/ertp/guide/test-amounts.js
+++ b/snippets/ertp/guide/test-amounts.js
@@ -1,4 +1,4 @@
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 

--- a/snippets/ertp/guide/test-issuers-and-mints.js
+++ b/snippets/ertp/guide/test-issuers-and-mints.js
@@ -1,4 +1,4 @@
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 // #region import
 import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';

--- a/snippets/ertp/guide/test-purses-and-payments.js
+++ b/snippets/ertp/guide/test-purses-and-payments.js
@@ -1,4 +1,4 @@
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 // #region import
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';

--- a/snippets/ertp/guide/test-readme.js
+++ b/snippets/ertp/guide/test-readme.js
@@ -1,11 +1,11 @@
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { E } from '@agoric/eventual-send';
 
 // We need to disable this lint until @agoric/vats is released
 // and adopted in package.json.
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { makeBoard } from '@agoric/vats/src/lib-board';
+import { makeBoard } from '@agoric/vats/src/lib-board.js';
 
 import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
 

--- a/snippets/test-distributed-programming.js
+++ b/snippets/test-distributed-programming.js
@@ -1,4 +1,4 @@
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { E } from '@agoric/eventual-send';
 

--- a/snippets/test-intro-zoe.js
+++ b/snippets/test-intro-zoe.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { E } from '@agoric/eventual-send';
 import { makeZoe } from '@agoric/zoe';
@@ -9,7 +9,7 @@ import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import bundleSource from '@agoric/bundle-source';
 // #endregion importBundleSource
 
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin';
+import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 
 test('intro to zoe', async t => {
   const zoe = makeZoe(makeFakeVatAdmin().admin);

--- a/snippets/tools/setupZcfTest.js
+++ b/snippets/tools/setupZcfTest.js
@@ -2,7 +2,7 @@ import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';
 
 import { makeZoe } from '@agoric/zoe';
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin';
+import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 
 const contractRoot = `${__dirname}/zcfTesterContract`;
 

--- a/snippets/tools/zcfTesterContract.js
+++ b/snippets/tools/zcfTesterContract.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import '@agoric/zoe/exported';
+import '@agoric/zoe/exported.js';
 
 /**
  * Tests ZCF

--- a/snippets/zoe/contracts/test-callSpread.js
+++ b/snippets/zoe/contracts/test-callSpread.js
@@ -1,15 +1,15 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
-import '@agoric/zoe/exported';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer';
+import '@agoric/zoe/exported.js';
+import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { AmountMath } from '@agoric/ertp';
 
-import { setup } from '@agoric/zoe/test/unitTests/setupBasicMints';
-import { assertPayoutDeposit } from '@agoric/zoe/test/zoeTestHelpers';
-import { makeFakePriceAuthority } from '@agoric/zoe/tools/fakePriceAuthority';
+import { setup } from '@agoric/zoe/test/unitTests/setupBasicMints.js';
+import { assertPayoutDeposit } from '@agoric/zoe/test/zoeTestHelpers.js';
+import { makeFakePriceAuthority } from '@agoric/zoe/tools/fakePriceAuthority.js';
 
 const makeTestPriceAuthority = (brands, priceList, timer) =>
   makeFakePriceAuthority({

--- a/snippets/zoe/contracts/test-loan.js
+++ b/snippets/zoe/contracts/test-loan.js
@@ -1,14 +1,14 @@
 // @ts-check
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin';
+import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoe } from '@agoric/zoe';
 import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
-import { makeRatio } from '@agoric/zoe/src/contractSupport';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer';
-import { makeFakePriceAuthority } from '@agoric/zoe/tools/fakePriceAuthority';
+import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
+import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { makeFakePriceAuthority } from '@agoric/zoe/tools/fakePriceAuthority.js';
 import { makeNotifierKit } from '@agoric/notifier';
 
 test('loan contract', async t => {

--- a/snippets/zoe/contracts/test-oracle.js
+++ b/snippets/zoe/contracts/test-oracle.js
@@ -1,7 +1,7 @@
 // @ts-check
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin';
+import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoe } from '@agoric/zoe';
 import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';


### PR DESCRIPTION
This change changes all imports to use extensions in preparation for using ESM proper in Node.js.
