### PR TITLE
docs: Generally straighten out SES and Endo references

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -245,6 +245,7 @@ dibc
 disjuncts
 DOM
 EcmaScript
+Endo
 enduser
 endregion
 ertp

--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -118,7 +118,7 @@ module.exports = {
           ]
         },
         {
-          title: 'SES',
+          title: 'Endo and Hardened JavaScript',
           path: '/guides/js-programming/ses/',
           collapsible: false,
           children: [

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -467,7 +467,7 @@ the [UserSeat documentation](/zoe/api/zoe.md#userseat-object).
 
 ## SES
 
-We have renamed SES to [Hardened JavaScript](#hardened-javascript).
+We have renamed SES to [Hardened JavaScript](#hardened-javascript-ses).
 
 ## Simoleons
 An imaginary currency Agoric documentation uses in examples.

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -467,7 +467,7 @@ the [UserSeat documentation](/zoe/api/zoe.md#userseat-object).
 
 ## SES
 
-We have renamed SES to [Hardened JavaScript](#ses).
+We have renamed SES to [Hardened JavaScript](#hardened-javascript).
 
 ## Simoleons
 An imaginary currency Agoric documentation uses in examples.

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -18,7 +18,7 @@ The AllegedName must be a string.
 
 ## Allocation
 
-Allocations represent the [amounts](#amounts) to be paid out to each [seat](#seat) on exit from a contract instance. Possible 
+Allocations represent the [amounts](#amounts) to be paid out to each [seat](#seat) on exit from a contract instance. Possible
 exit causes are exercising an exit condition, the contract's explicit choice, or a crash or freeze. There are several methods
 for getting the amounts currently allocated.
 
@@ -26,16 +26,16 @@ In more detail, Zoe's guarantee is each [seat](#seat) will either get what it as
 The contract can reallocate fairly arbitrarily to achieve that. As contract code is visible to its clients, users can see
 what the contract intends to do.
 
-Zoe enforces those terms by keeping track of a current allocation for each seat. The initial allocation is the deposit. 
-The contract can modify a seat's allocation as long as it never violates offer safety or rights conservation. i.e. it can't 
-assign assets that weren't already in some allocation and it can't assign them to more than one seat. Also, goods can't 
+Zoe enforces those terms by keeping track of a current allocation for each seat. The initial allocation is the deposit.
+The contract can modify a seat's allocation as long as it never violates offer safety or rights conservation. i.e. it can't
+assign assets that weren't already in some allocation and it can't assign them to more than one seat. Also, goods can't
 disappear from the total allocation.
 
 ## AmountMath
 The AmountMath library executes the logic of how [amounts](#amounts) are changed when digital assets are merged, separated,
-or otherwise manipulated. For example, a deposit of 2 bucks into a purse that already has 3 bucks 
+or otherwise manipulated. For example, a deposit of 2 bucks into a purse that already has 3 bucks
 gives a new balance of 5 bucks. But, a deposit of a non-fungible theater ticket into a purse that already holds
-five tickets isn't done by numeric addition. Instead, you have to combine two arrays, containing either 
+five tickets isn't done by numeric addition. Instead, you have to combine two arrays, containing either
 strings or objects/records.
 
 `AmountMath` has a single set of polymorphic
@@ -45,9 +45,9 @@ methods of two different asset kinds to deal with [fungible](#fungible) assets (
 - `AssetKind.SET`: Used with non-fungible assets. Amount values are
   arrays of strings, numbers, objects, or other comparable values.
   Values should never include promises (they aren't comparable), or
-  payments, purses, and anything else that can't be shared freely. 
+  payments, purses, and anything else that can't be shared freely.
 
-For more information, see the [ERTP Guide's AmountMath section](/ertp/guide/amount-math.md) 
+For more information, see the [ERTP Guide's AmountMath section](/ertp/guide/amount-math.md)
 and the [ERTP API's AmountMath section](/ertp/api/amount-math.md).
 
 ## Amounts
@@ -60,13 +60,13 @@ An amount is comprised of a [brand](#brand) with an [value](#value). For example
 is an amount with a value of "4" and a brand of the imaginary currency "quatloos".
 
 **Important**: Amounts are *descriptions* of digital assets, not the actual assets. They have no
-intrinsic value. For example, to make you an offer to buy a magic sword in a game, 
+intrinsic value. For example, to make you an offer to buy a magic sword in a game,
 a party sends you an amount describing the asset of 5 Quatloos they're willing to trade for your
 sword. They don't send you the actual 5 Quatloos; that only happens when there is agreement on the
 trade terms and they send you a payment, not an amount, of 5 Quatloos, the actual asset. Creating
 a new `amount` does **not** create new assets.
 
-For more information, see the [ERTP Guide's Amounts section](/ertp/guide/amounts.md) 
+For more information, see the [ERTP Guide's Amounts section](/ertp/guide/amounts.md)
 and the [ERTP API's AmountMath section](/ertp/api/amount-math.md).
 
 ## AssetHolder
@@ -84,14 +84,14 @@ or `BigInt(123)`.
 
 ## Board (Agoric Board)
 
-The Board is a shared, on-chain location where users can post a value and make it 
-accessible to others. When a user posts a value, they receive a unique ID for the value. 
-Others can get the value just by knowing the ID. You can make an ID known by any 
+The Board is a shared, on-chain location where users can post a value and make it
+accessible to others. When a user posts a value, they receive a unique ID for the value.
+Others can get the value just by knowing the ID. You can make an ID known by any
 communication method; private email, a DM or other private message, a phone call/voicemail,
 an email blast to a mailing list or many individuals, listing it on a website, etc.
 
 ## Brand
-Identifies the kind of [issuer](#issuer), such as "quatloos", "moola", etc. Brands are one of the two elements that 
+Identifies the kind of [issuer](#issuer), such as "quatloos", "moola", etc. Brands are one of the two elements that
 make up an [amount](#amounts).
 For more information, see the [ERTP Guide's Brand section](/ertp/guide/amounts.md)
 and the [ERTP API's Brand section](/ertp/api/brand.md).
@@ -134,59 +134,78 @@ to Presences and local state, then either they're the same all the way
 down, or they represent different objects.
 
 ## Contract and Contract Instance
-In Agoric documentation, *contract* usually refers to a contract's source code that 
-defines how the contract works. A contract's source code is *installed* on Zoe. A 
-contract is *instantiated* to create *contract instances*, which are the active 
-execution of a contract's code running on Zoe.  
+In Agoric documentation, *contract* usually refers to a contract's source code that
+defines how the contract works. A contract's source code is *installed* on Zoe. A
+contract is *instantiated* to create *contract instances*, which are the active
+execution of a contract's code running on Zoe.
 
-For example, a realtor has a standard house selling agreement. The contract is the 
-code defining how that agreement works. When the realtor has a new house to sell, 
-they instantiate a new instance of their standard contract for that specific property. 
+For example, a realtor has a standard house selling agreement. The contract is the
+code defining how that agreement works. When the realtor has a new house to sell,
+they instantiate a new instance of their standard contract for that specific property.
 If they have ten houses for sale, they have ten different contract instances.
 
 ## CreatorInvitation
 
 An [invitation](#invitation) optionally returned by `startInstance()` that the contract instance
-creator can use. It is usually used in contracts where the creator immediately 
-sells something (auctions, swaps, etc.). 
+creator can use. It is usually used in contracts where the creator immediately
+sells something (auctions, swaps, etc.).
 
 ## Deposit Facet
 
-A [facet](#facet) of a [purse](#purse). Anyone with a reference to its deposit facet object can add 
+A [facet](#facet) of a [purse](#purse). Anyone with a reference to its deposit facet object can add
 appropriately branded assets to the purse, but cannot withdraw assets from the purse or find out its balance.
 
 ## dIBC
 
-Dynamic version of the [Inter-Blockchain Communication](#ibc) protocol. 
+Dynamic version of the [Inter-Blockchain Communication](#ibc) protocol.
 See [here](https://github.com/Agoric/agoric-sdk/blob/master/packages/SwingSet/docs/networking.md) for more details.
 
 ## E()
 
 (Also referred to as *eventual send*) `E()` is a local "bridge" function that invokes methods on remote objects, for example
-in another vat, machine, or blockchain. It takes a local representative (a proxy) for a remote object as an argument and 
-sends messages to it using normal message-sending syntax. The local proxy forwards all messages to the remote object to deal with. 
-All `E()` calls return a promise for the eventual returned value. For more detail, see 
+in another vat, machine, or blockchain. It takes a local representative (a proxy) for a remote object as an argument and
+sends messages to it using normal message-sending syntax. The local proxy forwards all messages to the remote object to deal with.
+All `E()` calls return a promise for the eventual returned value. For more detail, see
 the [`E()` section in the Distributed JavaScript page](/guides/js-programming/eventual-send.md).
+
+## Endo
+
+What Node.js does for JavaScript, Endo does for [Hardened
+JavaScript](#hardened-javascript).
+Endo guest programs run in Hardened JavaScript and communicate with their host
+and other guests through hardened interfaces and object-to-object
+message-passing.
+For example, an Agoric smart contract is an Endo program that runs in an Endo
+host.
+Endo is responsible for linking and isolating Node.js packages and modules in
+Hardened JavaScript compartments and providing limited access to host
+resources.
+The scope of vision for the Endo project includes the creation of other Endo
+host programs like an Endo browser, an Endo browser extension, and `endo`
+command line tools, as well allowing programs to limit the powers they delegate
+to dependencies, to limit exposure to supply-chain attacks.
+For more information, see the [Endo and Hardened JavaScript Programming
+Guide](/guides/js-programming/ses/ses-guide.md)
 
 ## ERTP
 
-*Electronic Rights Transfer Protocol* is a uniform way of transferring tokens and other digital assets, 
+*Electronic Rights Transfer Protocol* is a uniform way of transferring tokens and other digital assets,
 both [fungible](#fungible) and [non-fungible](#non-fungible), in JavaScript. All kinds of digital assets
 can easily be created and they can be all be transferred in exactly the same ways, with exactly the same security properties.
 
-It uses [object capabilities](#object-capabilities) to enforce access control. Instead of having 
-to prove ownership of a corresponding private key, if your program has a 
-reference to an object, it can call methods on that object. If it doesn't 
+It uses [object capabilities](#object-capabilities) to enforce access control. Instead of having
+to prove ownership of a corresponding private key, if your program has a
+reference to an object, it can call methods on that object. If it doesn't
 have a reference, it can't. For more on object capabilities, see [this post](http://habitatchronicles.com/2017/05/what-are-capabilities/).
 
-Key ERTP concepts include [Issuers](#issuer), [Mints](#mint), 
-[Purses](#purse), [Payments](#payment), [Brands](#brand), and [Amounts](#amounts). Also 
+Key ERTP concepts include [Issuers](#issuer), [Mints](#mint),
+[Purses](#purse), [Payments](#payment), [Brands](#brand), and [Amounts](#amounts). Also
 see the [ERTP Introduction](/getting-started/ertp-introduction.md),
 [ERTP Guide](/ertp/guide/), and [ERTP API](/ertp/api/).
 
 ## Escrow
 
-To give assets for a possible transaction to an impartial third party, who keeps them until specified conditions are satisfied. 
+To give assets for a possible transaction to an impartial third party, who keeps them until specified conditions are satisfied.
 For example, Alice wants to sell Bob a ticket for $100. Alice escrows the ticket, and Bob escrows the $100, with Zoe. Zoe
 does not give Alice the $100 or Bob the ticket until it has both items. Since neither Alice nor Bob ever holds both items at
 once, they don't have to trust each other to do the transaction. Zoe automatically escrows payments for transaction offers.
@@ -204,7 +223,7 @@ Part of an [offer](#offer) specifying how the offer can be cancelled/exited. The
 
 ## Facet
 
-A *facet* is an object that exposes an API or particular view of some larger entity, which may be an object itself. 
+A *facet* is an object that exposes an API or particular view of some larger entity, which may be an object itself.
 You can make any number of facets of an entity. In JavaScript, you often make a facet by selecting methods from the entity,
 either directly or by destructuring:
 ```js
@@ -213,36 +232,45 @@ const facet = {
 }
 ```
 Two Agoric uses are:
-- *Deposit Facet*: A facet of a [purse](#purse). Anyone with a reference to its deposit facet object can add 
+- *Deposit Facet*: A facet of a [purse](#purse). Anyone with a reference to its deposit facet object can add
   appropriately branded assets to the purse, but cannot withdraw assets from the purse or find out its balance.
 - *Public Facet*: A set of methods and properties for an object that a developer chooses to be publicly visible and usable.
 
 ## Fungible
-A fungible asset is one where all exemplars of the asset are interchangeable. For example, if you 
+A fungible asset is one where all exemplars of the asset are interchangeable. For example, if you
 have 100 one dollar bills and need to pay someone five dollars, it does not matter which
 five one dollar bills you use. Also see [non-fungible](#non-fungible).
 
 ## Handle
-A handle is a unique identifier implemented as a JavaScript object. Only its identity 
-is meaningful, so handles do not have properties. Unlike number or string identifiers, 
-handles are unforgeable. This means the only way to know a handle identity is being given 
-an object reference, and no identity can be guessed and no fake identity will succeed. 
+A handle is a unique identifier implemented as a JavaScript object. Only its identity
+is meaningful, so handles do not have properties. Unlike number or string identifiers,
+handles are unforgeable. This means the only way to know a handle identity is being given
+an object reference, and no identity can be guessed and no fake identity will succeed.
 
 ## Harden
 A hardened object’s properties cannot be changed, so the only way to interact with a hardened object is through its methods.
 `harden()` is similar to `Object.freeze()` but more powerful. For more about `harden()`, see
 its [section in the JavaScript Distributed Programming Guide](/guides/js-programming/ses/ses-guide.md)
 
+## Hardened JavaScript (SES)
+
+Hardened JavaScript is a standards-track extension to the JavaScript standard.
+Hardening JavaScript turns the sandbox into firm ground, where you can code run
+you don't completely trust, without being vulnerable to their bugs or bad
+intentions.
+See the [Endo and Hardened JavaScript Programming
+Guide](/guides/js-programming/ses/ses-guide.md) for more details.
+
 ## IBC
 The Inter-Blockchain Communication protocol, used by blockchains to communicate with each other. A short article about IBC
 is available [here](https://www.computerweekly.com/blog/Open-Source-Insider/What-developers-need-to-know-about-inter-blockchain-communication).
 
 ## Invitation
-To participate in a contract instance, one must hold an invitation to do so. Contracts often 
-return a creator invitation on their instantiation, in case the contract instantiator wants 
-to immediately participate. Otherwise, the contract instance must create any additional invitations. 
-These, or any invitation held by a party, are distributed by sending it to someone's wallet. When you receive 
-an invitation, your wallet will validate it via the [InvitationIssuer](#invitationissuer). Note that 
+To participate in a contract instance, one must hold an invitation to do so. Contracts often
+return a creator invitation on their instantiation, in case the contract instantiator wants
+to immediately participate. Otherwise, the contract instance must create any additional invitations.
+These, or any invitation held by a party, are distributed by sending it to someone's wallet. When you receive
+an invitation, your wallet will validate it via the [InvitationIssuer](#invitationissuer). Note that
 the invitation is a [`Payment`](#payment), and so is associated with a specific [`Issuer`](#issuer).
 
 To participate in a contract instance by making an [offer](#offer), an invitation to that instance must accompany the offer.
@@ -255,11 +283,11 @@ An `invitation`'s amount includes the following properties:
 
 ## InvitationIssuer
 
-Since [invitations](#invitation) are [payments](#payment), invitations 
+Since [invitations](#invitation) are [payments](#payment), invitations
 must have a dedicated [issuer](#issuer), which is the InvitationIssuer.
 
-Zoe has a single `InvitationIssuer` for its entire lifetime. By having a reference to Zoe, 
-a user can get the `InvitationIssuer`. This lets them claim any invitation they 
+Zoe has a single `InvitationIssuer` for its entire lifetime. By having a reference to Zoe,
+a user can get the `InvitationIssuer`. This lets them claim any invitation they
 receive from someone else by calling `E(invitationIssuer).claim()` with the untrusted
 invitation as the argument. During the claiming process, the invitationIssuer validates
 the invitation. A successful claim also means that invitation is exclusively yours.
@@ -270,30 +298,30 @@ what the [wallet](#wallet) does.
 ## Issuer
 Issuers are a one-to-one relationship with both a [mint](#mint) and a [brand](#brand), so each issuer works
 with one and only one asset type, such as only working with quatloos or only working
-with moola. This association cannot change to another type. 
+with moola. This association cannot change to another type.
 
 Issuers can create empty [purses](#purse) for
 their asset type, but cannot mint new [amounts](#amounts). Issuers can also transform
 payments of their asset type (splitting, combining, burning, and exclusively claiming
 payments). An issuer from a trusted source can determine if an untrusted payment of
-its asset type is valid. 
+its asset type is valid.
 
 For more information, see the [ERTP Guide's Issuer section](/ertp/guide/issuers-and-mints.md)
 and the [ERTP API's Issuer section](/ertp/api/issuer.md).
 
 ## Keywords
 
-Keywords are unique identifiers per contract. They tie together the [proposal](#proposal), [payments](#payment) 
-to be [escrowed](#escrow), and [payouts](#payout) to the user by serving as keys for key-value pairs in various 
+Keywords are unique identifiers per contract. They tie together the [proposal](#proposal), [payments](#payment)
+to be [escrowed](#escrow), and [payouts](#payout) to the user by serving as keys for key-value pairs in various
 records with values of [amounts](#amounts), [issuers](#issuer), etc.
 
 ## Mint
 
 [ERTP](#ertp) has a *mint* object, which creates digital assets. [ZCF](#zcf) provides a different interface to an ERTP mint, called a
-*ZCFMint*. Assets and AssetHolders created using ZcfMints can be used in all the same ways as assets created by other ERTP Mints. 
+*ZCFMint*. Assets and AssetHolders created using ZcfMints can be used in all the same ways as assets created by other ERTP Mints.
 They interact with Purses, Payments, Brands, and Issuers in the same ways.
 
-- ERTP mints create digital assets and are the only ERTP objects with the authority to do so. 
+- ERTP mints create digital assets and are the only ERTP objects with the authority to do so.
   Access to an ERTP mint gives you the power to create more digital assets of its type at will. Mints
   can only create one type of asset and cannot change to create a different type.
 
@@ -304,12 +332,12 @@ They interact with Purses, Payments, Brands, and Issuers in the same ways.
   an internal ERTP mint, they have the same one-to-one relationships
   with an issuer and its associated brand. A ZCFMint can mint assets and assign them to a seat without having to escrow
   payments, and burn assets that used to be associated with a seat without having to payout assets.
-  
+
 ZCFMints and ERTP mints do **not** have the same methods. Do not try to use ERTP methods on a ZCFMint or vice versa.
 However, issuers and brands associated with either an ERTP mint or a ZCFMint are the same concepts and have the same methods.
 
-For more information on ERTP mints, see the [ERTP Guide's Mint section](/ertp/guide/issuers-and-mints.md) 
-and the [ERTP API's Mint section](/ertp/api/mint.md). For more information about ZCFMints, 
+For more information on ERTP mints, see the [ERTP Guide's Mint section](/ertp/guide/issuers-and-mints.md)
+and the [ERTP API's Mint section](/ertp/api/mint.md). For more information about ZCFMints,
 see the [zcfMakeZCFMint() API entry](/zoe/api/zoe-contract-facet.md) in the Zoe Contract Facet API.
 
 ## Moola
@@ -317,8 +345,8 @@ An imaginary currency Agoric documentation uses in examples.
 
 ## Non-fungible
 A non-fungible asset is one where each incidence of the asset has unique individual properties and
-is not interchangeable with another incidence. For example, if your asset is show tickets, it matters to the buyer 
-what the date and time of the show is, which row the seat is in, and where in the row the 
+is not interchangeable with another incidence. For example, if your asset is show tickets, it matters to the buyer
+what the date and time of the show is, which row the seat is in, and where in the row the
 seat is (and likely other factors as well). You can't just give them any ticket in your supply,
 as they are not interchangeable (and may have different prices). See also [fungible](#fungible).
 
@@ -329,45 +357,45 @@ For more information, see [Notifiers and Subscriptions](/guides/js-programming/n
 
 ## Object Capabilities
 
-Objects have state, behavior, and references. Let's say Object A has references to Objects B 
-and C, while B and C do not have references to each other. Thus, A can communicate with B and C, 
+Objects have state, behavior, and references. Let's say Object A has references to Objects B
+and C, while B and C do not have references to each other. Thus, A can communicate with B and C,
 and B and C cannot communicate with each other. There is an effective zero-cost firewall between B and C.
 
-An *object capability system* constrains how references are obtained. You can't get one just by 
-knowing the name of a global variable or a public class. You can only get a reference via: 
+An *object capability system* constrains how references are obtained. You can't get one just by
+knowing the name of a global variable or a public class. You can only get a reference via:
 - Creation: Functions that create objects get a reference to them.
-- Construction: Constructors can endow their constructed objects with references, including inherited references. 
-- Introduction: 
-  - A has references to B and C. 
+- Construction: Constructors can endow their constructed objects with references, including inherited references.
+- Introduction:
+  - A has references to B and C.
   - B and C do *not* have references to each other
-  - A sends B a reference to C. 
-    - B now has a reference to C and can communicate with C. 
+  - A sends B a reference to C.
+    - B now has a reference to C and can communicate with C.
 
-If references can only be obtained by creation, construction, or introduction, you may have a safe 
+If references can only be obtained by creation, construction, or introduction, you may have a safe
 system. If they can be obtained in any other way, your system is unsafe.
 
 For more information, see [Douglas Crockford on Object Capabilities](https://frontendmasters.com/courses/good-parts-javascript-web/object-capabilities/).
 
 ## Offer
 
-Users interact with contract instances by making offers. In Zoe, an offer consists of a [proposal](#proposal) (what 
+Users interact with contract instances by making offers. In Zoe, an offer consists of a [proposal](#proposal) (what
 the offer making party is willing to give up and what they want in exchange) and [payments](#payment) corresponding
-to the amount in the proposal they're willing to give. The payments are automatically [escrowed](#escrow) by Zoe, and reallocated 
+to the amount in the proposal they're willing to give. The payments are automatically [escrowed](#escrow) by Zoe, and reallocated
 according to the contract code. An offer gets a [payout](#payout) of some combination of what the party originally contributed
-and what others have contributed. The specific payout is determined by the contract code. 
+and what others have contributed. The specific payout is determined by the contract code.
 
 See [`E(Zoe).offer(invitation, proposal, paymentKeywordRecord, offerArgs)`](/zoe/api/zoe.md#e-zoe-offer-invitation-proposal-paymentkeywordrecord-offerargs).
 
 ## Offer Safety
 
-Zoe guarantees offer safety. When a user makes an [offer](#offer) and its payments are [escrowed](#escrow) with Zoe, Zoe guarantees that 
+Zoe guarantees offer safety. When a user makes an [offer](#offer) and its payments are [escrowed](#escrow) with Zoe, Zoe guarantees that
 the user either gets what they said they wanted, or gets back (gets a refund) what they originally offered and
 escrowed. One reason this is possible is if a [proposal](#proposal) doesn't match what the contract expects to do, it
 can immediately cause the [seat](#seat) to exit, getting back the amount it offered.
 
 ## Payment
 
-Payments hold assets created by [Mints](#mint). Specifically assets intended for transfer 
+Payments hold assets created by [Mints](#mint). Specifically assets intended for transfer
 from one party to another. All assets of a payment are of the same [brand](#brand).
 
 For more information, see the [ERTP Guide's Payments section](/ertp/guide/purses-and-payments.md#purses-and-payments)
@@ -375,22 +403,22 @@ and the [ERTP API's Payments section](/ertp/api/payment.md).
 
 ## Payout
 The assets paid out to a user when an [seat](#seat) exits, either successfully or not. The payout is always
-what the seat's current [allocation](#allocation) is. 
+what the seat's current [allocation](#allocation) is.
 
 If there was a previous reallocation, the payout is different than what the user escrowed. If there is no reallocation
 before the seat exits, the payout is the same as what they escrowed.
 
 ## Petname
 
-Petnames are your personal names for objects. No one else can see or modify a petname without your permission. 
-Think of them as similar to a phone's contacts list. The actual phone number is what a phone uses to call 
-someone, but to more easily tell who a number is associated with, it's assigned a petname, such 
+Petnames are your personal names for objects. No one else can see or modify a petname without your permission.
+Think of them as similar to a phone's contacts list. The actual phone number is what a phone uses to call
+someone, but to more easily tell who a number is associated with, it's assigned a petname, such
 as Mom, Grandpa, Kate S., etc. In the Agoric platform, petnames are used in [wallets](#wallet).
 
-## Presence 
-A local version of a remote object that serves as the remote object's proxy. 
-If `obj` is a presence of a remote object, you can send messages to the remote object by using `E()` on `obj`. 
-For more information, see the [JavaScript Distributed Programming Guide](/guides/js-programming/). 
+## Presence
+A local version of a remote object that serves as the remote object's proxy.
+If `obj` is a presence of a remote object, you can send messages to the remote object by using `E()` on `obj`.
+For more information, see the [JavaScript Distributed Programming Guide](/guides/js-programming/).
 
 ## Proposal
 
@@ -405,54 +433,50 @@ const myProposal = harden({
 })
 ```
 `give` and `want` use [keywords](#keywords) defined by the contract. Each specifies via an [amount](#amounts), a description of what
-asset they are willing to give/want to get, and how much of it. 
+asset they are willing to give/want to get, and how much of it.
 
-## Purse 
+## Purse
 Purses hold [amounts](#amounts) of a certain [mint](#mint) issued assets. Specifically amounts that are _stationary_.
-Purses can transfer part of their held balance to a [payment](#payment), which is usually used to transfer value. 
+Purses can transfer part of their held balance to a [payment](#payment), which is usually used to transfer value.
 A purse's contents are all of the same [brand](#brand).
 
 For more information, see the [ERTP Guide's Purses section](/ertp/guide/purses-and-payments.md#purses-and-payments) and the
 [ERTP API's Purses section](/ertp/api/purse.md).
 
 ## Quatloos
-An imaginary currency Agoric documentation uses in examples. For its origins, see the Wikipedia entry for the Star Trek 
+An imaginary currency Agoric documentation uses in examples. For its origins, see the Wikipedia entry for the Star Trek
 episode [The Gamesters of Triskelion](https://en.wikipedia.org/wiki/The_Gamesters_of_Triskelion).
 
 ## Reallocation
 
 A transfer of [amounts](#amounts) between [seats](#seat) within Zoe; i.e. a change in their [allocations](#allocation). When a seat exits, it gets its
-current allocation as a [payout](#payout). 
+current allocation as a [payout](#payout).
 
 ## Seat
 
 Zoe uses a seat to represent an [offer](#offer) in progress, and has two seat [facets](#facet) representing
 two views of the same seat; a `ZCFSeat` and a `UserSeat`. The `UserSeat` is returned to the user who made an
-offer, and can check payouts' status or retrieve their results. The `ZCFSeat` is the argument passed to 
+offer, and can check payouts' status or retrieve their results. The `ZCFSeat` is the argument passed to
 the `offerHandler` in the contract code. It is used within contracts and with `zcf.` methods.
 
-The two seat facets have slightly different methods but represent the same seat and offer in progress. 
+The two seat facets have slightly different methods but represent the same seat and offer in progress.
 The term comes from the expression "having a seat at the table" with regards to participating in a negotiation.
 
-For more details, see the [ZCFSeat documentation](/zoe/api/zoe-contract-facet.md#zcfseat-object) and 
+For more details, see the [ZCFSeat documentation](/zoe/api/zoe-contract-facet.md#zcfseat-object) and
 the [UserSeat documentation](/zoe/api/zoe.md#userseat-object).
 
-## SES (Secure ECMAScript)
+## SES
 
-SES is a standards-track extension to the JavaScript standard. It
-provides a secure platform for executing programs. With SES, you can run code you don't
-completely trust, without being vulnerable to bugs or bad intentions. 
-See the [SES section of the Distributed JavaScript Programming Guide](/guides/js-programming/ses/ses-guide.md) for 
-more details. 
+We have renamed SES to [Hardened JavaScript](#ses).
 
 ## Simoleons
 An imaginary currency Agoric documentation uses in examples.
 
 ## Terms
 Contract instances have associated terms, gotten via `E(zoe).getTerms(instance)`,
-which include the instance's associated [issuers](#issuer), [brands](#brand), and any custom terms. For 
+which include the instance's associated [issuers](#issuer), [brands](#brand), and any custom terms. For
 example, you might have a general auction contract. When someone instantiates it,
-they provide terms applicable only to that instance. For some instances of 
+they provide terms applicable only to that instance. For some instances of
 the auction, they want the minimum bid set at $1000. At other instances, they'd like
 it set at $10. They can specify the instance's minimum bid amount in its terms.
 
@@ -461,31 +485,31 @@ it set at $10. They can specify the instance's minimum bid amount in its terms.
 Values are the part of an [amount](#amounts) that describe the value of something
 that can be owned or shared: How much, how many, or a description of a unique asset, such as
 Pixel(3,2), $3, or 'Seat J12 for the show September 27th at 9:00pm'.
-[Fungible](#fungible) values are usually 
+[Fungible](#fungible) values are usually
 represented by natural numbers. Other values may be represented as strings naming a particular
-rights, or an array of arbitrary objects representing the rights at issue. The latter two examples 
+rights, or an array of arbitrary objects representing the rights at issue. The latter two examples
 are usually [non-fungible](#non-fungible) assets. Values must be [Comparable](#comparable).
 
 For more information, see the [ERTP Guide's Value section](/ertp/guide/amounts.md#values).
 
-## Vat 
-A vat is a unit of isolation. 
+## Vat
+A vat is a unit of isolation.
 Objects and functions in a JavaScript vat can communicate synchronously with one another. Vats and their contents can
-communicate with other vats and their objects and functions, but can only communicate asynchronously. 
+communicate with other vats and their objects and functions, but can only communicate asynchronously.
 
 For more information, see the [Vat section in the Distributed JS Programming Guide](/guides/js-programming/#vats-the-unit-of-synchrony)
 
 ## Wallet
 
 The overall place a party keeps their assets of all brands. For example, your wallet might contain 5 Quatloos
-[purses](#purse), 8 Moola purses, and 2 Simoleons purses. A wallet can distinguish between [Issuers](#issuer). 
-Dapps can propose [offers](#offer) to a wallet. If a user accepts the offer proposal, 
-the wallet makes an offer on the user's behalf and deposits the [payout](#payout) in the user's [purses](#purse). 
+[purses](#purse), 8 Moola purses, and 2 Simoleons purses. A wallet can distinguish between [Issuers](#issuer).
+Dapps can propose [offers](#offer) to a wallet. If a user accepts the offer proposal,
+the wallet makes an offer on the user's behalf and deposits the [payout](#payout) in the user's [purses](#purse).
 See the [Wallet Guide and API](/guides/wallet/).
 
 ## ZCF
-*ZCF (Zoe Contract Facet)* is the [facet](#facet) of Zoe exposed to contract code. The Zoe 
-Contract Facet methods can be called synchronously by contract code. 
+*ZCF (Zoe Contract Facet)* is the [facet](#facet) of Zoe exposed to contract code. The Zoe
+Contract Facet methods can be called synchronously by contract code.
 
 See the [ZCF API](/zoe/api/zoe-contract-facet.md).
 

--- a/main/guides/README.md
+++ b/main/guides/README.md
@@ -10,7 +10,7 @@ all guides across our Documentation repo.
 - [ERTP](/ertp/guide)
 - [JavaScript Distributed Programming on the Agoric Platform](./js-programming)
 - [REPL](/repl/)
-- [SES (Secure Ecmascript)](./js-programming/ses/ses-guide.md)
+- [Endo and Hardened JavaScript (SES)](./js-programming/ses/ses-guide.md)
 - [Wallet](./wallet)
 - [Zoe](/zoe/guide)
 

--- a/main/guides/js-programming/ses/README.md
+++ b/main/guides/js-programming/ses/README.md
@@ -1,15 +1,18 @@
-# SES
+# Endo, Hardened JavaScript, and SES
 
-The Agoric platform includes a *SES (Secure ECMAScript)* shim, (a library
-providing SES features) for writing secure smart contracts in JavaScript. 
+The Agoric platform includes a *SES (Secure ECMAScript)* shim, (a library that
+extends JavaScript to include Hardened JavaScript features) for writing secure
+smart contracts in JavaScript.
 SES is a JavaScript runtime library for safely running third-party code.
+What Node.js does for JavaScript, Endo does for Hardened JavaScript.
 
-Our SES documentation consists of two primary documents:
-- [SES Guide](./ses-guide.md): Intended for initial reading when starting to use or learn 
-  about Agoric. It provides relatively detailed background information on 
+Our documentation consists of two primary documents:
+- [Guide](./ses-guide.md): Intended for
+  initial reading when starting to use or learn
+  about Agoric. It provides relatively detailed background information on
   how and why SES works so that you'll get a greater understanding of what's
   going on.
-- [SES Reference](./ses-reference.md): Intended for those knowledgeable about or experienced with
+- [Reference](./ses-reference.md): Intended for those knowledgeable about or experienced with
   SES. Use this if you just want to see or remind yourself of what SES can do
   and how to use it without much explanation.
 

--- a/main/guides/js-programming/ses/ses-guide.md
+++ b/main/guides/js-programming/ses/ses-guide.md
@@ -1,82 +1,127 @@
-# SES Guide
+# Endo and Hardened JavaScript (SES) Programming Guide
 
-This is a guide to understanding *SES (Secure ECMAScript)*. It:
-- Shows what you can and cannot do with a SES-using JavaScript program.
-- Defines what SES is and does.
+This is a guide to programming with *Hardened JavaScript* and *Endo*. It:
+- Shows what you can and cannot do with a Hardened JavaScript program.
+- Defines what SES, the Hardened JavaScript shim, is and does.
 - Provides background on why JavaScript functionality was added, removed, or changed.
 - Describes *realms* and *compartments*.
+- Introduces Endo.
 
-This is intended for initial reading when starting to use or learn about Agoric. For 
-those knowledgeable about or experienced with SES, see the [SES Reference](./ses-reference.md)
-for to use SES without much explanation.
+This is intended for initial reading when starting to use or learn about Agoric. For
+those knowledgeable about or experienced with Hardened JavaScript, see the
+[Endo and Hardened JavaScript Programming Reference](./ses-reference.md)
+for to use Hardened JavaScript without much explanation.
+
+## What is Hardened JavaScript?
+
+Hardened JavaScript:
+- Is a JavaScript runtime library for safely running third-party code.
+- Addresses JavaScript’s lack of internal security.
+  - This is particularly significant because JavaScript applications
+    use and rely on third-party code (modules, packages, libraries,
+    user-provided code for extensions and plug-ins, etc.).
+- Enforces best practices by removing hazardous features such as global
+  mutable state and lack of encapsulation in sloppy mode.
+- Is a safe deterministic subset of "strict mode" JavaScript.
+- Does not include any IO objects that provide
+  [*ambient authority*](https://en.wikipedia.org/wiki/Ambient_authority).
+- Removes non-determinism by modifying a few built-in objects.
+- Adds functionality to freeze and make immutable both built-in JavaScript
+  objects and program created objects and make them immutable.
+- Is (as SES) is a proposed extension to the JavaScript standard.
+
+Hardened JavaScript consists of three parts:
+- Lockdown is a function that irreversibly repairs and hardens an existing
+  mutable JavaScript environment.
+- Harden is a function that makes interfaces tamper-proof, so objects can be
+  shared between programs.
+- Compartment is a class that constructs isolated environments, with separate
+  globals and modules, but shared hardened primordials and limited access to
+  other powerful objects in global scope.
 
 ## What is SES?
 
-SES (*Secure ECMAScript*):
-- Is a JavaScript runtime library for safely running third-party code. 
-- Addresses JavaScript’s lack of internal security.
-  - This is particularly significant because JavaScript applications
-    use and rely on third-party code (modules, packages, libraries, 
-    user-provided code for extensions and plug-ins, etc.). 
-- Enforces best practices by removing hazardous features such as global 
-  mutable state and lack of encapsulation in sloppy mode. 
-- Is a safe deterministic subset of "strict mode" JavaScript. 
-- Does not include any IO objects that provide 
-  [*ambient authority*](https://en.wikipedia.org/wiki/Ambient_authority). 
-- Removes non-determinism by modifying a few built-in objects. 
-- Adds functionality to freeze and make immutable both built-in JavaScript 
-  objects and program created objects and make them immutable.
+SES is an old umbrella term for the Hardened JavaScript effort, and while we
+refer to these specific features as Hardened JavaScript, the SES name lingers
+in a few places.
 
-## The SES story
+SES (as `ses` in npm, the Node.js package registry) is the name of a JavaScript
+library that implements the Hardened JavaScript, that works in most modern
+JavaScript engines.
 
-JavaScript was created to let web surfers safely run programs from strangers. 
-Web pages put JavaScript programs in a *sandbox* that restricts their abilities 
+The SES Strategy group is a
+[community](https://groups.google.com/g/ses-strategy) of developers advocating
+and discussing security features for inclusion in JavaScript.
+
+As 2021 closes at time of writing, the language proposals still bear the SES
+name, though that is likely to change.
+
+## What is Endo?
+
+What Node.js does for JavaScript, Endo does for Hardened JavaScript.
+Endo loads packages and modules in an ECMAScript module loader that isolates
+every package, granting limited access to the host's resources.
+Agoric smart contracts are an example of Endo guest programs.
+
+## The Hardened JavaScript story
+
+JavaScript was created to let web surfers safely run programs from strangers.
+Web pages put JavaScript programs in a *sandbox* that restricts their abilities
 while maximizing utility.
 
 This worked well until web applications started inviting multiple strangers
-into the same sandbox. But they continued to depend on a security model where 
+into the same sandbox. But they continued to depend on a security model where
 every stranger had their own sandbox.
 
 Meanwhile, server-side JavaScript applications imbued their sandbox with unbounded
-abilities and ran programs written by strangers. They were vulnerable 
+abilities and ran programs written by strangers. They were vulnerable
 to both their dependencies *and* also the rarely reviewed dependencies of their dependencies.
 
-SES uses a finer grain security model, *Object Capabilities* or *OCaps*. 
+Hardened JavaScript uses a finer grain security model, *Object Capabilities* or *OCaps*.
 With OCaps, many strangers can collaborate in a single sandbox, without risking them
 frustrating, interfering, or conspiring with or against the user or each other.
 
-To do this, SES *hardens* the entire surface of the JavaScript environment. 
+To do this, the Lockdown function *hardens* the entire surface of the
+JavaScript environment.
 *The only way a program can subvert or communicate with another program is to
 have been expressly granted a reference to an object provided by that other program.*
 
 Any programming environment fitting the OCaps model satisfies three requirements:
 - Any program can protect its invariants by hiding its own data and capabilities.
-- Power can only be exercised over something by having a reference to the 
-  object providing that power, for example, a file system object. A 
+- Power can only be exercised over something by having a reference to the
+  object providing that power, for example, a file system object. A
   reference to a powerful object is a *capability*.
 - The only way to get a capability is by being given one. For example, by receiving
   one as an argument of a constructor or method.
 
-Ordinary JavaScript does not fully qualify as an OCaps language due to the pervasive 
-mutability of shared objects. You can construct a JavaScript subset with a 
+Ordinary JavaScript does not fully qualify as an OCaps language due to the pervasive
+mutability of shared objects. You can construct a JavaScript subset with a
 transitively immutable environment without any unintended capabilities. Starting
 in 2007 with ECMAScript 5, Agoric engineers and the OCap community have influenced
-JavaScript’s evolution so a program can transform its own environment into 
+JavaScript’s evolution so a program can transform its own environment into
 this safe JavaScript environment.
 
-As of February 2021, SES is making its way through JavaScript standards committees. 
-It is expected to become official JavaScript when the standards process 
-is completed. Meanwhile, Agoric provides its own SES *shim* (a library providing
-the needed SES features) for writing secure smart contracts in JavaScript. 
-Note that several Agoric engineers are on the relevant standards committees 
-and are responsible for aspects of SES, so our SES should be very close to the
-eventual standards.
+As of February 2021, Hardened JavaScript (under the name SES) is making its way
+through JavaScript standards committees.
+It is expected to become official JavaScript when the standards process
+is completed.
+Meanwhile, Agoric provides its own SES *shim* (a library providing
+the needed Hardened JavaScript features) for writing secure smart contracts in
+JavaScript.
+Several Agoric engineers are on the relevant standards committees
+and are responsible for aspects of Hardened JavaScript, so our SES should be
+very close to the eventual standards.
 
-## Using SES with your code
+## Using Hardened JavaScript with your code
 
-The SES shim transforms ordinary JavaScript environments into SES environments.
+The Lockdown function transforms ordinary JavaScript environments into Hardened
+JavaScript environments.
 
-On Node.js you can import or require `ses` in either CommonJS or ECMAScript modules, then call `lockdown()`. This is a *shim*. It mutates the environment in place so any code running after the shim can assume it’s running in a SES environment. This includes the globals `lockdown()`, `harden()`, `Compartment`, and so on. For example:
+On Node.js you can import or require `ses` in either CommonJS or ECMAScript
+modules, then call `lockdown()`. This is a *shim*. It mutates the environment
+in place so any code running after the shim can assume it’s running in a hardened
+environment. This includes the globals `lockdown()`, `harden()`, `Compartment`,
+and so on. For example:
 ```js
 require("ses");
 lockdown();
@@ -87,7 +132,7 @@ import 'ses';
 lockdown();
 ```
 
-To ensure a module runs in a SES environment, wrap the above code in a `ses-lockdown.js` module and import it:
+To ensure a module runs in a hardened environment, wrap the above code in a `ses-lockdown.js` module and import it:
 ```js
 import './non-ses-code-before-lockdown.js';
 import './ses-lockdown.js'; // calls lockdown.
@@ -98,18 +143,12 @@ To use SES as a script on the web, use the UMD build.
 <script src="node_modules/ses/dist/ses.umd.min.js">
 ```
 
-The full SES environment's module system requires a translating compiler. There is a much thinner SES version that just provides an evaluator Compartment. For it, use the much smaller `ses/lockdown` layer. Especially if all client code gets bundled as a script out-of-band.
-```js
-import 'ses/lockdown';
-<script src="node_modules/ses/dist/lockdown.umd.min.js"></script>
-```
+## What Lockdown does to JavaScript
 
-## What SES does to JavaScript
+Hardened JavaScript does not include any I/O objects providing "unsafe" [*ambient authority*](https://en.wikipedia.org/wiki/Ambient_authority).
+It also doesn't allow non-determinism from built-in JavaScript objects.
 
-As mentioned, SES does not include any IO objects providing "unsafe" [*ambient authority*](https://en.wikipedia.org/wiki/Ambient_authority). 
-It also doesn't allow non-determinism from built-in JavaScript objects. 
-
-As of SES-0.8.0/Fall 2020, [Agoric's SES source code](https://github.com/endojs/endo/blob/SES-v0.8.0/packages/ses/src/whitelist.js) 
+As of SES-0.8.0/Fall 2020, [Agoric's SES source code](https://github.com/endojs/endo/blob/SES-v0.8.0/packages/ses/src/whitelist.js)
 defines a subset of the globals defined by the baseline JavaScript language specification. SES includes these globals:
 
 - `Object`
@@ -121,38 +160,38 @@ defines a subset of the globals defined by the baseline JavaScript language spec
 - `BigInt`
 - `Intl`
 - `Math` all features except
-  - `Math.random()` is disabled (calling it throws an error) as an obvious source of   
-     non-determinism.  
+  - `Math.random()` is disabled (calling it throws an error) as an obvious source of
+     non-determinism.
 - `Date` all features except
   - `Date.now()` returns `NaN`
   - `new Date(nonNumber)` or `Date(anything)` return a `Date` that stringifies to `"Invalid Date"`
 
 Much of the `Intl` package, and some other objects' locale-specific aspects (e.g. `Number.prototype.toLocaleString`)
-have results that depend upon which locale is configured. This varies from one process to another. 
+have results that depend upon which locale is configured. This varies from one process to another.
 See [`lockdown()`](./lockdown.md) for how those are handled.
 
-SES freezes *primordials*; built-in JavaScript objects such as `Object`, `Array`, and `RegExp`, 
-and their prototype chains. `globalThis` is also frozen. This prevents malicious code from changing their behavior 
-(imagine `Array.prototype.push` delivering a copy of its argument to an attacker, or ignoring 
-certain values). It also prevents using, for example, `Object.heyBuddy` or `globalThis.heyBuddy` 
-as an ambient communication channel via setting a property and another program periodically reading it. 
-This would violate object-capability discipline; objects may only communicate through references. 
+Lockdown freezes *primordials*; built-in JavaScript objects such as `Object`, `Array`, and `RegExp`,
+and their prototype chains. `globalThis` is also frozen. This prevents malicious code from changing their behavior
+(imagine `Array.prototype.push` delivering a copy of its argument to an attacker, or ignoring
+certain values). It also prevents using, for example, `Object.heyBuddy` or `globalThis.heyBuddy`
+as an ambient communication channel via setting a property and another program periodically reading it.
+This would violate object-capability discipline; objects may only communicate through references.
 
-Both frozen primordials and a frozen `globalThis` have problems with a few JavaScript 
+Both frozen primordials and a frozen `globalThis` have problems with a few JavaScript
 libraries that add new features to built-in objects (shims/polyfills). These
-libraries stretch best practices' boundaries by adding new features to built-in 
-objects in a way SES Compartments don't allow. 
+libraries stretch best practices' boundaries by adding new features to built-in
+objects in a way Compartments don't allow.
 
-## What SES removes from standard JavaScript
+## What Lockdown removes from standard JavaScript
 
-Almost all existing JavaScript code runs under Node.js or inside a browser, so 
-it's easy to conflate environment features with JavaScript. For example, you may 
-be surprised that `Buffer` and `require` are Node.js additions. Also `setTimeout()`, 
-`setInterval()`, `URL`, `atob()`, `btoa()`, `TextEncoder`, and `TextDecoder` are additions 
+Almost all existing JavaScript code runs under Node.js or inside a browser, so
+it's easy to conflate environment features with JavaScript. For example, you may
+be surprised that `Buffer` and `require` are Node.js additions. Also `setTimeout()`,
+`setInterval()`, `URL`, `atob()`, `btoa()`, `TextEncoder`, and `TextDecoder` are additions
 to the programming environment standardized by the web, and are not intrinsic
 to JavaScript.
 
-Most Node.js-specific [global objects](https://nodejs.org/dist/latest-v14.x/docs/api/globals.html) are 
+Most Node.js-specific [global objects](https://nodejs.org/dist/latest-v14.x/docs/api/globals.html) are
 **unavailable** including:
 
 * `queueMicrotask`
@@ -166,44 +205,48 @@ Most Node.js-specific [global objects](https://nodejs.org/dist/latest-v14.x/docs
   * No `process.argv` for the argument array.
 * `Buffer` (consider using `TypedArray` instead, but see below)
 * `setImmediate`/`clearImmediate`
-  * You can generally replace `setImmediate(fn)` 
+  * You can generally replace `setImmediate(fn)`
     with `Promise.resolve().then(_ => fn())` to defer execution of `fn` until after the current event/callback
-    finishes processing. But it won't run until after all *other* ready Promise callbacks execute. 
+    finishes processing. But it won't run until after all *other* ready Promise callbacks execute.
 
-    There are two queues: the *IO queue* (accessed by `setImmediate`), and the *Promise queue* (accessed by 
-    Promise resolution). SES code can add to the Promise queue, but needs to be given a 
-    capability to be able to add to the IO queue. Note that the Promise queue is 
+    There are two queues: the *IO queue* (accessed by `setImmediate`), and the *Promise queue* (accessed by
+    Promise resolution). Hardened JavaScript code can add to the Promise queue, but needs to be given a
+    capability to be able to add to the I/O queue. Note that the Promise queue is
     higher-priority than the IO queue, so the Promise queue must be empty for any IO or timers to be handled.
 * `setInterval` and `setTimeout` (and `clearInterval`/`clearTimeout`)
-  * Any notion of time must come from 
-    exchanging messages with external timer services (the SwingSet environment provides a `TimerService` object 
+  * Any notion of time must come from
+    exchanging messages with external timer services (the SwingSet environment provides a `TimerService` object
     to the bootstrap vat, which can share it with other vats)
 
-None of the huge list of [other Browser environment features](https://developer.mozilla.org/en-US/docs/Web/API) 
-presented as names in the global scope (some also added to Node.js) are available in a 
-SES environment. The most surprising removals include `atob`, `TextEncoder`, and `URL`.
+None of the huge list of [other Browser environment features](https://developer.mozilla.org/en-US/docs/Web/API)
+presented as names in the global scope (some also added to Node.js) are available in a
+hardened environment. The most surprising removals include `atob`, `TextEncoder`, and `URL`.
 
 `debugger` is a first-class JavaScript statement, and behaves as expected.
 
-## What SES adds to standard Javascript
+## What Hardened JavaScript adds to standard Javascript
 
-The following anticipate additional proposed standard-track features. If they become standards, 
-future JavaScript environments will include them as global objects. So the current Agoric SES shim 
+The following anticipate additional proposed standard-track features. If they become standards,
+future JavaScript environments will include them as global objects. So the current Agoric SES shim
 makes those global objects available.
 
 - `console` is available for debugging. While not in the official spec, since all implementations
-  add it, leaving it out would cause confusion. Note that `console.log`’s exact 
-  behavior is up to the host program; display to the operator is not guaranteed. Use the 
+  add it, leaving it out would cause confusion. Note that `console.log`’s exact
+  behavior is up to the host program; display to the operator is not guaranteed. Use the
   console for debug information only. The console is not obliged to write to the POSIX standard output.
 
-- `lockdown()` and `harden()` both freeze an object’s API surface (enumerable data properties). 
-  A hardened object’s properties cannot be changed, only read, so the only way to interact with a 
-  hardened object is through its methods. `harden()` is similar to `Object.freeze()` but more 
-  thorough. See the individual [`lockdown()`](#lockdown) and [`harden()`](#harden) sections
-  below. 
+- `assert` is also a debugging tool that allows programs to express assertions
+  and defer the construction of error objects and computed messages until an
+  assertion fails.
 
-- `[Compartment](https://github.com/endojs/endo/tree/SES-v0.8.0/packages/ses#compartment)` is 
-  a global. Code runs inside a `Compartment` and can create sub-compartments to host other 
+- `lockdown()` and `harden()` both freeze an object’s API surface (enumerable data properties).
+  A hardened object’s properties cannot be changed, only read, so the only way to interact with a
+  hardened object is through its methods. `harden()` is similar to `Object.freeze()` but more
+  thorough. See the individual [`lockdown()`](#lockdown) and [`harden()`](#harden) sections
+  below.
+
+- `[Compartment](https://github.com/endojs/endo/tree/SES-v0.8.0/packages/ses#compartment)` is
+  a global. Code runs inside a `Compartment` and can create sub-compartments to host other
   code (with different globals or transforms). Note that these child compartments get `harden()` and `Compartment`.
 
 ## Realms
@@ -211,32 +254,33 @@ makes those global objects available.
 Agoric deploy scripts and smart contract code run in an *immutable
 realm* with *Compartments* providing just enough authority to create
 useful and secure contracts. But not enough authority to do anything
-unintended or harmful to the participants of the smart contract. 
+unintended or harmful to the participants of the smart contract.
 
-JavaScript code runs in the context of 
-a [*Realm*](https://www.ecma-international.org/ecma-262/10.0/index.html#sec-code-realms). A 
+JavaScript code runs in the context of
+a [*Realm*](https://www.ecma-international.org/ecma-262/10.0/index.html#sec-code-realms). A
 realm is the set of *primordials* (objects and standard library functions
-like `Array.prototype.push`) and a global object. In a web browser, an iframe is a realm. 
+like `Array.prototype.push`) and a global object. In a web browser, an iframe is a realm.
 In Node.js, a Node process is a realm.
 
 For historical reasons, the ECMAScript specification requires primordials
-be mutable (`Array.prototype.push = yourFunction` is valid ECMAScript but not 
-recommended). By using the Agoric SES shim and calling `lockdown()`, you can turn the 
-current realm into an *immutable realm*; a realm within which the primordials 
-are deeply frozen. 
+be mutable (`Array.prototype.push = yourFunction` is valid ECMAScript but not
+recommended). By using the Agoric SES shim and calling `lockdown()`, you can turn the
+current realm into an *immutable realm*; a realm within which the primordials
+are deeply frozen.
 
 SES also lets programs create *Compartments*. These are "mini-realms".
-A Compartment has its own dedicated global object and environment, but 
+A Compartment has its own dedicated global object and environment, but
 it inherits the primordials from their parent realm. Components are described
-in detail in the next section. 
+in detail in the next section.
 
 ## Compartments
+
 A *compartment* is an execution environment for evaluating a stranger’s code. It has
-its own `globalThis` global object and wholly independent system of 
-modules. Otherwise it shares the same batch of intrinsics such as `Array` with its surrounding 
-compartment. The concept of a compartment implies an initial compartment, 
-the initial execution environment of a realm. After lockdown is called, all compartments share the same 
-frozen realm. 
+its own `globalThis` global object and wholly independent system of
+modules. Otherwise it shares the same batch of intrinsics such as `Array` with its surrounding
+compartment. The concept of a compartment implies an initial compartment,
+the initial execution environment of a realm. After lockdown is called, all compartments share the same
+frozen realm.
 
 Here we create a compartment with a `print()` function on `globalThis`.
 ```js
@@ -250,22 +294,22 @@ c.evaluate(`
   print('Hello! Hello?');
 `);
 ```
-This new compartment has a different global object than the start compartment. We 
-posit that all JavaScript executes in a realm and compartment. Every realm has 
-distinct intrinsics, whereas every compartment shares intrinsics. The initial 
+This new compartment has a different global object than the start compartment. We
+posit that all JavaScript executes in a realm and compartment. Every realm has
+distinct intrinsics, whereas every compartment shares intrinsics. The initial
 realm and compartment are not constructed with `new Realm()` or `new Compartment()` but
-that’s invisible to the code running; they could just as well be running within 
-a constructed realm or compartment. 
+that’s invisible to the code running; they could just as well be running within
+a constructed realm or compartment.
 
-We call the one compartment in a realm that was not expressly constructed the start 
-compartment. The start compartment receives some ambient authorities from the host, 
-often access to timers and IO that are denied to other compartments. Running lockdown 
-does not erase these powerful objects, but puts the program running in the start 
-compartment on a footing where it is possible to carefully delegate powers to child 
+We call the one compartment in a realm that was not expressly constructed the start
+compartment. The start compartment receives some ambient authorities from the host,
+often access to timers and IO that are denied to other compartments. Running lockdown
+does not erase these powerful objects, but puts the program running in the start
+compartment on a footing where it is possible to carefully delegate powers to child
 compartments.
 
-The global object is initially mutable. Locking down the realm hardened the objects in 
-global scope. After lockdown, no compartment can tamper with these intrinsics and 
+The global object is initially mutable. Locking down the realm hardened the objects in
+global scope. After lockdown, no compartment can tamper with these intrinsics and
 undeniable objects. Many of these are identical in the new compartment.
 
 ```js
@@ -284,10 +328,10 @@ c1.globalThis.JSON === c2.globalThis.JSON; // true
 ```
 Every compartment's global scope includes a shallow, specialized copy of the JavaScript
 intrinsics. These omit `Date.now()` and `Math.random()`
-since they can be covert inter-program communication channels. 
+since they can be covert inter-program communication channels.
 
 However, a compartment may be expressly given access to these objects through
-the compartment constructor's first argument or by assigning them to the 
+the compartment constructor's first argument or by assigning them to the
 compartment's `globalThis` after construction.
 ```js
 const powerfulCompartment = new Compartment({ Math });
@@ -297,25 +341,25 @@ powerfulCompartment.globalThis.Date = Date;
 When you create a new `Compartment` object, you must decide if it supports OCaps security.
 If it does, run `harden(compartment.globalThis)` on it before loading any untrusted code into it.
 
-A single compartment can run a JavaScript program in the locked-down SES environment.
+A single compartment can run a JavaScript program in the locked-down environment.
 However, most interesting programs have multiple modules. So, each compartment also has
 its own module system. SES version 0.8.0 adds support for ECMAScript modules,
 a relatively new system supported by many browsers, and officially released in Node.js 14.
 
 Compartments can be linked, so one compartment can export a module that another compartment
-imports. Each compartment may have its own rules for how to resolve import specifiers and 
-how to locate and retrieve modules. In the following example, we use the compartment constructor to 
+imports. Each compartment may have its own rules for how to resolve import specifiers and
+how to locate and retrieve modules. In the following example, we use the compartment constructor to
 create two compartments: one for the application and another for its dependency.
 
-The `resolveHook` is synchronous and determines how to compute the full module specifier 
-for a partially resolved module specifier in ESM source text, like `import "./even.js"` as 
+The `resolveHook` is synchronous and determines how to compute the full module specifier
+for a partially resolved module specifier in ESM source text, like `import "./even.js"` as
 it appears in `./math/odd.js` corresponds to `./math/even.js` in a Node.js program.
 
-The `importHook` is asynchronous and responsible for for locating, retrieving, and parsing 
-modules. Retrieving is getting the source text from the web, archive, or database based on 
-its location. Converting a module specifier to a location is an internal concern of 
-the `importHook` and the particular storage medium for the module texts, but should generally 
-be a URL and may appear in stack traces. The `importHook` may use the `ModuleStaticRecord` 
+The `importHook` is asynchronous and responsible for for locating, retrieving, and parsing
+modules. Retrieving is getting the source text from the web, archive, or database based on
+its location. Converting a module specifier to a location is an internal concern of
+the `importHook` and the particular storage medium for the module texts, but should generally
+be a URL and may appear in stack traces. The `importHook` may use the `ModuleStaticRecord`
 constructor to create a reusable, parsed representation of the module text.
 
 ```js
@@ -335,32 +379,32 @@ const application = new Compartment({}, {
   importHook,
 });
 ```
-Compartments provide a low-level loader API for JavaScript modules. 
-Your code might run in compartments, but they are an implementation 
+Compartments provide a low-level loader API for JavaScript modules.
+Your code might run in compartments, but they are an implementation
 detail of tools and runtimes.
 
-Vats in the Agoric runtime use compartments to isolate contracts within a vat. 
+Vats in the Agoric runtime use compartments to isolate contracts within a vat.
 A vat can use multiple compartments.
-MetaMask’s LavaMoat uses a Compartment for every module, to create 
+MetaMask’s LavaMoat uses a Compartment for every module, to create
 boundaries between application code and third-party dependencies.
 
-The lifetime of a compartment is bounded by garbage collection and the 
+The lifetime of a compartment is bounded by garbage collection and the
 lifetime of the realm that contains them. You will not ever have to tear
-down or delete one. 
+down or delete one.
 
 ## `lockdown()`
 
-`lockdown()` freezes all JavaScript defined objects accessible to any 
+`lockdown()` freezes all JavaScript defined objects accessible to any
 program in the execution environment. Calling `lockdown()` turns a JavaScript
-system into a SES system, with enforced OCap (object-capability) security. It
-alters the surrounding execution environment (realm) such that no two 
-programs running in the same realm can observe or interfere with each other 
+system into a hardened system, with enforced OCap (object-capability) security. It
+alters the surrounding execution environment (realm) such that no two
+programs running in the same realm can observe or interfere with each other
 until they have been introduced.
 
-To do this, `lockdown()` tamper-proofs all of the JavaScript intrinsics to prevent 
-prototype pollution. After that, no program can subvert the methods of these objects 
+To do this, `lockdown()` tamper-proofs all of the JavaScript intrinsics to prevent
+prototype pollution. After that, no program can subvert the methods of these objects
 (preventing some man in the middle attacks). Also, no program can use these mutable
-objects to pass notes to parties that haven't been expressly introduced (preventing 
+objects to pass notes to parties that haven't been expressly introduced (preventing
 some covert communication channels).
 
 For a full explanation of `lockdown()` and its options, please click
@@ -368,26 +412,26 @@ For a full explanation of `lockdown()` and its options, please click
 
 ## `harden()`
 
-`harden()` is automatically provided by SES. Any code that will run inside a vat or a 
-contract can use harden as a global, without importing anything. The Agoric programming 
-environment defines objects (`mint`, `issuer`, `zcf`, etc.) that shouldn't need hardening 
-as their constructors do that work. You mainly need to harden records, callbacks, and ephemeral objects. 
+`harden()` is automatically provided by `lockdown()`. Any code that will run inside a vat or a
+contract can use harden as a global, without importing anything. The Agoric programming
+environment defines objects (`mint`, `issuer`, `zcf`, etc.) that shouldn't need hardening
+as their constructors do that work. You mainly need to harden records, callbacks, and ephemeral objects.
 
-`harden()` must be called on all objects that will be transferred across a trust boundary 
-The general rule is if you make a new object and give it to someone else (and don't 
-immediately forget it yourself), you should give them `harden(obj)` instead of the raw object. 
-This ensures other objects can only interact with them through their defined method interface, 
-i.e. the functions in the object's API. *CapTP*, our communications layer for passing 
-references to distributed objects, enforces this at vat boundaries. 
+`harden()` must be called on all objects that will be transferred across a trust boundary
+The general rule is if you make a new object and give it to someone else (and don't
+immediately forget it yourself), you should give them `harden(obj)` instead of the raw object.
+This ensures other objects can only interact with them through their defined method interface,
+i.e. the functions in the object's API. *CapTP*, our communications layer for passing
+references to distributed objects, enforces this at vat boundaries.
 
 Hardening an instance also hardens its class.
 
-You can send a message to a hardened object. If it's a record, you can access 
-its properties and their values. Being hardened doesn't preclude an object from having 
-access to mutable state (`harden(new Map())` still behaves like a normal mutable `Map`), 
+You can send a message to a hardened object. If it's a record, you can access
+its properties and their values. Being hardened doesn't preclude an object from having
+access to mutable state (`harden(new Map())` still behaves like a normal mutable `Map`),
 but it means their methods stay the same and can't be surprisingly changed by someone else.
 
-> Tip: If your text editor/IDE complains about `harden()` not being defined or imported, 
+> Tip: If your text editor/IDE complains about `harden()` not being defined or imported,
 > try adding `/* global harden */` to the top of the file.
 >
 > You use `harden()` like this:
@@ -400,15 +444,15 @@ but it means their methods stay the same and can't be surprisingly changed by so
 > ```
 ## `lockdown()` and `harden()`
 
-`lockdown()` and `harden()` essentially do the same thing; freeze objects so their 
-properties cannot be changed. The only way to interact with frozen objects is through 
+`lockdown()` and `harden()` essentially do the same thing; freeze objects so their
+properties cannot be changed. The only way to interact with frozen objects is through
 their methods. Their differences are what objects you use them on, and when you use them.
 
-`lockdown()` **must** be called first. It hardens JavaScript's built-in *primordials* 
-(implicitly shared global objects) and enables `harden()`. If you call `harden()` 
+`lockdown()` **must** be called first. It hardens JavaScript's built-in *primordials*
+(implicitly shared global objects) and enables `harden()`. If you call `harden()`
 before `lockdown()` executes, it throws an error.
 
-`lockdown()` works on objects created by the JavaScript language itself as part of 
+`lockdown()` works on objects created by the JavaScript language itself as part of
 its definition. Use `harden()` to freeze objects created after `lockdown()`was called;
 i.e. objects created by programs written in JavaScript.
 
@@ -417,23 +461,23 @@ i.e. objects created by programs written in JavaScript.
 Programs running under SES can use `import` or `require()` to import other libraries consisting
 only of SES-compatible JavaScript code. This includes a significant part of the NPM registry.
 
-However, many NPM packages use built-in Node.js modules. If used at import time (in their top-level 
-code), SES-enabled code cannot use the package and fails to load at all. If they use the built-in 
-features at runtime, then the package can load. However, it might fail later when an invoked function 
-accesses the missing functionality. So some NPM packages are partially compatible; 
+However, many NPM packages use built-in Node.js modules. If used at import time (in their top-level
+code), hardened JavaScript code cannot use the package and fails to load at all. If they use the built-in
+features at runtime, then the package can load. However, it might fail later when an invoked function
+accesses the missing functionality. So some NPM packages are partially compatible;
 usable if you don't invoke certain features.
 
 The same is true for NPM packages that use missing globals, or attempt to modify frozen primordials.
 
-The [SES wiki](https://github.com/endojs/endo/wiki) tracks compatibility reports for NPM packages, 
+The [Endo wiki](https://github.com/endojs/endo/wiki) tracks compatibility reports for NPM packages,
 including potential workarounds.
 
 ## HTML comments
 
 JavaScript parsers may not recognize HTML comments within source code, potentially causing different
 behavior on different engines. For safety, the Agoric SES shim rejects any source code containing a comment
-open (`<!--`) or close (`-->`) sequence. However, its filter uses a regular expression, not a full 
-parser. It unnecessarily rejects any source code containing either of the strings `<!--` or `-->`, 
+open (`<!--`) or close (`-->`) sequence. However, its filter uses a regular expression, not a full
+parser. It unnecessarily rejects any source code containing either of the strings `<!--` or `-->`,
 even if neither marks a comment.
 
 ### Dynamic import expressions
@@ -466,7 +510,7 @@ sneaky = import
 
 ## Direct vs. indirect eval expressions
 
-A *direct eval*, invoked as `eval(code)`, behaves as if `code` were expanded in place. The 
+A *direct eval*, invoked as `eval(code)`, behaves as if `code` were expanded in place. The
 evaluated code sees the same scope as the `eval` itself sees, so this `code` can reference `x`:
 
 ```js
@@ -476,20 +520,20 @@ function foo(code) {
 }
 ```
 
-If you perform a direct eval, you cannot hide your internal authorities from the code being evaluated. 
+If you perform a direct eval, you cannot hide your internal authorities from the code being evaluated.
 
-In contrast, an *indirect eval* only gets the global scope, not the local scope. In a safe SES 
-environment, indirect eval is a useful and common tool. The evaluated code can only access global 
-objects, and those are all safe (and frozen). The only bad thing an indirect eval can do is consume 
-unbounded CPU or memory. Once you've evaluated the code, you can invoke it with arguments to give it 
+In contrast, an *indirect eval* only gets the global scope, not the local scope. In a hardened
+environment, indirect eval is a useful and common tool. The evaluated code can only access global
+objects, and those are all safe (and frozen). The only bad thing an indirect eval can do is consume
+unbounded CPU or memory. Once you've evaluated the code, you can invoke it with arguments to give it
 as many or as few authorities as you like.
 
 The most common way to invoke an indirect eval is `(1,eval)(code)`.
 
-The SES proposal does not change how direct and indirect eval work. However, the SES shim
+The Hardened JavaScript proposal does not change how direct and indirect eval work. However, the SES shim
 cannot correctly emulate a direct eval. If it tried, it would perform an indirect eval.
 This could be pretty confusing, because the evaluated code would not use objects from
-the local scope as expected. Furthermore, in the future when SES is natively implemented
+the local scope as expected. Furthermore, in the future when Hardened JavaScript is natively implemented
 by JavaScript engines, the behavior would revert to direct eval, allowing access to
 anything in scope.
 

--- a/main/guides/js-programming/ses/ses-reference.md
+++ b/main/guides/js-programming/ses/ses-reference.md
@@ -1,15 +1,16 @@
-# SES Reference
+# Endo and Hardened JavaScript (SES) Programming Reference
 
-This document describes how SES (Secure ECMAScript) affects writing Agoric JavaScript code. 
+This document describes how Hardened JavaScript (formerly SES) affects writing
+Agoric JavaScript code.
 It is very much a "how to do something" document, with little explanation about why and
 how something was implemented or other background information. For that, see the more
-comprehensive [SES Guide](./ses-guide.md).
+comprehensive [Endo and Hardened JavaScript Programming Guide](./ses-guide.md).
 
 ## Using SES with your code
 
-The SES shim transforms ordinary JavaScript environments into SES environments.
+The SES shim transforms ordinary JavaScript environments into Hardened JavaScript environments.
 
-On Node.js you can import or require `ses` in either CommonJS or ECMAScript modules, then call `lockdown()`. This is a *shim*. It mutates the environment in place so any code running after the shim can assume it’s running in a SES environment. This includes the globals `lockdown()`, `harden()`, `Compartment`, and so on. For example:
+On Node.js you can import or require `ses` in either CommonJS or ECMAScript modules, then call `lockdown()`. This is a *shim*. It mutates the environment in place so any code running after the shim can assume it’s running in a Hardened JavaScript environment. This includes the globals `lockdown()`, `harden()`, `Compartment`, and so on. For example:
 ```js
 require("ses");
 lockdown();
@@ -20,7 +21,7 @@ import 'ses';
 lockdown();
 ```
 
-To ensure a module runs in a SES environment, wrap the above code in a `ses-lockdown.js` module and import it:
+To ensure a module runs in a Hardened JavaScript environment, wrap the above code in a `ses-lockdown.js` module and import it:
 ```js
 import './non-ses-code-before-lockdown.js';
 import './ses-lockdown.js'; // calls lockdown.
@@ -31,32 +32,26 @@ To use SES as a script on the web, use the UMD build.
 <script src="node_modules/ses/dist/ses.umd.min.js">
 ```
 
-The full SES environment's module system requires a translating compiler. There is a much thinner SES version that just provides an evaluator Compartment. For it, use the much smaller `ses/lockdown` layer. Especially if all client code gets bundled as a script out-of-band.
-```js
-import 'ses/lockdown';
-<script src="node_modules/ses/dist/lockdown.umd.min.js"></script>
-```
+## Removed by Hardened JavaScript summary
 
-## Removed by SES summary
-
-The following are missing or unusable under SES:
-- Most [Node.js-specific global objects](https://nodejs.org/dist/latest-v14.x/docs/api/globals.html) 
-- All [Node.js built-in modules](https://nodejs.org/dist/latest-v14.x/docs/api/) such as `http` and 
-  `crypto`. 
+The following are missing or unusable under Hardened JavaScript:
+- Most [Node.js-specific global objects](https://nodejs.org/dist/latest-v14.x/docs/api/globals.html)
+- All [Node.js built-in modules](https://nodejs.org/dist/latest-v14.x/docs/api/) such as `http` and
+  `crypto`.
 - [Features from browser environments](https://developer.mozilla.org/en-US/docs/Web/API) presented as names in the global scope including `atob`, `TextEncoder`, and `URL`.
 - HTML comments
 - Dynamic `import` expressions
 - Direct evals
 
-## Added/Changed by SES summary
+## Added/Changed by Hardened JavaScript summary
 
-SES adds the following to JavaScript or changes them significantly: 
-- console	
-- `Compartment`
+Hardened JavaScript adds the following to JavaScript or changes them significantly:
 - `lockdown()`
 - `harden()`
-- `globalThis` is frozen.
-- JavaScript primordials are frozen.
+- `Compartment`
+- `console`
+- `assert`
+- Shared JavaScript primordials are frozen.
 
 ## `lockdown()`
 
@@ -64,13 +59,13 @@ SES adds the following to JavaScript or changes them significantly:
 (preventing some man in the middle attacks). Also, no program can use them to pass notes to parties
 that haven't been expressly introduced (preventing some covert communication channels).
 
-Lockdown *freezes* all JavaScript defined objects accessible to any program in the realm. The frozen 
-accessible objects include but are not limited to: 
+Lockdown *freezes* all JavaScript defined objects accessible to any program in the realm. The frozen
+accessible objects include but are not limited to:
 - `globalThis`
 - `[].__proto__` the array prototype, equivalent to `Array.prototype` in a pristine JavaScript environment.
-- `{}.__proto__` the `Object.prototype` 
+- `{}.__proto__` the `Object.prototype`
 - `(() => {}).__proto__` the `Function.prototype`
-- `(async () => {}).__proto__` the prototype of all asynchronous functions, and has no alias 
+- `(async () => {}).__proto__` the prototype of all asynchronous functions, and has no alias
    in the global scope of a pristine JavaScript environment.
 - The properties of any accessible object
 
@@ -78,33 +73,33 @@ accessible objects include but are not limited to:
 - Regular expressions
   - A tamed RexExp does not have the deprecated compile method.
 - Locale methods
-  - Lockdown replaces locale methods like `String.prototype.localeCompare()` with lexical 
+  - Lockdown replaces locale methods like `String.prototype.localeCompare()` with lexical
     versions that do not reveal the user locale.
 - Errors
   - A tamed error does not have a V8 stack, but the console can still see the stack.
-   
-Lockdown does not erase any powerful objects from the initial global scope. Instead, 
+
+Lockdown does not erase any powerful objects from the initial global scope. Instead,
 Compartments give complete control over what powerful objects exist for client code.
 
 ## `lockdown()` and `harden()`
 
-`lockdown()` and `harden()` essentially do the same thing; freeze objects so their 
-properties cannot be changed. You can only interact with frozen objects through 
+`lockdown()` and `harden()` essentially do the same thing; freeze objects so their
+properties cannot be changed. You can only interact with frozen objects through
 their methods. Their differences are what objects you use them on, and when you use them.
 
-`lockdown()` **must** be called first. It hardens JavaScript's built-in *primordials* 
-(implicitly shared global objects) and enables `harden()`. Calling `harden()` 
+`lockdown()` **must** be called first. It hardens JavaScript's built-in *primordials*
+(implicitly shared global objects) and enables `harden()`. Calling `harden()`
 before `lockdown()` executes throws an error.
 
-`lockdown()` works on objects created by the JavaScript language itself as part of 
-its definition. Use `harden()` to freeze objects created by your JavaScript code 
-after `lockdown()`was called. 
+`lockdown()` works on objects created by the JavaScript language itself as part of
+its definition. Use `harden()` to freeze objects created by your JavaScript code
+after `lockdown()`was called.
 
 ## `lockdown` Options
 
 ### Default `'safe'` settings
 
-All four of these safety-relevant options default to `'safe'` if omitted 
+All four of these safety-relevant options default to `'safe'` if omitted
 from a call to `lockdown()`. Their other possible value is `'unsafe'`.
 - `regExpTaming`
 - `localeTaming`
@@ -112,9 +107,9 @@ from a call to `lockdown()`. Their other possible value is `'unsafe'`.
 - `errorTaming`
 
 The tradeoff is safety vs compatibility with existing code. However, much legacy
-JavaScript code does run under SES, even if both not written to do so and with all
-the options set to `'safe'`. Only consider an `'unsafe'` value if you both need it 
-and can evaluate its risks.
+JavaScript code does run under Hardened JavaScript, even if both not written to
+do so and with all the options set to `'safe'`. Only consider an `'unsafe'`
+value if you both need it and can evaluate its risks.
 
 ### Options quick reference
 
@@ -150,7 +145,7 @@ below.
   <tr>
     <td><code>errorTaming</code></td>
     <td><code>'safe'</code> (default) or <code>'unsafe'</code></td>
-    <td><code>'safe'</code> denies unprivileged stacks access,<br> 
+    <td><code>'safe'</code> denies unprivileged stacks access,<br>
         <code>'unsafe'</code> makes stacks also available by <code>errorInstance.stackkeeps()</code>.</td>
   </tr>
   <tr>
@@ -162,7 +157,7 @@ below.
   <tr>
     <td><code>overrideTaming</code></td>
     <td><code>'moderate'</code> (default) or <code>'min'</code></td>
-    <td><code>'moderate'</code> moderates mitigations for legacy compatibility,<br> 
+    <td><code>'moderate'</code> moderates mitigations for legacy compatibility,<br>
         <code>'min'</code> minimal mitigations for purely modern code</td>
   </tr>
   </tbody>
@@ -172,7 +167,7 @@ below.
 
 With its default `'safe'` value, regExpTaming prevents using `RegExp.*()` methods in the locked down code.
 
-With its `'unsafe'` value, `RegExp.prototype.compile()` can be used in locked down code. 
+With its `'unsafe'` value, `RegExp.prototype.compile()` can be used in locked down code.
 All other `RegExp.*()` methods are disabled.
 
 ```js
@@ -187,7 +182,7 @@ lockdown({ regExpTaming: 'unsafe' }); // Disables all RegExp.*() methods except 
 
 The default `'safe'` setting replaces each method listed below with their
 corresponding non-locale-specific method. For example, `Object.prototype.toLocaleString()`
-becomes another name for `Object.prototype.toString()`. 
+becomes another name for `Object.prototype.toString()`.
 - `toLocaleString`
 - `toLocaleDateString`
 - `toLocaleTimeString`
@@ -196,7 +191,7 @@ becomes another name for `Object.prototype.toString()`.
 - `localeCompare`
 
 The `'unsafe'` setting keeps the original behavior for compatibility at the price
-of reproducibility and fingerprinting. 
+of reproducibility and fingerprinting.
 
 ```js
 lockdown(); // localeTaming defaults to 'safe'
@@ -208,17 +203,17 @@ lockdown({ localeTaming: 'unsafe' }); // Allow locale-specific behavior
 
 ### `consoleTaming` Options
 
-The default `'safe'` option actually expands what you would expect from `console`'s logging 
+The default `'safe'` option actually expands what you would expect from `console`'s logging
 output. It will show information from the `assert` package and error objects.
 Errors can report more diagnostic information that should be hidden from other objects. See
-the [error README](https://github.com/endojs/endo/blob/master/packages/ses/src/error/README.md) 
+the [error README](https://github.com/endojs/endo/blob/master/packages/ses/src/error/README.md)
 for an in depth explanation of this.
 
 The `'unsafe'` setting leaves the original `console` in place. The `assert` package
-and error objects continue to work, but the `console` logging output will not 
-show this extra information. `'unsafe'` does **not** remove any additional `console` 
-methods beyond its de facto "standards". Since we do not know if these 
-methods violate OCap security, we should assume they are unsafe. A raw `console` 
+and error objects continue to work, but the `console` logging output will not
+show this extra information. `'unsafe'` does **not** remove any additional `console`
+methods beyond its de facto "standards". Since we do not know if these
+methods violate OCap security, we should assume they are unsafe. A raw `console`
 object should only be handled by very trustworthy code.
 
 ```js
@@ -232,15 +227,15 @@ lockdown({ consoleTaming: 'unsafe' }); // Leave original start console in place
 ### `errorTaming` Options
 
 The `errorTaming` default `'safe'` setting makes the stack trace inaccessible
-from error instances alone. It does this on v8 engines (Chrome, Brave, Node). 
+from error instances alone. It does this on v8 engines (Chrome, Brave, Node).
 Note that it is **not** hidden on other engines, leaving an information
-leak available. It reveals information only as a powerless string. 
+leak available. It reveals information only as a powerless string.
 
-In JavaScript the stack is only available via `err.stack`, so some 
-development tools assume it is there. When the information leak is tolerable, 
+In JavaScript the stack is only available via `err.stack`, so some
+development tools assume it is there. When the information leak is tolerable,
 the `'unsafe'` setting preserves `err.stack`'s filtered stack information.
 
-`errorTaming` does not affect the `Error` constructor's safety. 
+`errorTaming` does not affect the `Error` constructor's safety.
 After calling `lockdown`, the tamed `Error` constructor in the
 start compartment follows OCap rules. Under v8 it emulates most of the
 magic powers of the v8 `Error` constructor&mdash;those consistent with the
@@ -258,7 +253,7 @@ lockdown({ errorTaming: 'unsafe' }); // Stacks also available by errorInstance.s
 
 `stackFiltering` trades off stronger stack traceback filtering to
 minimize distractions vs completeness for tracking down bugs in
-obscure places. 
+obscure places.
 
 The default `'concise'` setting removes "noise" from the full distributed
 stack traces, in particularly artifacts from low level infrastructure. It
@@ -267,7 +262,7 @@ only works on v8 engines.
 With the `'verbose'` setting, the `console` displays the full raw stack
 information for each level of the "deep stack", tracing back through the
 [eventually sent messages](https://github.com/tc39/proposal-eventual-send)
-from other turns of the event loop. This makes JavaScript's already voluminous 
+from other turns of the event loop. This makes JavaScript's already voluminous
 error stacks even more so. However, this is sometimes useful for finding bugs
 in low level infrastructure.
 
@@ -290,10 +285,10 @@ compatibility vs better tool compatibility.
 
 When starting a project, we recommend using the non-default `'min'` option to make
 debugging more pleasant. You may need to reset it to the `'moderate'` default if
-third-party shimming code interferes with `lockdown()`. 
+third-party shimming code interferes with `lockdown()`.
 
 `'moderate'` option is intended to be fairly minimal. Expand it when you
-encounter code which should run under SES but can't due to
+encounter code which should run under Hardened JavaScript but can't due to
 the [override mistake](https://web.archive.org/web/20141230041441/http://wiki.ecmascript.org/doku.php?id=strawman:fixing_override_mistake),
 
 The `'min'` setting serves two purposes:
@@ -303,7 +298,7 @@ The `'min'` setting serves two purposes:
 All Agoric-authored code is compatible with both settings, but
 Agoric currently still pulls in some third party dependencies only compatible
 with the `'moderate'` setting.
- 
+
  ```js
 lockdown(); // overrideTaming defaults to 'moderate'
 // or

--- a/main/zoe/guide/contract-requirements.md
+++ b/main/zoe/guide/contract-requirements.md
@@ -23,8 +23,8 @@ A Zoe contract will be bundled up, so you should feel free to divide
 your contract into multiple files (perhaps putting helper functions in a
 separate file, for example) and import them.
 
-A Zoe contract needs to be able to run under [Agoric's SES](https://github.com/endojs/endo/tree/master/packages/ses). Some legacy
-JavaScript code is incompatible with SES, because SES freezes the
+A Zoe contract needs to be able to run under [Agoric's SES shim for Hardened JavaScript](https://github.com/endojs/endo/tree/master/packages/ses). Some legacy
+JavaScript code is incompatible with Hardened JavaScript, because Lockdown freezes the
 JavaScript objects you start out with (the primordials, such as `Object`), and some legacy code tries to
 mutate these. 
 
@@ -134,7 +134,7 @@ Facet method [`zcf.makeInvitation`](/zoe/api/zoe-contract-facet.md#zcf-makeinvit
 
 Modules start as files on disk, but then are bundled together
 into an archive before being loaded into a vat. The bundling tool uses several standard
-functions to locate other modules that must be included. These are not a part of SES, but
+functions to locate other modules that must be included. These are not a part of Hardened JavaScript, but
 are allowed in module source code, and are translated or removed before execution.
 
 - `import` and `export` syntax are allowed in ESM-style modules (preferred over CommonJS).
@@ -145,7 +145,7 @@ are allowed in module source code, and are translated or removed before executio
   environment, or otherwise rewritten to work sensibly
 - `__dirname` and `__filename` are not provided
 - The dynamic import expression (`await import('name')`) is currently prohibited in vat
-  code, but a future SES implementation may allow it.
+  code, but a future SES implementation of Hardened JavaScript may allow it.
 
 The [Node.js API](https://nodejs.org/dist/latest-v14.x/docs/api/) includes "built-in
 modules", such as `http` and `crypto`. Some are clearly platform-specific (e.g. `v8`), while
@@ -161,7 +161,7 @@ module's functions, then have the vat send messages to the device.
 ## Library compatibility
 
 Vat code can use `import` or `require()` to import other libraries consisting
-only of JS code, which are compatible with the SES environment. This includes
+only of JS code, which are compatible with the Hardened JavaScript environment. This includes
 a significant portion of the NPM registry.
 
 However, many NPM packages use built-in Node.js modules. If used at import


### PR DESCRIPTION
This change reviews every occurrence of SES in the documentation and either replaces it with Hardened JavaScript or Endo, or clarifies that it refers specifically to one of the three entities that retain the old name: the shim, the standard proposal, or the strategy group.

This change adds sections that call out Endo specifically in the glossary and its role in the Agoric programming environment.
