### PR TITLE
optimize getting started path

### DIFF
--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -182,7 +182,7 @@ module.exports = {
           ]
         },
         {
-          title: 'Before Using Agoric',
+          title: 'Installing the Agoric SDK',
           path: '/getting-started/before-using-agoric.html',
           collapsible: false,
           children: [

--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -63,13 +63,6 @@ module.exports = {
     sidebar: { 
       '/guides/': [
         {
-          title: 'Documentation Guide',
-          path: '/getting-started/',
-          collapsible: false,
-          children: [
-          ]
-        },
-        {
           title: 'Agoric CLI',
           path: '/guides/agoric-cli/',
           collapsible: false,
@@ -165,18 +158,18 @@ module.exports = {
           children: [
           ]
        },
-      ],
+       {
+        title: 'Documentation Guide',
+        path: '/getting-started/',
+        collapsible: false,
+        children: [
+        ]
+      },
+    ],
       '/getting-started/': [
         {
           title: 'Agoric Beta',
           path: '/getting-started/beta.html',
-          collapsible: false,
-          children: [
-          ]
-        },
-        {
-          title: 'Documentation Guide',
-          path: '/getting-started/',
           collapsible: false,
           children: [
           ]
@@ -226,6 +219,13 @@ module.exports = {
         {
           title: 'Agoric CLI Guide',
           path: '/guides/agoric-cli/',
+          collapsible: false,
+          children: [
+          ]
+        },
+        {
+          title: 'Documentation Guide',
+          path: '/getting-started/',
           collapsible: false,
           children: [
           ]

--- a/main/.vuepress/themeConfig/nav.js
+++ b/main/.vuepress/themeConfig/nav.js
@@ -15,8 +15,8 @@ module.exports = [
         link: '/getting-started/',
       },
       {
-        text: 'Before Using Agoric',
-        ariaLabel: 'Before Using Agoric Menu',
+        text: 'Installing the Agoric SDK',
+        ariaLabel: 'Installing the Agoric SDK Menu',
         link: '/getting-started/before-using-agoric',
       },
       {

--- a/main/.vuepress/themeConfig/nav.js
+++ b/main/.vuepress/themeConfig/nav.js
@@ -10,11 +10,6 @@ module.exports = [
     ariaLabel: 'Getting Started Menu',
     items: [
       {
-        text: 'Documentation Guide',
-        ariaLabel: 'Documentation Guide Menu',
-        link: '/getting-started/',
-      },
-      {
         text: 'Installing the Agoric SDK',
         ariaLabel: 'Installing the Agoric SDK Menu',
         link: '/getting-started/before-using-agoric',
@@ -54,17 +49,17 @@ module.exports = [
         ariaLabel: 'Agoric Beta',
         link: '/getting-started/beta',
       },
+      {
+        text: 'Documentation Guide',
+        ariaLabel: 'Documentation Guide Menu',
+        link: '/getting-started/',
+      },
     ]
   },
   {
     text: 'Guides',
     ariaLabel: 'Guides',
     items: [
-      {
-        text: 'Documentation',
-        ariaLabel: 'Documentation Guide',
-        link: '/getting-started/',
-      },
       {
         text: 'Agoric CLI Guide and API',
         ariaLabel: 'Agoric CLI Guide and API',
@@ -109,6 +104,11 @@ module.exports = [
         text: 'Dynamic IBC (dIBC)',
         ariaLabel: 'dIBC Guide',
         link: 'https://github.com/Agoric/agoric-sdk/blob/master/packages/SwingSet/docs/networking.md'
+      },
+      {
+        text: 'Documentation',
+        ariaLabel: 'Documentation Guide',
+        link: '/getting-started/',
       },
     ],
   },

--- a/main/README.md
+++ b/main/README.md
@@ -7,7 +7,7 @@
 home: true # use default home page layout (hero image with text, features section)
 heroImage: https://agoric.com/wp-content/themes/agoric_2021_theme/assets/img/logo.svg
 ## Action button
-actionText: Try Beta → # text that goes in the button
+actionText: Try Beta Dapps → # text that goes in the button
 actionLink: /getting-started/beta.html # go-to link when clicking on button
 features:
   - title: New Protocol

--- a/main/getting-started/before-using-agoric.md
+++ b/main/getting-started/before-using-agoric.md
@@ -24,8 +24,12 @@ Then proceed to [starting a project](/getting-started/start-a-project.md).
 A more detailed explanation follows.
 
 ::: tip Watch: Prepare Your Agoric Environment (Nov 2020)
-While you will need to read below for updated details such as `node` version,
-this presentation is a good overview of the Agoric SDK setup process.
+This presentation is a good overview of the Agoric SDK setup process,
+though a few details are out of date:
+
+ - node version: 12.x is too old; use 14.15.0 or higher
+ - skip `git checkout hackathon-2020-11`; use the default `master` branch
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/w0By22jYhJA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 :::
 
@@ -33,7 +37,7 @@ this presentation is a good overview of the Agoric SDK setup process.
 
 The Agoric SDK is supported on
 <a href="https://en.wikipedia.org/wiki/Linux">Linux</a>,
-(<a href="https://www.apple.com/macos/">MacOS</a>, or
+<a href="https://www.apple.com/macos/">MacOS</a>, or
 <a href="https://docs.microsoft.com/en-us/windows/wsl/">Windows Subsystem for Linux (wsl).</a>
 
  - To open a terminal on Macs, see **Applications>Utilities>terminal** in the **Finder**.

--- a/main/getting-started/before-using-agoric.md
+++ b/main/getting-started/before-using-agoric.md
@@ -19,7 +19,15 @@ yarn link-cli ~/bin/agoric
 agoric --version
 ```
 
+Then proceed to [starting a project](/getting-started/start-a-project.md).
+
 A more detailed explanation follows.
+
+::: tip Watch: Prepare Your Agoric Environment (Nov 2020)
+While you will need to read below for updated details such as `node` version,
+this presentation is a good overview of the Agoric SDK setup process.
+<iframe width="560" height="315" src="https://www.youtube.com/embed/w0By22jYhJA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+:::
 
 ## Platform: Linux shell or equivalent
 

--- a/main/getting-started/before-using-agoric.md
+++ b/main/getting-started/before-using-agoric.md
@@ -61,8 +61,6 @@ _Be sure to get Yarn 1 and not a later version._
 
 ## Clone the Agoric SDK
 
-_@@TODO: cite an issue about being able to install with yarn/npm._
-
 ```shell
 git clone https://github.com/Agoric/agoric-sdk
 cd agoric-sdk

--- a/main/getting-started/before-using-agoric.md
+++ b/main/getting-started/before-using-agoric.md
@@ -48,7 +48,7 @@ The Agoric SDK is supported on
 Download from [nodejs.org](https://nodejs.org/) and follow the instructions for your platform.
 
 
-## Install Yarn 1 package manager
+## Install Yarn package manager
 
 Follow [Yarn Installation](https://classic.yarnpkg.com/en/docs/install)
 instructions; for example:
@@ -56,8 +56,6 @@ instructions; for example:
 ```shell
 npm install --global yarn
 ```
-
-_Be sure to get Yarn 1 and not a later version._
 
 ## Clone the Agoric SDK
 

--- a/main/getting-started/before-using-agoric.md
+++ b/main/getting-started/before-using-agoric.md
@@ -1,105 +1,101 @@
 
-# Before Using Agoric Software
+# Installing the Agoric SDK
 
-Before working with the Agoric CLI, Zoe, and other Agoric tools and
-software, you need to install the following.
+To write JavaScript smart contracts using the Agoric Zoe framework,
+first install the Agoric Software Development Kit (SDK).
 
-<table>
-  <thead>
-    <tr>
-      <th><b>Step</b></th>
-      <th><b>Action</b></th>
-      <th><b>Explanation</b></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>0</td>
-      <td>Use a Unix-like environment</td>
-      <td>You will need to type commands at a Bash-like shell command line prompt,
-        such as is found in <a href="https://en.wikipedia.org/wiki/Linux">Linux</a>, 
-        (<a href="https://www.apple.com/macos/">MacOS</a>, or
-        <a href="https://docs.microsoft.com/en-us/windows/wsl/">Windows Subsystem for Linux (wsl)</a>.</td>
-    <tr>
-      <td>1</td>
-      <td><a href="https://nodejs.org/">Install Node.js</a>, version 14.15.0 or higher</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>2</td>
-      <td><a href="https://classic.yarnpkg.com/en/docs/install">Install Yarn 1<br>(Yes, Yarn 1 and not a later version)</a></td>
-      <td>Yarn is a package manager for your code and lets developers
-    share code with others. Code is shared via a <i>package</i> that contains all shared code and a
-    <code>package.json</code> file describing the package. The link takes you to 
-    the Yarn install page, where you first select what operating system you want to
-    install on. Your selection changes the page's content to give install instructions for that 
-    OS and links to the needed downloads.</td>
-    </tr>
-    <tr>
-      <td>3</td>
-      <td>Open a shell. The rest of this table's Actions take place in
-    this shell.</td>
-      <td><ul><li>A terminal on Macs; see 
-        <b>Finder&gt;Applications&gt;Utilities&gt;terminal</b></li>
-        <li>To launch a bash shell at a specific folder on Windows 10:
-          <ol><li>Navigate to that folder in File Explorer.</li>
-            <li>Click the address bar while in that folder.</li>
-            <li>Type <code>bash</code> in the address bar and press <b>Enter</b>
-            </li></ol></li></ul>  
-      </td>
-    </tr>
-    <tr>
-      <td>4</td>
-      <td>If you already have a <code>~/agoric-sdk</code> directory, update it: 
-        <br><code>cd agoric-sdk</code>
-        <br><code>git checkout master</code>
-        <br><code>git pull</code>
-      </td>
-      <td>In the next step, if you don't have a copy of our <code>agoric-sdk</code> directory, you'll get one. This is in case you already have one and might need to update it.</td>
-    </tr>
-    <tr>
-      <td>5</td>
-      <td>If you don't have an <code>~/agoric-sdk</code> directory with Agoric's SDK content in it,
-        <code>git clone https://github.com/Agoric/agoric-sdk</code></td> 
-      <td>Get the latest Agoric SDK from the Agoric GitHub
-    repository. It goes into the 
-        <code>agoric-sdk</code> sub-directory of your home directory.
-        If the <code>agoric-sdk</code> sub-directory doesn't already exist, 
-        this operation creates it.
-      </td>
-    </tr>
-    <tr>
-      <td>6</td>
-      <td><code>cd ~/agoric-sdk</code></td>
-      <td>Change to the <code>agoric-sdk</code> subdirectory in your home
-    directory.</td>
-    </tr>
-    <tr>
-      <td>7</td>
-      <td><code>yarn install</code></td>
-      <td>Install NPM dependencies. <b>Note:</b> If you run into errors during install or build, make sure you have build-essential installed. <code>gcc --version</code></td>
-    </tr>
-    <tr>
-      <td>8</td>
-      <td><code>yarn build</code></td>
-      <td>Build sources that need compiling. <b>Note:</b>
-    <code>build</code> is not a standard <code>yarn</code> command,
-    but one installed with the Agoric SDK.</td>
-    </tr>
-    <tr>
-      <td>9</td>
-      <td>Install the Agoric CLI by: <code>yarn link-cli 
-        &lt;<i>agoric script location</i>&gt;</code></td>
-      <td>Select a location for the Agoric wrapper script. For example,
-        <code>yarn link-cli /usr/local/bin/agoric</code> (or if that fails
-        with permission problems, <code>sudo yarn link-cli /usr/local/bin/agoric</code>
-        If you have problems with <code>sudo</code> or just don't want to use it do;<br>
-        <code>yarn link-cli &lt;name of a file for which you have write permission&gt;</code>)<br><br>
-        This creates a shell script that, when run, accesses the SDK's Agoric CLI. We 
-        strongly recommend putting it at <code>/usr/local/bin/agoric</code>, but its specific 
-        location and name is up to you.
-      </td>
-    </tr>
-  </tbody>
-</table>
+## Quick Start
 
+If you're familar with JavaScript development tools such as `node`, `yarn`, and `git`:
+
+```shell
+node --version # 14.15.0 or higher
+npm install --global yarn
+git clone https://github.com/Agoric/agoric-sdk
+cd agoric-sdk
+yarn install
+yarn build
+yarn link-cli ~/bin/agoric
+agoric --version
+```
+
+A more detailed explanation follows.
+
+## Platform: Linux shell or equivalent
+
+The Agoric SDK is supported on
+<a href="https://en.wikipedia.org/wiki/Linux">Linux</a>,
+(<a href="https://www.apple.com/macos/">MacOS</a>, or
+<a href="https://docs.microsoft.com/en-us/windows/wsl/">Windows Subsystem for Linux (wsl).</a>
+
+ - To open a terminal on Macs, see **Applications>Utilities>terminal** in the **Finder**.
+ - To launch a bash shell at a specific folder on Windows 10:
+   1. Navigate to that folder in File Explorer.
+   2. Click the address bar while in that folder.
+   3. Type <code>bash</code> in the address bar and press <b>Enter</b>
+
+
+## Install Node.js 14.15.0 or higher
+
+Download from [nodejs.org](https://nodejs.org/) and follow the instructions for your platform.
+
+
+## Install Yarn 1 package manager
+
+Follow [Yarn Installation](https://classic.yarnpkg.com/en/docs/install)
+instructions; for example:
+
+```shell
+npm install --global yarn
+```
+
+_Be sure to get Yarn 1 and not a later version._
+
+## Clone the Agoric SDK
+
+_@@TODO: cite an issue about being able to install with yarn/npm._
+
+```shell
+git clone https://github.com/Agoric/agoric-sdk
+cd agoric-sdk
+```
+
+To update an existing clone:
+
+```shell
+git pull
+```
+
+## Install NPM dependencies
+
+```shell
+yarn install
+```
+
+**Note:** If you run into errors during install or build, make sure you have build-essential installed. `gcc --version`.
+
+## Build packages
+
+```shell
+yarn build
+```
+
+## Install `agoric` CLI
+
+Install the `agoric` command-line interface in a convenient place in your `$PATH` such as:
+
+```shell
+yarn link-cli ~/bin/agoric
+```
+
+or:
+
+```shell
+sudo yarn link-cli /usr/local/bin/agoric
+```
+
+To check that it's installed correctly:
+
+```shell
+agoric --version
+```

--- a/main/getting-started/start-a-project.md
+++ b/main/getting-started/start-a-project.md
@@ -6,115 +6,96 @@ It has not yet been formally tested or hardened.
 Do not use for production purposes.
 :::
 
-This document shows how to start a new Agoric project. Our demos are called <i>Dapps (decentralized
-applications)</i>, which typically have a browser-based user interface, 
-a public API server, and a contract running on the Agoric blockchain.
+Now that you have [installed the Agoric SDK](/getting-started/before-using-agoric.md),
+let's try out your first Agoric _Dapp_ (decentralized application).
 
-Before doing the steps given in this document, be sure you have done the necessary prerequisites
-specified in [Installing the Agoric SDK](/getting-started/before-using-agoric.md).
+In addition to a shell window for ordinary commands,
+open two additional shells for long-running processes and their logs,
+for a total of **three shell windows**:
 
-For complete documentation on the Agoric CLI commands (those starting with `agoric`) used here, 
-see the [Agoric CLI Guide](/guides/agoric-cli/commands.md).
+ 1. main command shell
+ 2. simulated blockchain and "solo" client
+ 3. web user interface
 
-For starting a local chain with multiple users, making it possible to develop and test multiuser Dapps, also see the 
- [Agoric CLI Guide](/guides/agoric-cli/starting-multiuser-dapps.md).
+## Initialize `demo` from Dapp Template
 
-Also, for what needs to be done after you modify a project's code, see 
-[Development
-Cycle](/getting-started/development-cycle.md)
+Use the [Aagoric CLI](/guides/agoric-cli/commands.md) to fetch from a Dapp template
+and put it in a `demo` directory _not located in your `agoric-sdk` clone_:
 
-<table>
-  <tbody>
-  <tr>
-  <th><b>Step</b></th>
-  <th><b>Action</b></th>
-  <th><b>Explanation</b></th>
-  </th>
-  <tr>
-    <td>1</td>
-    <td>Go to or open a shell and <code>cd &lt;directory-where-you-want-to-install-Dapp-code&gt;</code></td>
-    <td>When you initialize your project/Dapp in the next step, its initial code is copied into your current directory (permissions allowing).</td>
-  </tr>
-  <tr>
-    <td>2</td>
-    <td>Run <code>agoric init demo</code>
-    <td>Initializes a <i>Dapp</i> (<i>Decentralized application</i>)
-  project.
-  <br><br>
-    <code>init</code> creates a sub-directory with the specified name
-    (<code>demo</code> in this case) in your current directory and copies an existing project's files
-    into it. You can give the project any name you like. This
-    documentation assumes you used <code>demo</code>. 
-    <br><br>
-    There are optional arguments that let you specify which project
-    you want copied into the specified directory. By default, their values are set to
-    use the Fungible Faucet Dapp we wrote to provide a simple skeleton for a smart contract.
-    To specify a different project, use the optional arguments:<br>
-    <code>--dapp-template &lt;name&gt;</code> Use the project specified by this &lt;name&gt; as the template copied into your current directory.<br> 
-      <code>--dapp-base &lt;base-url&gt;</code> Look under this directory for the Dapp template. 
-  <br><br> <a href="/documentation/dapps/dapp-templates">Learn more about the available dapp templates.</a>
-  <br><br>If this 
-  doesn't work, use <code>echo $PATH</code> to check that your Agoric
-      CLI install directory is in your <code>$PATH</code> If not, add
-      it to <code>$PATH</code></td>
-  </tr>
-  <tr>
-    <td>3</td>
-    <td><code>cd demo</code></td>
-    <td>Move to the directory where your project (the demo) is
-  located.</td> 
-  </tr>
-  <tr>
-    <td>4</td>
-    <td><code>agoric install</code></td>
-    <td>Install JavaScript dependencies, which may take a while.<br>
-        Note: When on a Mac, you must first install 
-        <a href="https://apps.apple.com/us/app/xcode/id497799835">Xcode</a>. 
-    </td>
-  </tr>
-  <tr>
-    <td>5</td>
-    <td><code>agoric start --reset</code><br>
-  (leave this shell up with the process running)</td>
-    <td>Start the Agoric VM. <code>--reset</code> discards any prior Agoric
-  state. This creates the <i>vats</i> in which smart contract code runs.
-  The VM continues to run in this shell, making it unusable for
-  running commands.</td>
-  </tr>
-  <tr>
-    <td>6</td>
-    <td>Open another shell, go to your <code>demo</code> directory</td>
-    <td>For the remainder of this table, we call this the <i>deploy shell</i>.
-    <br><br>Use the same project directory name and location as you used in Step 2. In
-      this example, we used <code>demo</code> but you may have used a
-      different name in Step 2.</td>
-  </tr>
-  <tr>
-    <td>7</td>
-    <td>In the deploy shell, <code>agoric deploy ./contract/deploy.js ./api/deploy.js</code></td>
-    <td>Deploy the Dapp on an Agoric VM, install the Dapp's smart
-  contract and web API, as well as JavaScript code that implements the Agoric APIs for writing and implementing
-      contracts.</td>
-  </tr>
-  <tr>
-    <td>8</td>
-    <td>In the deploy shell, <code>(cd ui && yarn start)</code></td>
-    <td>This starts the demo project's UI development server.</td></td>
-  </tr>
-  <tr>
-    <td>9</td>
-    <td>Go to a browser and open <code>http://localhost:3000</code> to
-      see the Dapp. If you used the default values for <code>agoric init</code>
-      in Step 2, you'll see the Fungible Faucet demo Dapp, described in the next cell.</td>
-    <td>If you used the <code>agoric init</code> defaults in Step 2, 
-      you'll see our Fungible Faucet Dapp, which lets you get 1000 fungible tokens at a time for free. Receiving the tokens requires interaction
-      with your wallet where your assets are stored (which was started with the Agoric VM).</td>
-  </tr>
-  <tr>
-    <td>10</td>
-    <td>To open your Wallet UI in a browser tab, <code>agoric open</code></td>
-    <td>Running <code>agoric open --repl</code> in a shell opens a browser tab
-     that shows both the Wallet UI and REPL (<i>Read-Eval-Print Loop</i>).</td>
-  </tr>
-</tbody>
-</table>
+
+```shell
+# Shell 1
+# Don't use your agoric-sdk clone as the parent of the demo directory.
+# It doesn't have to be your home directory; any other directory will do.
+cd
+agoric init demo
+```
+
+The name `demo` is an arbitrary suggestion; in general,
+use `agoric init DIRNAME` with any name you like.
+
+The default template is the [Fungible Faucet Dapp](https://github.com/Agoric/dapp-fungible-faucet).
+Learn more about the [available dapp templates](/dapps/dapp-templates.md).
+
+### Install the Agoric SDK in the Dapp
+
+```shell
+cd demo
+agoric install
+```
+
+It may take a minute or so to install all the dependencies.
+
+::: tip Mac Dev Tools
+On a Mac, you must first install
+[Xcode](https://apps.apple.com/us/app/xcode/id497799835)
+:::
+## Start the Agoric Solo Client and Simulated Blockchain
+
+<pre style="background: aqua">
+# Shell 2
+cd demo # if not already there
+agoric start --reset
+</pre>
+
+Leave this process and its logs running in its own shell window.
+## Deploy the Contract and API
+
+Deploy the contract to the simulated blockchain
+and the API to the solo client.
+
+```shell
+# Shell 1
+agoric deploy ./contract/deploy.js ./api/deploy.js
+```
+
+We'll cover [deploying smart contracts](/getting-started/deploying.md)
+in detail later.
+
+## Start the Dapp User Interface
+
+The web user interface communicates with the API in
+the solo client as well as the wallet (below).
+
+<pre style="background: bisque">
+# Shell 3
+cd ui && yarn start
+</pre>
+
+Leave this running in its own shell window and
+visit [http://localhost:3000](http://localhost:3000)
+in a web browser.
+
+## Open the Agoric Wallet and REPL
+
+```shell
+# Shell 1
+agoric open --repl
+```
+
+Another browser window or tab should appear.
+
+## Use the Dapp to collect your (simulated) tokens
+
+Use the wallet to grant the Dapp's request to connect.
+Then use the Fungible Faucet Dapp to collect your tokens.

--- a/main/getting-started/start-a-project.md
+++ b/main/getting-started/start-a-project.md
@@ -17,6 +17,12 @@ for a total of **three shell windows**:
  2. simulated blockchain and "solo" client
  3. web user interface
 
+::: tip Watch: Prepare Your Agoric Environment (Nov 2020)
+While you will need to read up on details such as `node` version,
+this presentation is a good overview of the Agoric SDK setup process.
+<iframe width="560" height="315" src="https://www.youtube.com/embed/w0By22jYhJA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+:::
+
 ## Initialize `demo` from Dapp Template
 
 Use the [Aagoric CLI](/guides/agoric-cli/commands.md) to fetch from a Dapp template

--- a/main/getting-started/start-a-project.md
+++ b/main/getting-started/start-a-project.md
@@ -27,7 +27,7 @@ This presentation includes starting a project, but note an outdated detail:
 
 ## Initialize `demo` from Dapp Template
 
-Use the [Aagoric CLI](/guides/agoric-cli/commands.md) to fetch from a Dapp template
+Use the [Agoric CLI](/guides/agoric-cli/commands.md) to fetch from a Dapp template
 and put it in a `demo` directory _not located in your `agoric-sdk` clone_:
 
 

--- a/main/getting-started/start-a-project.md
+++ b/main/getting-started/start-a-project.md
@@ -18,8 +18,10 @@ for a total of **three shell windows**:
  3. web user interface
 
 ::: tip Watch: Prepare Your Agoric Environment (Nov 2020)
-While you will need to read up on details such as `node` version,
-this presentation is a good overview of the Agoric SDK setup process.
+This presentation includes starting a project, but note an outdated detail:
+
+ - In the REPL `x~.go()` tildot support has been postponed; use `E(x).go()`.
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/w0By22jYhJA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 :::
 

--- a/main/getting-started/start-a-project.md
+++ b/main/getting-started/start-a-project.md
@@ -11,7 +11,7 @@ applications)</i>, which typically have a browser-based user interface,
 a public API server, and a contract running on the Agoric blockchain.
 
 Before doing the steps given in this document, be sure you have done the necessary prerequisites
-specified in [Before Using Agoric](/getting-started/before-using-agoric.md).
+specified in [Installing the Agoric SDK](/getting-started/before-using-agoric.md).
 
 For complete documentation on the Agoric CLI commands (those starting with `agoric`) used here, 
 see the [Agoric CLI Guide](/guides/agoric-cli/commands.md).

--- a/main/guides/js-programming/README.md
+++ b/main/guides/js-programming/README.md
@@ -7,8 +7,6 @@ and understand before programming on the platform. Some are *concepts*, others
 are *Agoric library additions*, and some are at the *syntax level*. All changes at the 
 language level are in process to become official standards.
 
-Click on the top heading of each section for complete documentation of the topic.
-
 - **[Agoric JavaScript Overview](./agoric-js-overview.md)**
   - This is the key document to familiarize yourself with and refer back to. It briefly specifies 
     all the things in JavaScript you can't or shouldn't use when working on the Agoric platform and


### PR DESCRIPTION
 - demote Documentation Guide - "how to read the documentation" should be implicit by following conventions; for now, just get it out of the way of folks getting started
 - format installation instructions conventionally (fenced code rather than table)
   - add quick-start
   - integrate Nov 2020 video
 - format "starting a project" steps conventionally
   - integrate Nov 2020 video

trial deployment:
https://ag-docs-org.netlify.app/documentation/getting-started/before-using-agoric.html
https://ag-docs-org.netlify.app/documentation/getting-started/start-a-project.html#initialize-demo-from-dapp-template