### PR TITLE
Fix the link to SES Compartment docs

### DIFF
--- a/main/guides/js-programming/ses/ses-guide.md
+++ b/main/guides/js-programming/ses/ses-guide.md
@@ -202,9 +202,10 @@ makes those global objects available.
   thorough. See the individual [`lockdown()`](#lockdown) and [`harden()`](#harden) sections
   below. 
 
-- `[Compartment](https://github.com/endojs/endo/tree/SES-v0.8.0/packages/ses#compartment)` is 
-  a global. Code runs inside a `Compartment` and can create sub-compartments to host other 
-  code (with different globals or transforms). Note that these child compartments get `harden()` and `Compartment`.
+- `Compartment` is a global. Code runs inside a
+  [*Compartment*](https://github.com/endojs/endo/tree/SES-v0.8.0/packages/ses#compartment)
+  and can create sub-compartments to host other  code (with different globals or transforms).
+  Note that these child compartments get `harden()` and `Compartment`.
 
 ## Realms
 


### PR DESCRIPTION
The backticks on Compartment were preventing the link from rendering correctly:
<img width="724" alt="Screen Shot 2021-12-12 at 7 03 34 AM" src="https://user-images.githubusercontent.com/21505/145717715-bf61924d-119d-4a6b-9090-08ef59e19042.png">

While moving the backticks since the link text would work I moved the link to the use of the term in the sentence.