### PR TITLE
Update test-readme.js snippet getId

### DIFF
--- a/snippets/ertp/guide/test-readme.js
+++ b/snippets/ertp/guide/test-readme.js
@@ -60,7 +60,7 @@ test('ertp guide readme', async t => {
   await E(depositFacet).receive(myQuatloosPayment);
   // #endregion getValue
 
-  t.is(depositFacet, aliceQuatloosDepositFacet);
+  t.is(await depositFacet, aliceQuatloosDepositFacet);
   t.deepEqual(await aliceQuatloosPurse.getCurrentAmount(), quatloosFive);
 
   // #region ticketValues

--- a/snippets/ertp/guide/test-readme.js
+++ b/snippets/ertp/guide/test-readme.js
@@ -56,8 +56,8 @@ test('ertp guide readme', async t => {
   // #endregion getId
 
   // #region getValue
-  const depositFacet = await E(board).getValue(aliceQuatloosDepositFacetId);
-  await E(aliceQuatloosDepositFacet).receive(myQuatloosPayment);
+  const depositFacet = E(board).getValue(aliceQuatloosDepositFacetId);
+  await E(depositFacet).receive(myQuatloosPayment);
   // #endregion getValue
 
   t.is(depositFacet, aliceQuatloosDepositFacet);


### PR DESCRIPTION
The snippet `getId` does not make sense in the context of the ertp/guide/readme.md as it was.
Updated to be more sensible, plus it now hints at promise pipelining instead of having an unnescisarry `await` in it.
The sooner we get Agoric beginners to internalize promise pipelining the less `await`ing everything has to do.