### PR TITLE
docs: Clearer instructions for  getting-started/start-a-project

### DIFF
--- a/main/getting-started/start-a-project.md
+++ b/main/getting-started/start-a-project.md
@@ -63,6 +63,12 @@ On a Mac, you must first install
 <pre style="background: aqua">
 # Shell 2
 cd demo # if not already there
+agoric start
+
+# if the process was interrupted or crashed
+# rerun the command above and it should resume
+
+# to reset and start over
 agoric start --reset
 </pre>
 
@@ -101,9 +107,12 @@ in a web browser.
 agoric open --repl
 ```
 
-Another browser window or tab should appear.
+This should automatically open [http://127.0.0.1:8000](http://127.0.0.1:8000)
+in a new browser window or tab.
 
 ## Use the Dapp to collect your (simulated) tokens
 
-Use the wallet to grant the Dapp's request to connect.
+Use the wallet to grant the Dapp's request to connect. For more information about the wallet UI see
+[https://agoric.com/documentation/guides/wallet/ui.html#wallet-ui](https://agoric.com/documentation/guides/wallet/ui.html#wallet-ui)
+
 Then use the Fungible Faucet Dapp to collect your tokens.

--- a/main/getting-started/start-a-project.md
+++ b/main/getting-started/start-a-project.md
@@ -112,6 +112,6 @@ in a new browser window or tab.
 
 ## Use the Dapp to collect your (simulated) tokens
 
-Use the wallet to grant the Dapp's request to connect. See also the [wallet UI](/guides/wallet/ui.html#wallet-ui) section.
+Use the wallet to grant the Dapp's request to connect. See also the [wallet UI](/guides/wallet/ui.md#wallet-ui) section.
 
 Then use the Fungible Faucet Dapp to collect your tokens.

--- a/main/getting-started/start-a-project.md
+++ b/main/getting-started/start-a-project.md
@@ -112,6 +112,6 @@ in a new browser window or tab.
 
 ## Use the Dapp to collect your (simulated) tokens
 
-Use the wallet to grant the Dapp's request to connect. See also the [wallet UI] (/guides/wallet/ui.html#wallet-ui) section.
+Use the wallet to grant the Dapp's request to connect. See also the [wallet UI](/guides/wallet/ui.html#wallet-ui) section.
 
 Then use the Fungible Faucet Dapp to collect your tokens.

--- a/main/getting-started/start-a-project.md
+++ b/main/getting-started/start-a-project.md
@@ -112,7 +112,6 @@ in a new browser window or tab.
 
 ## Use the Dapp to collect your (simulated) tokens
 
-Use the wallet to grant the Dapp's request to connect. For more information about the wallet UI see
-[https://agoric.com/documentation/guides/wallet/ui.html#wallet-ui](https://agoric.com/documentation/guides/wallet/ui.html#wallet-ui)
+Use the wallet to grant the Dapp's request to connect. See also the [wallet UI] (/guides/wallet/ui.html#wallet-ui) section.
 
 Then use the Fungible Faucet Dapp to collect your tokens.


### PR DESCRIPTION
* clearer expectation around `agoric start` & `agoric start --reset`
* specify the link to the local wallet endpoint
* specify the link to wallet-ui documentation