### PR TITLE
fix: Move zoe to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/Agoric/documentation#readme",
   "dependencies": {
+    "@agoric/zoe": "*",
     "typescript": "^4.0.3"
   },
   "devDependencies": {
@@ -42,7 +43,6 @@
     "@agoric/ertp": "*",
     "@agoric/eventual-send": "*",
     "@agoric/install-ses": "*",
-    "@agoric/zoe": "*",
     "@agoric/notifier": "*",
     "@agoric/promise-kit": "*",
     "@agoric/assert": "*",


### PR DESCRIPTION
This ensures that bundleSource can find Zoe with the Endo Zip bundle format when that becomes the default.  For this case, I elected to keep the bundleSource example simple rather than thread the `dev` option.
