### PR TITLE
refactor: Remove now-superfluous babel-standalone

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,19 +36,18 @@
   "homepage": "https://github.com/Agoric/documentation#readme",
   "dependencies": {
     "@agoric/zoe": "beta",
-    "@endo/marshal": "^0.6.1",
+    "@endo/marshal": "^0.6.3",
     "typescript": "^4.0.3"
   },
   "devDependencies": {
-    "@agoric/babel-standalone": "^7.14.3",
     "@agoric/assert": "beta",
     "@agoric/cosmic-swingset": "beta",
     "@agoric/ertp": "beta",
     "@agoric/notifier": "beta",
     "@agoric/solo": "beta",
-    "@endo/bundle-source": "^2.0.7",
-    "@endo/eventual-send": "^0.14.6",
-    "@endo/promise-kit": "^0.2.35",
+    "@endo/bundle-source": "^2.1.1",
+    "@endo/eventual-send": "^0.14.8",
+    "@endo/promise-kit": "^0.2.37",
     "@typescript-eslint/parser": "^4.26.0",
     "ava": "^3.15.0",
     "eslint": "^7.27.0",
@@ -60,14 +59,11 @@
     "eslint-plugin-prettier": "^3.4.0",
     "import-meta-resolve": "^1.1.1",
     "prettier": "^1.19.1",
-    "ses": "^0.15.9",
+    "ses": "^0.15.11",
     "vuepress": "^1.8.2",
-    "vuepress-plugin-check-md": "0.0.2",
-    "@agoric/solo": "beta",
-    "@agoric/cosmic-swingset": "beta"
+    "vuepress-plugin-check-md": "0.0.2"
   },
-  "resolutions": {
-  },
+  "resolutions": {},
   "globals": {
     "harden": "readonly"
   },

--- a/snippets/ertp/guide/test-amount-math.js
+++ b/snippets/ertp/guide/test-amount-math.js
@@ -1,7 +1,3 @@
-// TODO Remove babel-standalone preinitialization
-// https://github.com/endojs/endo/issues/768
-import '@agoric/babel-standalone';
-
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
 

--- a/snippets/test-intro-zoe.js
+++ b/snippets/test-intro-zoe.js
@@ -1,9 +1,5 @@
 // @ts-check
 
-// TODO Remove babel-standalone preinitialization
-// https://github.com/endojs/endo/issues/768
-import '@agoric/babel-standalone';
-
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import url from 'url';

--- a/snippets/zoe/contracts/test-callSpread.js
+++ b/snippets/zoe/contracts/test-callSpread.js
@@ -1,9 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 
-// TODO Remove babel-standalone preinitialization
-// https://github.com/endojs/endo/issues/768
-import '@agoric/babel-standalone';
-
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import url from 'url';

--- a/snippets/zoe/contracts/test-loan.js
+++ b/snippets/zoe/contracts/test-loan.js
@@ -1,9 +1,5 @@
 // @ts-check
 
-// TODO Remove babel-standalone preinitialization
-// https://github.com/endojs/endo/issues/768
-import '@agoric/babel-standalone';
-
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import url from 'url';

--- a/snippets/zoe/contracts/test-oracle.js
+++ b/snippets/zoe/contracts/test-oracle.js
@@ -1,9 +1,5 @@
 // @ts-check
 
-// TODO Remove babel-standalone preinitialization
-// https://github.com/endojs/endo/issues/768
-import '@agoric/babel-standalone';
-
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import url from 'url';

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,15 @@
   resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.3.15.tgz#149d120790b76bb79ca9a02f265d8e7a8a904a87"
   integrity sha512-6Kb0mtRoAd3O3VwnEXnGpy+ldqD+nB4OSZdgfKZkGn+apN9nLQP4OStEZKeG+jWsgBIzpNE61LrXv6HnBMCX+Q==
 
+"@agoric/babel-generator@^7.17.4", "@agoric/babel-generator@^7.17.6":
+  version "7.17.6"
+  resolved "https://registry.yarnpkg.com/@agoric/babel-generator/-/babel-generator-7.17.6.tgz#75ff4629468a481d670b4154bcfade11af6de674"
+  integrity sha512-D2wnk5fGajxMN5SCRSaA/triQGEaEX2Du0EzrRqobuD4wRXjvtF1e7jC1PPOk/RC2bZ8/0fzp0CHOiB7YLwb5w==
+  dependencies:
+    "@babel/types" "^7.17.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@agoric/babel-standalone@^7.14.3":
   version "7.14.3"
   resolved "https://registry.yarnpkg.com/@agoric/babel-standalone/-/babel-standalone-7.14.3.tgz#1bf201417481d37d2797dd3283590dcbef775b4d"
