### PR TITLE
style: Italicize in-page links

### DIFF
--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -15,6 +15,9 @@ module.exports = {
     }
     .two-col-table table {
         table-layout: fixed;
+    }
+    a[href^='#'] {
+        font-style: italic;
     }`],
     ['script', { src: 'https://www.googletagmanager.com/gtag/js?id=UA-118217811-1' }],
     ['script', {}, "window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'UA-118217811-1'); "],


### PR DESCRIPTION
I think this makes the [Glossary](https://agoric.com/documentation/glossary/) more readable, and on other pages has a negligible effect.

Before | After
-- | --
![glossary (before)](https://user-images.githubusercontent.com/1199584/157720086-92649be5-515c-47a1-98dc-5661dadba33c.png) | ![glossary (after)](https://user-images.githubusercontent.com/1199584/157720115-1821f7a8-0307-4633-9b11-02f9f4d44c45.png)
![Treasury contract (before)](https://user-images.githubusercontent.com/1199584/157722324-fa12f5c8-dbf0-4922-95d3-762332768da4.png) | ![Treasury contract (after)](https://user-images.githubusercontent.com/1199584/157722350-ecb4d255-5768-4ca1-bacb-2aea58477e8d.png)