@@ -468,7 +477,7 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.14.2", "@babel/generator@^7.14.3", "@babel/generator@^7.16.8", "@babel/generator@^7.17.3":
+"@babel/generator@^7.14.2", "@babel/generator@^7.14.3", "@babel/generator@^7.17.3":
   version "7.17.3"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.3.tgz#a2c30b0c4f89858cb87050c3ffdfd36bdf443200"
   integrity sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==
@@ -559,7 +568,7 @@
     "@babel/template" "^7.16.7"
     "@babel/types" "^7.16.7"
 
-"@babel/helper-get-function-arity@^7.12.13", "@babel/helper-get-function-arity@^7.16.7":
+"@babel/helper-get-function-arity@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz#ea08ac753117a669f1508ba06ebcc49156387419"
   integrity sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==
@@ -682,7 +691,7 @@
     "@babel/traverse" "^7.14.0"
     "@babel/types" "^7.14.0"
 
-"@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13", "@babel/highlight@^7.16.7":
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.16.7":
   version "7.16.10"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
   integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
@@ -691,7 +700,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.12.13", "@babel/parser@^7.14.2", "@babel/parser@^7.14.3", "@babel/parser@^7.16.10", "@babel/parser@^7.16.7", "@babel/parser@^7.17.3", "@babel/parser@^7.7.0":
+"@babel/parser@^7.14.2", "@babel/parser@^7.14.3", "@babel/parser@^7.16.7", "@babel/parser@^7.17.3", "@babel/parser@^7.7.0":
   version "7.17.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.3.tgz#b07702b982990bf6fdc1da5049a23fece4c5c3d0"
   integrity sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==
@@ -1320,7 +1329,7 @@
     "@babel/parser" "^7.16.7"
     "@babel/types" "^7.16.7"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.13.0", "@babel/traverse@^7.13.15", "@babel/traverse@^7.14.0", "@babel/traverse@^7.14.2", "@babel/traverse@^7.7.0":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.0", "@babel/traverse@^7.14.2", "@babel/traverse@^7.17.3", "@babel/traverse@^7.7.0":
   version "7.17.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
   integrity sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
@@ -1336,7 +1345,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.16", "@babel/types@^7.14.0", "@babel/types@^7.14.2", "@babel/types@^7.14.4", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+"@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.14.0", "@babel/types@^7.14.2", "@babel/types@^7.14.4", "@babel/types@^7.16.7", "@babel/types@^7.17.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
   integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
@@ -1356,32 +1365,31 @@
   dependencies:
     arrify "^1.0.1"
 
-"@endo/base64@^0.2.19", "@endo/base64@^0.2.8":
-  version "0.2.19"
-  resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-0.2.19.tgz#8180751278faca637ec5fde9d334301671bd3841"
-  integrity sha512-wRDeRf9iP2QuwW9/vZjdJfsYGC0fDJx9wK44Beayq9TG8nCQ8q9HTLNyVtTqkDD+1yDiOM/Q/gDqWSkO6S2Miw==
+"@endo/base64@^0.2.21", "@endo/base64@^0.2.8":
+  version "0.2.21"
+  resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-0.2.21.tgz#e58fc38891fda25d57f1ed90274210c8781b2f22"
+  integrity sha512-Q7L3Ns1xoWma0qisXPUukuS/imugvE17HrwrXypfQlx5k0nh9zrhfboVs59EWfYtBllF27ZmxLZW2C88IUreFQ==
 
-"@endo/bundle-source@^2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@endo/bundle-source/-/bundle-source-2.0.7.tgz#ec638947d7dcdb19f9be2d7ec5df4ded6b375050"
-  integrity sha512-JMQGxzZCGi+BDbFAy993PpipEw160ni1stoQDXwj/DFL80o787E4QdXasklP4TwOLxf8Z3x6f29SfW+kkXiUUg==
+"@endo/bundle-source@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@endo/bundle-source/-/bundle-source-2.1.1.tgz#87ac2a90fea941cf253f409a06f7db9bf032f0bf"
+  integrity sha512-2XI9j7njyxlYsbECBYlN3DPNPrIBlmbtikXB7qp1XuRYBwyiXC2D3ch0nbO+swBCJZCueBPcnrEwrcvn3BQaIw==
   dependencies:
-    "@babel/generator" "^7.14.2"
-    "@babel/parser" "^7.14.2"
-    "@babel/traverse" "^7.14.2"
-    "@endo/base64" "^0.2.19"
-    "@endo/compartment-mapper" "^0.6.7"
+    "@agoric/babel-generator" "^7.17.4"
+    "@babel/parser" "^7.17.3"
+    "@babel/traverse" "^7.17.3"
+    "@endo/base64" "^0.2.21"
+    "@endo/compartment-mapper" "^0.7.1"
     "@rollup/plugin-commonjs" "^19.0.0"
     "@rollup/plugin-node-resolve" "^13.0.0"
     acorn "^8.2.4"
-    c8 "^7.7.3"
     rollup "^2.47.0"
     source-map "^0.7.3"
 
-"@endo/cjs-module-analyzer@^0.2.11", "@endo/cjs-module-analyzer@^0.2.19":
-  version "0.2.19"
-  resolved "https://registry.yarnpkg.com/@endo/cjs-module-analyzer/-/cjs-module-analyzer-0.2.19.tgz#8688bfbbe0f40f84824807f41d298b03e08b0575"
-  integrity sha512-fv80zSl8XrQYGb5L5Wh/M1COaVEasblJL4AWn29zpCpgT+1TB+/Grmy3icC/aZClEUWwTgiEUEZxhVvMTBTJGg==
+"@endo/cjs-module-analyzer@^0.2.11", "@endo/cjs-module-analyzer@^0.2.21":
+  version "0.2.21"
+  resolved "https://registry.yarnpkg.com/@endo/cjs-module-analyzer/-/cjs-module-analyzer-0.2.21.tgz#e6b6f65d9378d1e56a62caa69948f9e2e442dd17"
+  integrity sha512-nmRVyuqVWTVzewn/4Iy28XGPXcxwdR0475V8E0151Iy221Xyi4q+EcsB4lLbu8dIimkps8pR1eoY4oCWsedbTw==
 
 "@endo/compartment-mapper@^0.5.3":
   version "0.5.6"
@@ -1393,48 +1401,48 @@
     "@endo/zip" "^0.2.11"
     ses "^0.15.1"
 
-"@endo/compartment-mapper@^0.6.7":
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/@endo/compartment-mapper/-/compartment-mapper-0.6.7.tgz#89b31217371addbd0a67b52cc3796197d50c19fd"
-  integrity sha512-w99J1XbTYdgvvmzJK9xs+EPEuDDQpIAvTr+Jj2sdps4MTfbFKAZkMBM4tTl7fWNGUI7p5bqm5LWx2RyF7A1hMg==
+"@endo/compartment-mapper@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@endo/compartment-mapper/-/compartment-mapper-0.7.1.tgz#f740db7557727e0c4bee6eb5b96d7489080e84c0"
+  integrity sha512-Oj3gvvqkROUnD3Ckzw10OXY7kFTFA7sAVgE7E7HhURq/CBe1A0RD11iOQRhAlPMEXSk0dUkpTxnpXkxYwlIncQ==
   dependencies:
-    "@endo/cjs-module-analyzer" "^0.2.19"
-    "@endo/static-module-record" "^0.6.14"
-    "@endo/zip" "^0.2.19"
-    ses "^0.15.9"
+    "@endo/cjs-module-analyzer" "^0.2.21"
+    "@endo/static-module-record" "^0.7.0"
+    "@endo/zip" "^0.2.21"
+    ses "^0.15.11"
 
-"@endo/eventual-send@^0.14.6":
-  version "0.14.6"
-  resolved "https://registry.yarnpkg.com/@endo/eventual-send/-/eventual-send-0.14.6.tgz#62f8acd44baa4ea0a319111c528cabea10c8984b"
-  integrity sha512-NAImlJSV6g0JA6yxSpZyn/FCxdWkyPvnn1Xhn3RFDWf4rKziGeTxuyvlqFroXXocWOr8f7++5hH7BqnKrijFIA==
+"@endo/eventual-send@^0.14.8":
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/@endo/eventual-send/-/eventual-send-0.14.8.tgz#0d95b5cd7e420219cdd84c43683bfbd0b6cd2ff6"
+  integrity sha512-JIbzzIk1/Z+44O7+IuF5HfMzGu1txOvW5IJKu91syk//MIWU1+XQyPhwQKuWiZ2KX+ADdSPyNZTZjAN2IAE8gQ==
 
-"@endo/marshal@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@endo/marshal/-/marshal-0.6.1.tgz#909047382ca611976cf425c950eb83bd6cb86f57"
-  integrity sha512-ATjvOTBPHy2G5/TfWvQe3Te0Jim2u3gzxp5k+xVoitJUQpUIM8mvWQWjD3m8OdnnbowpsXHcc1V9B5yNQmp6og==
+"@endo/marshal@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@endo/marshal/-/marshal-0.6.3.tgz#9a22b77acb3371f8fb7f33958c7781c792617e9b"
+  integrity sha512-3TxX93F/hIWGU4h+dR/I5dskH7iDhMhRFfWIrmGj8yMMq6rW9CtgdOy59GfaHBJ1YB70ZH4ULwb1Iir5Z2EcLw==
   dependencies:
-    "@endo/eventual-send" "^0.14.6"
-    "@endo/nat" "^4.1.6"
-    "@endo/promise-kit" "^0.2.35"
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/nat" "^4.1.8"
+    "@endo/promise-kit" "^0.2.37"
 
-"@endo/nat@^4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@endo/nat/-/nat-4.1.6.tgz#91bd20376503c08f29e667f8ec5cf92511a06155"
-  integrity sha512-JfMeocAr9GyhQ2pFFibweIbIpgF9qV6xm7luOQ/JtB6n9mzAG9NVK+y6wAdLaIy3Ma/LONSHvF0PLZGwz5HvZQ==
+"@endo/nat@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@endo/nat/-/nat-4.1.8.tgz#2c761c64f124cb610a63bded0c78a306678d6304"
+  integrity sha512-KwNkmw2tS8rDs0V3Q/cgje6JNg2AarSjFimT/hchcxz4BMBHS5mI486/W9QC3yQcxkidqX7GX3sYcD18xu5tBA==
 
 "@endo/netstring@^0.2.8":
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/@endo/netstring/-/netstring-0.2.13.tgz#de0742010998eb373a4ab0a011f1c7a769838075"
   integrity sha512-+Q0pAg+3oA2ZlKth3k7BD+bhKMmVHfcHSWcBiCVg7LFVzrOIiltI9bEk7TJaGSWHTarUoR+vAPZwL/GULan15g==
 
-"@endo/promise-kit@^0.2.35":
-  version "0.2.35"
-  resolved "https://registry.yarnpkg.com/@endo/promise-kit/-/promise-kit-0.2.35.tgz#a32af869993dd74e2c9626afe9de34c802be67e4"
-  integrity sha512-FgG6V5JowgLsSqTIILn80yHn6Zp9JR7FzkN5Tvz4BI7faAVG7ywk7rhE+DKg71HJMvypy/2l1ptx7fbZ//y2zg==
+"@endo/promise-kit@^0.2.37":
+  version "0.2.37"
+  resolved "https://registry.yarnpkg.com/@endo/promise-kit/-/promise-kit-0.2.37.tgz#ef1506a953bbbb02793a33c7f22a6ac07783bea6"
+  integrity sha512-e8jbKRF4nPEvOq1zg/pFcO/wy7/oNdKYBdvC2DPT7WY2Q80BNQVFk9HpLC1WPn9JC+SHJBrXA8gciJCcC4emEQ==
   dependencies:
-    ses "^0.15.9"
+    ses "^0.15.11"
 
-"@endo/static-module-record@^0.6.14", "@endo/static-module-record@^0.6.6":
+"@endo/static-module-record@^0.6.6":
   version "0.6.14"
   resolved "https://registry.yarnpkg.com/@endo/static-module-record/-/static-module-record-0.6.14.tgz#6d172cac9fbcb0d8bd0d667cd5f27ad26a023d19"
   integrity sha512-E5ldjB2/Ma8fZ4CELeaNorJk1A3AksMnTovPFBs8JtcwZoFCmOq04I1X7M9jQ9SDUOryyYReiAtYp730kZozTA==
@@ -1445,10 +1453,21 @@
     recast agoric-labs/recast#Agoric-built
     ses "^0.15.9"
 
-"@endo/zip@^0.2.11", "@endo/zip@^0.2.19":
-  version "0.2.19"
-  resolved "https://registry.yarnpkg.com/@endo/zip/-/zip-0.2.19.tgz#0726e65a119227eac1cfa676f3ea39e8ae7bdf55"
-  integrity sha512-frZvtSvHxNw4Wd5LQYMWuWWlhofrDRK3nNkvuzRyGI9WGpUGNOsZybNQO0q2sLMC+rKA6uhgNZL7foEcxyXhaA==
+"@endo/static-module-record@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@endo/static-module-record/-/static-module-record-0.7.0.tgz#90ad6a85fcd8ab20c1ccb70cece5ea6f7120108a"
+  integrity sha512-A8X7Sdzy4MlJ3IJh9MM63ZKcESlP65rbYyjPNvoB5ja6IJmYF73ktGWywe5OoJZU8N7VJkgmgypby5kSxZs0uA==
+  dependencies:
+    "@agoric/babel-generator" "^7.17.6"
+    "@babel/parser" "^7.17.3"
+    "@babel/traverse" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    ses "^0.15.11"
+
+"@endo/zip@^0.2.11", "@endo/zip@^0.2.21":
+  version "0.2.21"
+  resolved "https://registry.yarnpkg.com/@endo/zip/-/zip-0.2.21.tgz#98ac48439ebb8bb146b7c4488633d975a42fda2d"
+  integrity sha512-YtvksxnEAQjh+7IrwZS87n5oNiY5tv2W9W56AOCBAazlG+yPmwITVm8zQYuXlc3P1Nl2BqKzC4Xw4SfbbCtzzw==
 
 "@es-joy/jsdoccomment@^0.8.0-alpha.2":
   version "0.8.0-alpha.2"
@@ -3048,7 +3067,7 @@ bytes@3.1.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
-c8@^7.7.2, c8@^7.7.3:
+c8@^7.7.2:
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/c8/-/c8-7.11.0.tgz#b3ab4e9e03295a102c47ce11d4ef6d735d9a9ac9"
   integrity sha512-XqPyj1uvlHMr+Y1IeRndC2X5P7iJzJlEJwBpCdBbq2JocXOgJfr+JVfJkyNMGROke5LfKrhSFXGFXnwnRJAUJw==
@@ -6059,7 +6078,7 @@ is-color-stop@^1.0.0:
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
 
-is-core-module@^2.2.0, is-core-module@^2.4.0, is-core-module@^2.8.0:
+is-core-module@^2.4.0, is-core-module@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
   integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
@@ -7835,7 +7854,7 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6, path-parse@^1.0.7:
+path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -8618,7 +8637,7 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
-"recast@github:agoric-labs/recast#Agoric-built":
+recast@agoric-labs/recast#Agoric-built:
   version "0.20.5"
   resolved "https://codeload.github.com/agoric-labs/recast/tar.gz/879398a55cd50a53ade179de203706a25c53fb49"
   dependencies:
@@ -9109,10 +9128,10 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
-ses@^0.15.1, ses@^0.15.9:
-  version "0.15.9"
-  resolved "https://registry.yarnpkg.com/ses/-/ses-0.15.9.tgz#0dab638298a6af5e910c44c8a3700e596e9e3ac5"
-  integrity sha512-OgNR4u9csFywovs10qq9qwy/TTldS3m8K/y6xHavLbuEJOnHYFD62Jf1fVbR1VgtTYnlYjQd8nyBASFSjSkvpA==
+ses@^0.15.1, ses@^0.15.11, ses@^0.15.9:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/ses/-/ses-0.15.11.tgz#851cb6a20d8967537075d25bb0185051c28c23db"
+  integrity sha512-lQg6q8/PVf+n18EjP+5Uv1tN9oVQ3br5QxJzPXoAVQleSYnlf20JY9coe7n1B9A6CtIKIHyr6m/TfskcRCufgA==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- refactor: Remove the now-superfluous babel-standalone
- chore: Update yarn.lock

I have run `yarn-deduplicate` here since there was certainly some nonsensical duplication of compatible semver range packages, but there remain some duplicates because of skew between the most recent Endo and Agoric SDK releases, that I assume will settle when an Agoric SDK release goes up with the latest Endo dependencies.

Refs https://github.com/Agoric/agoric-sdk/issues/4785