### PR TITLE
fix: Clean up the glossary

### DIFF
--- a/main/getting-started/before-using-agoric.md
+++ b/main/getting-started/before-using-agoric.md
@@ -38,7 +38,7 @@ though a few details are out of date:
 The Agoric SDK is supported on
 <a href="https://en.wikipedia.org/wiki/Linux">Linux</a>,
 <a href="https://www.apple.com/macos/">MacOS</a>, or
-<a href="https://docs.microsoft.com/en-us/windows/wsl/">Windows Subsystem for Linux (wsl).</a>
+<a href="https://docs.microsoft.com/en-us/windows/wsl/">Windows Subsystem for Linux (WSL).</a>
 
  - To open a terminal on Macs, see **Applications>Utilities>terminal** in the **Finder**.
  - To launch a bash shell at a specific folder on Windows 10:

--- a/main/getting-started/intro-zoe.md
+++ b/main/getting-started/intro-zoe.md
@@ -119,11 +119,10 @@ code directly by calling:
 
 <<< @/snippets/test-intro-zoe.js#inspectCode
 
-In many cases, the bundled source is a single reviewable string.
-In others, the bundle contains to base 64 encoded zip file that you can
-extract for review.
-```
-jq -r .endoZipBase64 bundle.json | base64 -d > bundle.zip
+In most cases, the bundle contains a base64-encoded zip file that you can
+extract for review:
+```sh
+echo "$endoZipBase64" | base64 -d > bundle.zip
 unzip bundle.zip
 ```
 

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -40,9 +40,9 @@ five tickets is performed by combining arrays rather than by arithmetic.
 `AmountMath` has a single set of polymorphic methods that deal with two different asset kinds:
 - `AssetKind.NAT`: Used with [fungible](#fungible) assets. Each amount value is a natural number (non-negative integer). This is the default `AssetKind`.
 - `AssetKind.SET`: Used with [non-fungible](#non-fungible) assets. Each amount value is an
-  array of comparable values (strings, numbers, objects, etc.).
-  Values should never include promises (they aren't comparable), or
-  data that should not be shared freely such as payments and purses.
+  array of [comparable](#comparable) values (strings, numbers, objects, etc.).
+  Values cannot include promises (they aren't comparable), and should not
+  include privileged objects such as payments and purses.
 
 For more information, see the [ERTP Guide's AmountMath section](/ertp/guide/amount-math.md)
 and the [ERTP API's AmountMath section](/ertp/api/amount-math.md).
@@ -121,13 +121,12 @@ Destroy all digital assets in a payment. See [`issuer.burn(payment, optAmount)`]
 
 ## Comparable
 
-A *passable* is something that can be marshalled. A *comparable* is a
-passable whose leaves contain no promises. Two comparables can be
-synchronously compared for structural equivalence.
+A *passable* is something that can be marshalled (see the
+[Marshaling section in the JavaScript Distributed Programming Guide](/guides/js-programming/far.md#marshaling-by-copy-or-by-presence)).
 
-A comparable is a JavaScript object containing no promises, and can
-thus be locally compared for equality with another object. If either object
-contains Promises, equality is indeterminable. If both are fulfilled down
+A *comparable* is a passable containing no promises or errors, and can
+thus be synchronously compared for structural equivalence with another object. If either object
+contains promises and/or errors, equality is indeterminable. If both are fulfilled down
 to Presences and local state, then either they're the same all the way
 down, or they represent different objects.
 

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -36,8 +36,8 @@ disappear from the total allocation.
 ## AmountMath
 
 The AmountMath library executes the logic of how [amounts](#amount) are changed when digital assets are merged, separated,
-or otherwise manipulated. For example, a deposit of 2 [Quatloos](#quatloos) into a purse that already has 3 Quatloos
-gives a new balance of 5 Quatloos. But a deposit of a non-fungible theater ticket into a purse that already holds
+or otherwise manipulated. For example, a deposit of 3 [Quatloos](#quatloos) into a purse that already has 7 Quatloos
+updates its balance to 10 Quatloos. But a deposit of a non-fungible theater ticket into a purse that already holds
 five tickets is performed by set union rather than by arithmetic.
 
 `AmountMath` has a single set of polymorphic methods that deal with different asset kinds:

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -382,8 +382,8 @@ See [`E(Zoe).offer(invitation, proposal, paymentKeywordRecord, offerArgs)`](/zoe
 ## Offer Safety
 
 Zoe guarantees offer safety. When a user makes an [offer](#offer) and its payments are [escrowed](#escrow) with Zoe, Zoe guarantees that
-the user either gets what they said they wanted, or gets back (gets a refund) what they originally offered and
-escrowed. One reason this is possible is if a [proposal](#proposal) doesn't match what the contract expects to do, it
+the user either gets what they said they wanted, or gets back what they originally offered and
+escrowed (i.e., a refund). One reason this is possible is if a [proposal](#proposal) doesn't match what the contract expects to do, it
 can immediately cause the [seat](#seat) to exit, getting back the amount it offered.
 
 ## Payment
@@ -425,8 +425,8 @@ const myProposal = harden({
   exit: { onDemand: null }
 })
 ```
-`give` and `want` use [keywords](#keywords) defined by the contract. Each specifies via an [amount](#amounts), a description of what
-asset they are willing to give/want to get, and how much of it.
+`give` and `want` use [keywords](#keywords) defined by the contract. Each specifies via an [amount](#amounts) a description of what
+they are willing to give or want to get.
 
 ## Purse
 A purse holds [amounts](#amounts) of assets issued by a particular [mint](#mint) that are all of the same [brand](#brand) and generally _stationary_.
@@ -459,7 +459,7 @@ the [UserSeat documentation](/zoe/api/zoe.md#userseat-object).
 
 ## SES
 
-We have renamed SES to [Hardened JavaScript](#hardened-javascript-ses).
+Secure ECMAScript has been renamed to [Hardened JavaScript](#hardened-javascript-ses).
 
 ## Simoleons
 An imaginary currency Agoric documentation uses in examples.
@@ -476,11 +476,11 @@ it set at $10. They can specify the instance's minimum bid amount in its terms.
 
 Values are the part of an [amount](#amounts) that describe the value of something
 that can be owned or shared: How much, how many, or a description of a unique asset, such as
-Pixel(3,2), $3, or 'Seat J12 for the show September 27th at 9:00pm'.
+Pixel(3,2), $3, or “Seat J12 for the show September 27th at 9:00pm”.
 [Fungible](#fungible) values are usually
 represented by natural numbers. Other values may be represented as strings naming a particular
 rights, or an array of arbitrary objects representing the rights at issue. The latter two examples
-are usually [non-fungible](#non-fungible) assets. Values must be [Comparable](#comparable).
+are usually [non-fungible](#non-fungible) assets. Values must be [comparable](#comparable).
 
 For more information, see the [ERTP Guide's Value section](/ertp/guide/amounts.md#values).
 
@@ -494,7 +494,7 @@ For more information, see the [Vat section in the Distributed JS Programming Gui
 ## Wallet
 
 The overall place a party keeps their assets of all brands. For example, your wallet might contain 5 Quatloos
-[purses](#purse), 8 Moola purses, and 2 Simoleons purses. A wallet can distinguish between [Issuers](#issuer).
+[purses](#purse), 8 Moola purses, and 2 Simoleons purses. A wallet can distinguish between [issuers](#issuer).
 Dapps can propose [offers](#offer) to a wallet. If a user accepts the offer proposal,
 the wallet makes an offer on the user's behalf and deposits the [payout](#payout) in the user's [purses](#purse).
 See the [Wallet Guide and API](/guides/wallet/).

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -120,14 +120,11 @@ Destroy all digital assets in a payment, for example as part of consuming it in 
 
 ## Comparable
 
-A *passable* is something that can be marshalled (see the
-[Marshaling section in the JavaScript Distributed Programming Guide](/guides/js-programming/far.md#marshaling-by-copy-or-by-presence)).
-
-A *comparable* is a passable containing no promises or errors, and can
-thus be synchronously compared for structural equivalence with another object. If either object
-contains promises and/or errors, equality is indeterminable. If both are fulfilled down
-to Presences and local state, then either they're the same all the way
-down, or they represent different objects.
+A *comparable* is a [passable](#passable) containing no promises or errors, and can
+thus be synchronously compared for structural equivalence with another piece of data.
+If either side of the comparison contains promises and/or errors, equality is indeterminable.
+If both are fulfilled down to [presences](#presence) and local state, then either they're the
+same all the way down, or they represent different objects.
 
 ## Contract and Contract Instance
 In Agoric documentation, *contract* usually refers to a contract's source code that
@@ -384,6 +381,11 @@ Zoe guarantees offer safety. When a user makes an [offer](#offer) and its paymen
 the user either gets what they said they wanted, or gets back what they originally offered and
 escrowed (a refund). One reason this is possible is if a [proposal](#proposal) doesn't match what the contract expects to do, it
 can immediately cause the [seat](#seat) to exit, getting back the amount it offered.
+
+## Passable
+
+A *passable* is something that can be marshalled (see the
+[Marshaling section in the JavaScript Distributed Programming Guide](/guides/js-programming/far.md#marshaling-by-copy-or-by-presence)).
 
 ## Payment
 

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -160,7 +160,7 @@ See [here](https://github.com/Agoric/agoric-sdk/blob/master/packages/SwingSet/do
 ## E()
 
 (Also referred to as *eventual send*) `E()` is a local "bridge" function that invokes methods on remote objects, for example
-in another vat, machine, or blockchain. It takes a local representative (a proxy) for a remote object as an argument and
+in another vat, machine, or blockchain. It takes a local representative (a [presence](#presence)) for a remote object as an argument and
 sends messages to it using normal message-sending syntax. The local proxy forwards all messages to the remote object to deal with.
 All `E()` calls return a promise for the eventual returned value. For more detail, see
 the [`E()` section in the Distributed JavaScript page](/guides/js-programming/eventual-send.md).
@@ -272,7 +272,7 @@ the invitation is a [`Payment`](#payment), and so is associated with a specific 
 
 To participate in a contract instance by making an [offer](#offer), an invitation to that instance must accompany the offer.
 
-An `invitation`'s amount includes the following properties:
+An invitation's [amount](#amounts) includes the following properties:
 - The contract's installation in Zoe, including access to its source code.
 - The contract instance this invitation is for.
 - A handle used to refer to this invitation.
@@ -453,7 +453,7 @@ current allocation as a [payout](#payout).
 
 Zoe uses a seat to represent an [offer](#offer) in progress, and has two seat [facets](#facet) representing
 two views of the same seat; a `ZCFSeat` and a `UserSeat`. The `UserSeat` is returned to the user who made an
-offer, and can check payouts' status or retrieve their results. The `ZCFSeat` is the argument passed to
+offer, and can check [payout](#payout) status or retrieve their results. The `ZCFSeat` is the argument passed to
 the `offerHandler` in the contract code. It is used within contracts and with [`zcf` methods](/zoe/api/zoe-contract-facet.md).
 
 The two seat facets have slightly different methods but represent the same seat and offer in progress.

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -97,7 +97,7 @@ and the [ERTP API's Brand section](/ertp/api/brand.md).
 ## Bundle
 
 Before a contract can be installed on Zoe, its source code must be bundled. This is done by:
-```
+```js
 import bundleSource from '@endo/bundle-source';
 const atomicSwapBundle = await bundleSource(
     require.resolve('@agoric/zoe/src/contracts/atomicSwap'),
@@ -109,8 +109,8 @@ code via `const { source } = await E(installation).getBundle();`.
 In many cases, the bundled source is a single reviewable string.
 In others, the bundle contains a base64-encoded zip file that you can
 extract for review.
-```
-jq -r .endoZipBase64 bundle.json | base64 -d > bundle.zip
+```sh
+echo "$bundle_source" | base64 -d > bundle.zip
 unzip bundle.zip
 ```
 
@@ -423,7 +423,7 @@ For more information, see the [JavaScript Distributed Programming Guide](/guides
 Proposals are records with `give`, `want`, and `exit` keys. [Offers](#offer) must include a proposal, which states
 what asset you want, what asset you will give for it, and how/when the offer maker can cancel the offer
 (see [Exit Rule](#exit-rule) for details on the last). For example:
-```
+```js
 const myProposal = harden({
   give: { Asset: AmountMath.make(quatloosBrand, 4)},
   want: { Price: AmountMath.make(moolaBrand, 15) },

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -20,7 +20,7 @@ The AllegedName must be a string.
 
 ## Allocation
 
-Allocations represent the [amounts](#amounts) to be paid out to each [seat](#seat) on exit from a contract instance. Possible
+Allocations represent the [amounts](#amount) to be paid out to each [seat](#seat) on exit from a contract instance. Possible
 exit causes are exercising an exit condition, the contract's explicit choice, or a crash or freeze. There are several methods
 for getting the amounts currently allocated.
 
@@ -35,7 +35,7 @@ disappear from the total allocation.
 
 ## AmountMath
 
-The AmountMath library executes the logic of how [amounts](#amounts) are changed when digital assets are merged, separated,
+The AmountMath library executes the logic of how [amounts](#amount) are changed when digital assets are merged, separated,
 or otherwise manipulated. For example, a deposit of 2 [Quatloos](#quatloos) into a purse that already has 3 Quatloos
 gives a new balance of 5 Quatloos. But a deposit of a non-fungible theater ticket into a purse that already holds
 five tickets is performed by set union rather than by arithmetic.
@@ -61,9 +61,9 @@ five tickets is performed by set union rather than by arithmetic.
 For more information, see the [ERTP Guide's AmountMath section](/ertp/guide/amount-math.md)
 and the [ERTP API's AmountMath section](/ertp/api/amount-math.md).
 
-## Amounts
+## Amount
 
-Amounts are the canonical description of tradable goods. They are manipulated
+Amounts are the canonical descriptions of tradable goods. They are manipulated
 by [issuers](#issuer) and [mints](#mint), and represent the goods and currency carried by
 [purses](#purse) and [payments](#payment). They represent things like currency, stock, and the
 abstract right to participate in a particular exchange.
@@ -84,7 +84,7 @@ and the [ERTP API's AmountMath section](/ertp/api/amount-math.md).
 ## AssetHolder
 
 [Purses](#purse) and [payments](#payment) are AssetHolders. These are objects that contain
-digital assets in the quantity specified by an [amount](#amounts).
+digital assets in the quantity specified by an [amount](#amount).
 
 ## BigInt
 
@@ -110,7 +110,7 @@ appropriate for an object, do not use the board to communicate access to it.
 
 Identifies the kind of [issuer](#issuer), such as "[Quatloos](#quatloos)",
 "[Moola](#moola)", etc. Brands are one of the two elements that
-make up an [amount](#amounts).
+make up an [amount](#amount).
 For more information, see the [ERTP Guide's Brand section](/ertp/guide/amounts.md)
 and the [ERTP API's Brand section](/ertp/api/brand.md).
 
@@ -212,7 +212,7 @@ reference to an object, it can call methods on that object. If it doesn't
 have a reference, it can't. For more on object capabilities, see [this post](http://habitatchronicles.com/2017/05/what-are-capabilities/).
 
 Key ERTP concepts include [Issuers](#issuer), [Mints](#mint),
-[Purses](#purse), [Payments](#payment), [Brands](#brand), and [Amounts](#amounts). Also
+[Purses](#purse), [Payments](#payment), [Brands](#brand), and [Amounts](#amount). Also
 see the [ERTP Introduction](/getting-started/ertp-introduction.md),
 [ERTP Guide](/ertp/guide/), and [ERTP API](/ertp/api/).
 
@@ -289,7 +289,7 @@ Contracts often return a creator invitation on their instantiation, in case the 
 to immediately participate. Otherwise, the contract instance must create any additional invitations.
 Every [offer](#offer) to participate in a contract instance must include an invitation to that instance in the first argument to [`E(Zoe).offer()`](/zoe/api/zoe.md#e-zoe-offer-invitation-proposal-paymentkeywordrecord-offerargs), and any wallet receiving one will validate it via the [InvitationIssuer](#invitationissuer).
 
-An invitation's [amount](#amounts) includes the following properties:
+An invitation's [amount](#amount) includes the following properties:
 - The contract's installation in Zoe, including access to its source code.
 - The contract instance this invitation is for.
 - A handle used to refer to this invitation.
@@ -316,7 +316,7 @@ with one and only one asset type, such as only working with [Quatloos](#quatloos
 or only working with [Moola](#moola). This association cannot change to another type.
 
 Issuers can create empty [purses](#purse) for
-their asset type, but cannot mint new [amounts](#amounts). Issuers can also transform
+their asset type, but cannot mint new [amounts](#amount). Issuers can also transform
 payments of their asset type (splitting, combining, burning, and exclusively claiming
 payments). An issuer from a trusted source can determine if an untrusted payment of
 its asset type is valid.
@@ -467,12 +467,12 @@ const myProposal = harden({
   exit: { onDemand: null }
 })
 ```
-`give` and `want` use [keywords](#keyword) defined by the contract. Each specifies via an [amount](#amounts) a description of what
+`give` and `want` use [keywords](#keyword) defined by the contract. Each specifies via an [amount](#amount) a description of what
 they are willing to give or want to get.
 
 ## Purse
 
-A purse holds [amounts](#amounts) of assets issued by a particular [mint](#mint) that are all of the same [brand](#brand), often for arbitrarily long periods of time.
+A purse holds [amounts](#amount) of assets issued by a particular [mint](#mint) that are all of the same [brand](#brand), often for arbitrarily long periods of time.
 When transfer is desired, a purse can move part of its held balance to a [payment](#payment).
 
 For more information, see the [ERTP Guide's Purses section](/ertp/guide/purses-and-payments.md#purses-and-payments) and the
@@ -485,7 +485,7 @@ episode [The Gamesters of Triskelion](https://en.wikipedia.org/wiki/The_Gamester
 
 ## Reallocation
 
-A transfer of [amounts](#amounts) between [seats](#seat) within Zoe; i.e. a change in their [allocations](#allocation). When a seat exits, it gets its
+A transfer of [amounts](#amount) between [seats](#seat) within Zoe; i.e. a change in their [allocations](#allocation). When a seat exits, it gets its
 current allocation as a [payout](#payout).
 
 ## Seat
@@ -530,7 +530,7 @@ it set at $10. They can specify the instance's minimum bid amount in its terms.
 
 ## Value
 
-Values are the part of an [amount](#amounts) that describe the value of something
+Values are the part of an [amount](#amount) that describe the value of something
 that can be owned or shared: How much, how many, or a description of a unique asset, such as
 Pixel(3,2), $3, or “Seat J12 for the show September 27th at 9:00pm”.
 [Fungible](#fungible) values are usually represented by natural numbers.

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -105,19 +105,18 @@ const atomicSwapBundle = await bundleSource(
 ```
 The installation operation returns
 an `installation`, which is an object with one method; `getBundle()`. You can access an installed contract's source
-code via `const { source } = await E(installation).getBundle();`.
-In many cases, the bundled source is a single reviewable string.
-In others, the bundle contains a base64-encoded zip file that you can
-extract for review.
+code via `const { endoZipBase64 } = await E(installation).getBundle();`.
+In most cases, the bundle contains a base64-encoded zip file that you can
+extract for review:
 ```sh
-echo "$bundle_source" | base64 -d > bundle.zip
+echo "$endoZipBase64" | base64 -d > bundle.zip
 unzip bundle.zip
 ```
 
 
 ## Burn
 
-Destroy all digital assets in a payment, e.g. as part of consuming it in an exchange. See [`issuer.burn(payment, optAmount)`](/ertp/api/issuer.md#issuer-burn-payment-optamount).
+Destroy all digital assets in a payment, for example as part of consuming it in an exchange. See [`issuer.burn(payment, optAmount)`](/ertp/api/issuer.md#issuer-burn-payment-optamount).
 
 ## Comparable
 
@@ -383,7 +382,7 @@ See [`E(Zoe).offer(invitation, proposal, paymentKeywordRecord, offerArgs)`](/zoe
 
 Zoe guarantees offer safety. When a user makes an [offer](#offer) and its payments are [escrowed](#escrow) with Zoe, Zoe guarantees that
 the user either gets what they said they wanted, or gets back what they originally offered and
-escrowed (i.e., a refund). One reason this is possible is if a [proposal](#proposal) doesn't match what the contract expects to do, it
+escrowed (a refund). One reason this is possible is if a [proposal](#proposal) doesn't match what the contract expects to do, it
 can immediately cause the [seat](#seat) to exit, getting back the amount it offered.
 
 ## Payment

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -6,10 +6,12 @@ sidebar: auto
 This page lists words, expressions, or concepts used by the Agoric technology stack.
 
 ## Agoric CLI
+
 A command line interface for installing dependencies and initializing, deploying, and starting Agoric projects.
 See the [Agoric CLI Guide](/guides/agoric-cli/).
 
 ## AllegedName
+
 Human-readable name of a kind of rights. The alleged name should
 not be trusted as an accurate depiction, since it is provided by
 the maker of the mint and could be deceptive, but is useful for debugging and double-checking.
@@ -32,6 +34,7 @@ assign assets that weren't already in some allocation and it can't assign them t
 disappear from the total allocation.
 
 ## AmountMath
+
 The AmountMath library executes the logic of how [amounts](#amounts) are changed when digital assets are merged, separated,
 or otherwise manipulated. For example, a deposit of 2 [Quatloos](#quatloos) into a purse that already has 3 Quatloos
 gives a new balance of 5 Quatloos. But a deposit of a non-fungible theater ticket into a purse that already holds
@@ -59,6 +62,7 @@ For more information, see the [ERTP Guide's AmountMath section](/ertp/guide/amou
 and the [ERTP API's AmountMath section](/ertp/api/amount-math.md).
 
 ## Amounts
+
 Amounts are the canonical description of tradable goods. They are manipulated
 by [issuers](#issuer) and [mints](#mint), and represent the goods and currency carried by
 [purses](#purse) and [payments](#payment). They represent things like currency, stock, and the
@@ -78,6 +82,7 @@ For more information, see the [ERTP Guide's Amounts section](/ertp/guide/amounts
 and the [ERTP API's AmountMath section](/ertp/api/amount-math.md).
 
 ## AssetHolder
+
 [Purses](#purse) and [payments](#payment) are AssetHolders. These are objects that contain
 digital assets in the quantity specified by an [amount](#amounts).
 
@@ -99,6 +104,7 @@ communication method&mdash;a DM or email or other private message, a phone call/
 an email blast to a mailing list, publishing it on a website, etc.
 
 ## Brand
+
 Identifies the kind of [issuer](#issuer), such as "[Quatloos](#quatloos)",
 "[Moola](#moola)", etc. Brands are one of the two elements that
 make up an [amount](#amounts).
@@ -124,7 +130,6 @@ echo "$endoZipBase64" | base64 -d > bundle.zip
 unzip bundle.zip
 ```
 
-
 ## Burn
 
 Destroy all digital assets in a payment, for example as part of consuming it in an exchange. See [`issuer.burn(payment, optAmount)`](/ertp/api/issuer.md#issuer-burn-payment-optamount).
@@ -134,6 +139,7 @@ Destroy all digital assets in a payment, for example as part of consuming it in 
 Comparable is a deprecated synonym of [key](#key).
 
 ## Contract Installation and Contract Instance
+
 In Agoric documentation, *contract* usually refers to a contract's source code that
 defines how the contract works. A contract's source code is *installed* on Zoe. A
 contract is *instantiated* to create *contract instances*, which are the active
@@ -239,17 +245,20 @@ Two Agoric uses are:
 - *Public Facet*: A set of methods and properties for an object that a developer chooses to be publicly visible and usable.
 
 ## Fungible
+
 A fungible asset is one where all exemplars of the asset are interchangeable. For example, if you
 have 100 one dollar bills and need to pay someone five dollars, it does not matter which
 five one dollar bills you use. Also see [non-fungible](#non-fungible).
 
 ## Handle
+
 A handle is a unique identifier implemented as a JavaScript object. Only its identity
 is meaningful, so handles do not have properties. Unlike number or string identifiers,
 handles are unforgeable. This means the only way to know a handle identity is being given
 an object reference, and no identity can be guessed and no fake identity will succeed.
 
 ## Harden
+
 A hardened object’s properties cannot be changed, so the only way to interact with a hardened object is through its methods.
 `harden()` is similar to `Object.freeze()` but more powerful. For more about `harden()`, see
 its [section in the JavaScript Distributed Programming Guide](https://github.com/endojs/endo/blob/master/packages/ses/docs/guide.md)
@@ -264,10 +273,12 @@ See the [Endo and Hardened JavaScript Programming
 Guide](https://github.com/endojs/endo/blob/master/packages/ses/docs/guide.md) for more details.
 
 ## IBC
+
 The Inter-Blockchain Communication protocol, used by blockchains to communicate with each other. A short article about IBC
 is available [here](https://www.computerweekly.com/blog/Open-Source-Insider/What-developers-need-to-know-about-inter-blockchain-communication).
 
 ## Invitation
+
 A [payment](#payment) whose amount represents (and is required for) participation in a contract instance.
 Contracts often return a creator invitation on their instantiation, in case the contract instantiator wants
 to immediately participate. Otherwise, the contract instance must create any additional invitations.
@@ -294,6 +305,7 @@ the invitation. A successful claim also means that invitation is exclusively you
 what the [wallet](#wallet) does.
 
 ## Issuer
+
 Issuers are a one-to-one relationship with both a [mint](#mint) and a [brand](#brand), so each issuer works
 with one and only one asset type, such as only working with [Quatloos](#quatloos)
 or only working with [Moola](#moola). This association cannot change to another type.
@@ -347,9 +359,11 @@ and the [ERTP API's Mint section](/ertp/api/mint.md). For more information about
 see the [ZCF API `zcf.makeZCFMint()`](/zoe/api/zoe-contract-facet.md#zcf-makezcfmint-keyword-assetkind-displayinfo).
 
 ## Moola
+
 An imaginary currency Agoric documentation uses in examples.
 
 ## Non-fungible
+
 A non-fungible asset is one where each incidence of the asset has unique individual properties and
 is not interchangeable with another incidence. For example, if your asset is theater tickets, it matters to the buyer
 what the date and time of the show is, which row the seat is in, and where in the row the
@@ -413,6 +427,7 @@ For more information, see the [ERTP Guide's Payments section](/ertp/guide/purses
 and the [ERTP API's Payments section](/ertp/api/payment.md).
 
 ## Payout
+
 The assets paid out to a user when an [seat](#seat) exits, either successfully or not. The payout is always
 what the seat's current [allocation](#allocation) is.
 
@@ -427,6 +442,7 @@ someone, but to more easily tell who a number is associated with, it's assigned 
 as Mom, Grandpa, Kate S., etc. In the Agoric platform, petnames are used in [wallets](#wallet).
 
 ## Presence
+
 A local version of a remote object that serves as the remote object's proxy.
 If `obj` is a presence of a remote object, you can send messages to the remote object by using `E()` on `obj`.
 For more information, see the [JavaScript Distributed Programming Guide](/guides/js-programming/).
@@ -447,6 +463,7 @@ const myProposal = harden({
 they are willing to give or want to get.
 
 ## Purse
+
 A purse holds [amounts](#amounts) of assets issued by a particular [mint](#mint) that are all of the same [brand](#brand) and generally _stationary_.
 When transfer is desired, a purse can move part of its held balance to a [payment](#payment).
 
@@ -454,6 +471,7 @@ For more information, see the [ERTP Guide's Purses section](/ertp/guide/purses-a
 [ERTP API's Purses section](/ertp/api/purse.md).
 
 ## Quatloos
+
 An imaginary currency Agoric documentation uses in examples. For its origins, see the Wikipedia entry for the Star Trek
 episode [The Gamesters of Triskelion](https://en.wikipedia.org/wiki/The_Gamesters_of_Triskelion).
 
@@ -480,9 +498,11 @@ the [UserSeat documentation](/zoe/api/zoe.md#userseat-object).
 Secure ECMAScript has been renamed to [Hardened JavaScript](#hardened-javascript-ses).
 
 ## Simoleons
+
 An imaginary currency Agoric documentation uses in examples.
 
 ## Terms
+
 Contract instances have associated terms, gotten via [`E(zoe).getTerms(instance)`](/zoe/api/zoe.md#e-zoe-getterms-instance),
 which include the instance's associated [issuers](#issuer), [brands](#brand), and any custom terms. For
 example, you might have a general auction contract. When someone instantiates it,
@@ -503,6 +523,7 @@ are usually [non-fungible](#non-fungible) assets. Values must be [keys](#key).
 For more information, see the [ERTP Guide's Value section](/ertp/guide/amounts.md#values).
 
 ## Vat
+
 A vat is a unit of isolation.
 Objects and functions in a JavaScript vat can communicate synchronously with one another. Vats and their contents can
 communicate with other vats and their objects and functions, but can only communicate asynchronously.
@@ -518,6 +539,7 @@ the wallet makes an offer on the user's behalf and deposits the [payout](#payout
 See the [Wallet Guide and API](/guides/wallet/).
 
 ## ZCF
+
 *ZCF (Zoe Contract Facet)* is the [facet](#facet) of Zoe exposed to contract code. The Zoe
 Contract Facet methods can be called synchronously by contract code.
 

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -318,13 +318,13 @@ They interact with Purses, Payments, Brands, and Issuers in the same ways.
   Access to an ERTP mint gives you the power to create more digital assets of its type at will. Mints
   can only create one type of asset and cannot change to create a different type.
 
-  ERTP mints are [issuer's](#issuer) admin [facets](#facet), and there is a one-to-one relationship between an issuer and
-  its mint. ERTP mints are also in a one-to-one relationship with that issuer's associated [brand](#brand).
+  There is a one-to-one relationship between an [issuer](#issuer) and its mint, and a mint is an administrative [facet](#facet) of its issuer.
+  ERTP mints are also in a one-to-one relationship with that issuer's associated [brand](#brand).
 
 - ZCFMints give contract code a simpler interface to interact with an ERTP mint. Because ZCFMints encapsulate
   an internal ERTP mint, they have the same one-to-one relationships
   with an issuer and its associated brand. A ZCFMint can mint assets and assign them to a seat without having to escrow
-  payments, and burn assets that used to be associated with a seat without having to payout assets.
+  payments, and burn seat-associated assets without corresponding payout.
 
 ZCFMints and ERTP mints do **not** have the same methods. Do not try to use ERTP methods on a ZCFMint or vice versa.
 However, issuers and brands associated with either an ERTP mint or a ZCFMint are the same concepts and have the same methods.

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -46,16 +46,16 @@ five tickets is performed by set union rather than by arithmetic.
   This is the default `AssetKind`.
 - `AssetKind.SET`: Used with [non-fungible](#non-fungible) assets;
   deprecated in favor of `AssetKind.COPY_SET` but still in wide use.
-  Each amount value is an array of [key](#key) values
+  Each amount value is an array of [Key](#key) values
   subject to the same constraints as those of `AssetKind.COPY_SET`.
 - `AssetKind.COPY_SET`: Used with [non-fungible](#non-fungible) assets.
-  Each amount value is a set of [key](#key) values
+  Each amount value is a set of [Key](#key) values
   (strings, numbers, objects, etc.).
   Values cannot include promises (they aren't keys), and should not
   include privileged objects such as payments and purses.
 - `AssetKind.COPY_BAG`: Used with [semi-fungible](#semi-fungible) assets.
   Each amount value is a [multiset](https://en.wikipedia.org/wiki/Multiset)
-  of [key](#key) values subject to the same constraints as
+  of [Key](#key) values subject to the same constraints as
   those of `AssetKind.COPY_SET` but allowed to be present more than once.
 
 For more information, see the [ERTP Guide's AmountMath section](/ertp/guide/amount-math.md)
@@ -141,7 +141,7 @@ Destroy all digital assets in a payment, for example as part of consuming it in 
 
 ## Comparable
 
-Comparable is a deprecated synonym of [key](#key).
+Comparable is a deprecated synonym of [Key](#key).
 
 ## Contract Installation and Contract Instance
 
@@ -175,8 +175,8 @@ See [here](https://github.com/Agoric/agoric-sdk/blob/master/packages/SwingSet/do
 
 (Also referred to as *eventual send*) `E()` is a local "bridge" function that
 asynchronously invokes methods on local or remote objects, for example those
-in another vat, machine, or blockchain. It takes a local object or a [presence](#presence)
-for a remote object as its argument and
+in another vat, machine, or blockchain. It takes as its argument either a local object
+or a [presence](#presence) for a remote object or a promise for a local or remote object, and
 sends messages to the object using normal message-sending syntax. The local proxy forwards all messages to the remote object to deal with.
 All `E()` calls return a promise for the eventual result. For more detail, see
 the [`E()` section in the Distributed JavaScript page](/guides/js-programming/eventual-send.md).
@@ -232,7 +232,7 @@ See [`E()`](#e) above.
 Part of an [offer](#offer) specifying how the offer can be cancelled/exited. There are three values:
 - `onDemand: null`: (Default) The offering party can cancel on demand.
 - `waived: null`: The offering party can't cancel and relies entirely on the smart contract to promptly finish their offer.
-- `afterDeadline: {…}`: The offer is automatically cancelled after a deadline, as determined by its `deadline` and `timer` properties.
+- `afterDeadline: {…}`: The offer is automatically cancelled after a deadline, as determined by its `timer` and `deadline` properties. See [Proposals and payments](/zoe/api/zoe.md#proposals-and-payments).
 
 ## Facet
 
@@ -287,7 +287,7 @@ is available [here](https://www.computerweekly.com/blog/Open-Source-Insider/What
 A [payment](#payment) whose amount represents (and is required for) participation in a contract instance.
 Contracts often return a creator invitation on their instantiation, in case the contract instantiator wants
 to immediately participate. Otherwise, the contract instance must create any additional invitations.
-Every [offer](#offer) to participate in a contract instance must include an invitation to that instance in its payment, and any wallet receiving one will validate it via the [InvitationIssuer](#invitationissuer).
+Every [offer](#offer) to participate in a contract instance must include an invitation to that instance in the first argument to [`E(Zoe).offer()`](/zoe/api/zoe.md#e-zoe-offer-invitation-proposal-paymentkeywordrecord-offerargs), and any wallet receiving one will validate it via the [InvitationIssuer](#invitationissuer).
 
 An invitation's [amount](#amounts) includes the following properties:
 - The contract's installation in Zoe, including access to its source code.
@@ -326,17 +326,19 @@ and the [ERTP API's Issuer section](/ertp/api/issuer.md).
 
 ## Key
 
-A *key* is a [passable](#passable) containing no promises or errors, and can
+A *Key* is a [passable](#passable) containing no promises or errors, and can
 thus be synchronously compared for structural equivalence with another piece of data.
 If either side of the comparison contains promises and/or errors, equality is indeterminable.
 If both are fulfilled down to [presences](#presence) and local state, then either they're the
 same all the way down, or they represent different objects.
 
-## Keywords
+Keys can be used as elements of CopySets and CopyBags and as keys of CopyMaps (see [AmountMath](#amountmath)). [Values](#value) must be Keys.
 
-Keywords are unique identifiers per contract. They tie together the [proposal](#proposal), [payments](#payment)
-to be [escrowed](#escrow), and [payouts](#payout) to the user by serving as keys for key-value pairs in various
-records with values of [amounts](#amounts), [issuers](#issuer), etc.
+## Keyword
+
+A keyword is a property name string that starts with an upper case letter and is a valid
+[identifier](https://developer.mozilla.org/en-US/docs/Glossary/Identifier).
+A KeywordRecord is a CopyRecord in which every property name is a keyword.
 
 ## Mint
 
@@ -351,8 +353,8 @@ They interact with Purses, Payments, Brands, and Issuers in the same ways.
   There is a one-to-one relationship between an [issuer](#issuer) and its mint, and a mint is an administrative [facet](#facet) of its issuer.
   ERTP mints are also in a one-to-one relationship with that issuer's associated [brand](#brand).
 
-- ZCFMints give contract code a simpler interface to interact with an ERTP mint. Because ZCFMints encapsulate
-  an internal ERTP mint, they have the same one-to-one relationships
+- ZCFMints give contract code a simpler interface to interact with an ERTP mint from inside a contract.
+  Because ZCFMints encapsulate an internal ERTP mint, they have the same one-to-one relationships
   with an issuer and its associated brand. A ZCFMint can mint assets and assign them to a seat without having to escrow
   payments, and burn seat-associated assets without corresponding payout.
 
@@ -421,7 +423,8 @@ can immediately cause the [seat](#seat) to exit, getting back the amount it offe
 ## Passable
 
 A *passable* is something that can be marshalled (see the
-[Marshaling section in the JavaScript Distributed Programming Guide](/guides/js-programming/far.md#marshaling-by-copy-or-by-presence)).
+[Marshaling section in the JavaScript Distributed Programming Guide](/guides/js-programming/far.md#marshaling-by-copy-or-by-presence))
+and sent to and from remote objects.
 
 ## Payment
 
@@ -454,7 +457,7 @@ For more information, see the [JavaScript Distributed Programming Guide](/guides
 
 ## Proposal
 
-Proposals are records with `give`, `want`, and `exit` keys. [Offers](#offer) must include a proposal, which states
+Proposals are records with `give`, `want`, and `exit` properties. [Offers](#offer) must include a proposal, which states
 what asset you want, what asset you will give for it, and how/when the offer maker can cancel the offer
 (see [Exit Rule](#exit-rule) for details on the last). For example:
 ```js
@@ -464,12 +467,12 @@ const myProposal = harden({
   exit: { onDemand: null }
 })
 ```
-`give` and `want` use [keywords](#keywords) defined by the contract. Each specifies via an [amount](#amounts) a description of what
+`give` and `want` use [keywords](#keyword) defined by the contract. Each specifies via an [amount](#amounts) a description of what
 they are willing to give or want to get.
 
 ## Purse
 
-A purse holds [amounts](#amounts) of assets issued by a particular [mint](#mint) that are all of the same [brand](#brand) and generally _stationary_.
+A purse holds [amounts](#amounts) of assets issued by a particular [mint](#mint) that are all of the same [brand](#brand), often for arbitrarily long periods of time.
 When transfer is desired, a purse can move part of its held balance to a [payment](#payment).
 
 For more information, see the [ERTP Guide's Purses section](/ertp/guide/purses-and-payments.md#purses-and-payments) and the
@@ -530,10 +533,10 @@ it set at $10. They can specify the instance's minimum bid amount in its terms.
 Values are the part of an [amount](#amounts) that describe the value of something
 that can be owned or shared: How much, how many, or a description of a unique asset, such as
 Pixel(3,2), $3, or “Seat J12 for the show September 27th at 9:00pm”.
-[Fungible](#fungible) values are usually
-represented by natural numbers. Other values may be represented as strings naming a particular
-rights, or an array of arbitrary objects representing the rights at issue. The latter two examples
-are usually [non-fungible](#non-fungible) assets. Values must be [keys](#key).
+[Fungible](#fungible) values are usually represented by natural numbers.
+Other values may be represented as a CopySet of strings naming particular rights or
+arbitrary objects representing the rights directly (usually [non-fungible](#non-fungible) assets).
+Values must be [Keys](#key).
 
 For more information, see the [ERTP Guide's Value section](/ertp/guide/amounts.md#values).
 

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -263,14 +263,10 @@ The Inter-Blockchain Communication protocol, used by blockchains to communicate 
 is available [here](https://www.computerweekly.com/blog/Open-Source-Insider/What-developers-need-to-know-about-inter-blockchain-communication).
 
 ## Invitation
-To participate in a contract instance, one must hold an invitation to do so. Contracts often
-return a creator invitation on their instantiation, in case the contract instantiator wants
+A [payment](#payment) whose amount represents (and is required for) participation in a contract instance.
+Contracts often return a creator invitation on their instantiation, in case the contract instantiator wants
 to immediately participate. Otherwise, the contract instance must create any additional invitations.
-These, or any invitation held by a party, are distributed by sending it to someone's wallet. When you receive
-an invitation, your wallet will validate it via the [InvitationIssuer](#invitationissuer). Note that
-the invitation is a [`Payment`](#payment), and so is associated with a specific [`Issuer`](#issuer).
-
-To participate in a contract instance by making an [offer](#offer), an invitation to that instance must accompany the offer.
+Every [offer](#offer) to participate in a contract instance must include an invitation to that instance in its payment, and any wallet receiving one will validate it via the [InvitationIssuer](#invitationissuer).
 
 An invitation's [amount](#amounts) includes the following properties:
 - The contract's installation in Zoe, including access to its source code.

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -123,11 +123,13 @@ const atomicSwapBundle = await bundleSource(
     require.resolve('@agoric/zoe/src/contracts/atomicSwap'),
 );
 ```
-The installation operation returns
-an `installation`, which is an object with one method; `getBundle()`. You can access an installed contract's source
-code via `const { endoZipBase64 } = await E(installation).getBundle();`.
+The installation operation returns an `installation`, which is an object with a single
+`getBundle()` method for accessing an installed contract's source code.
 In most cases, the bundle contains a base64-encoded zip file that you can
-extract for review:
+extract for review.
+```js
+const { endoZipBase64 } = await E(installation).getBundle();
+```
 ```sh
 echo "$endoZipBase64" | base64 -d > bundle.zip
 unzip bundle.zip

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -33,19 +33,16 @@ disappear from the total allocation.
 
 ## AmountMath
 The AmountMath library executes the logic of how [amounts](#amounts) are changed when digital assets are merged, separated,
-or otherwise manipulated. For example, a deposit of 2 bucks into a purse that already has 3 bucks
-gives a new balance of 5 bucks. But, a deposit of a non-fungible theater ticket into a purse that already holds
-five tickets isn't done by numeric addition. Instead, you have to combine two arrays, containing either
-strings or objects/records.
+or otherwise manipulated. For example, a deposit of 2 [Quatloos](#quatloos) into a purse that already has 3 Quatloos
+gives a new balance of 5 Quatloos. But a deposit of a non-fungible theater ticket into a purse that already holds
+five tickets is performed by combining arrays rather than by arithmetic.
 
-`AmountMath` has a single set of polymorphic
-methods of two different asset kinds to deal with [fungible](#fungible) assets (values are natural numbers) and
-[non-fungible](#non-fungible) assets (values are an array or object). The two `AssetKinds` are
-- `AssetKind.NAT`: Used with fungible assets. Amount values are natural numbers (non-negative integers). Default value.
-- `AssetKind.SET`: Used with non-fungible assets. Amount values are
-  arrays of strings, numbers, objects, or other comparable values.
+`AmountMath` has a single set of polymorphic methods that deal with two different asset kinds:
+- `AssetKind.NAT`: Used with [fungible](#fungible) assets. Each amount value is a natural number (non-negative integer). This is the default `AssetKind`.
+- `AssetKind.SET`: Used with [non-fungible](#non-fungible) assets. Each amount value is an
+  array of comparable values (strings, numbers, objects, etc.).
   Values should never include promises (they aren't comparable), or
-  payments, purses, and anything else that can't be shared freely.
+  data that should not be shared freely such as payments and purses.
 
 For more information, see the [ERTP Guide's AmountMath section](/ertp/guide/amount-math.md)
 and the [ERTP API's AmountMath section](/ertp/api/amount-math.md).

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -143,7 +143,7 @@ If they have ten houses for sale, they have ten different contract instances.
 
 ## CreatorInvitation
 
-An [invitation](#invitation) optionally returned by `startInstance()` that the contract instance
+An [invitation](#invitation) optionally returned by [`startInstance()`](/zoe/api/zoe.md#e-zoe-startinstance-installation-issuerkeywordrecord-terms) that the contract instance
 creator can use. It is usually used in contracts where the creator immediately
 sells something (auctions, swaps, etc.).
 
@@ -335,7 +335,7 @@ However, issuers and brands associated with either an ERTP mint or a ZCFMint are
 
 For more information on ERTP mints, see the [ERTP Guide's Mint section](/ertp/guide/issuers-and-mints.md)
 and the [ERTP API's Mint section](/ertp/api/mint.md). For more information about ZCFMints,
-see the [zcfMakeZCFMint() API entry](/zoe/api/zoe-contract-facet.md) in the Zoe Contract Facet API.
+see the [ZCF API `zcf.makeZCFMint()`](/zoe/api/zoe-contract-facet.md#zcf-makezcfmint-keyword-assetkind-displayinfo).
 
 ## Moola
 An imaginary currency Agoric documentation uses in examples.
@@ -454,7 +454,7 @@ current allocation as a [payout](#payout).
 Zoe uses a seat to represent an [offer](#offer) in progress, and has two seat [facets](#facet) representing
 two views of the same seat; a `ZCFSeat` and a `UserSeat`. The `UserSeat` is returned to the user who made an
 offer, and can check payouts' status or retrieve their results. The `ZCFSeat` is the argument passed to
-the `offerHandler` in the contract code. It is used within contracts and with `zcf.` methods.
+the `offerHandler` in the contract code. It is used within contracts and with [`zcf` methods](/zoe/api/zoe-contract-facet.md).
 
 The two seat facets have slightly different methods but represent the same seat and offer in progress.
 The term comes from the expression "having a seat at the table" with regards to participating in a negotiation.
@@ -470,7 +470,7 @@ We have renamed SES to [Hardened JavaScript](#hardened-javascript-ses).
 An imaginary currency Agoric documentation uses in examples.
 
 ## Terms
-Contract instances have associated terms, gotten via `E(zoe).getTerms(instance)`,
+Contract instances have associated terms, gotten via [`E(zoe).getTerms(instance)`](/zoe/api/zoe.md#e-zoe-getterms-instance),
 which include the instance's associated [issuers](#issuer), [brands](#brand), and any custom terms. For
 example, you might have a general auction contract. When someone instantiates it,
 they provide terms applicable only to that instance. For some instances of

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -53,7 +53,7 @@ five tickets is performed by set union rather than by arithmetic.
   (strings, numbers, objects, etc.).
   Values cannot include promises (they aren't keys), and should not
   include privileged objects such as payments and purses.
-- `AssetKind.COPY_BAG`: Used with semi-fungible assets.
+- `AssetKind.COPY_BAG`: Used with [semi-fungible](#semi-fungible) assets.
   Each amount value is a [multiset](https://en.wikipedia.org/wiki/Multiset)
   of [key](#key) values subject to the same constraints as
   those of `AssetKind.COPY_SET` but allowed to be present more than once.
@@ -492,6 +492,16 @@ The term comes from the expression "having a seat at the table" with regards to 
 
 For more details, see the [ZCFSeat documentation](/zoe/api/zoe-contract-facet.md#zcfseat-object) and
 the [UserSeat documentation](/zoe/api/zoe.md#userseat-object).
+
+## Semi-fungible
+
+A semi-fungible asset is one that has distinct forms which are not interchangeable
+with each other, but in which instances of a single form may interchangeable with
+other instances of the same form.
+As a variation on the [non-fungible](#non-fungible) theater ticket example, tickets
+might specify only a section, where the holder may sit in any seat of that section.
+For each section, the number of theater tickets minted should not exceed the number
+of seats in that section.
 
 ## SES
 

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -84,8 +84,8 @@ or `BigInt(123)`.
 The Board is a shared, on-chain location where users can post a value and make it
 accessible to others. When a user posts a value, they receive a unique ID for the value.
 Others can get the value just by knowing the ID. You can make an ID known by any
-communication method; private email, a DM or other private message, a phone call/voicemail,
-an email blast to a mailing list or many individuals, listing it on a website, etc.
+communication method&mdash;a DM or email or other private message, a phone call/voicemail,
+an email blast to a mailing list, publishing it on a website, etc.
 
 ## Brand
 Identifies the kind of [issuer](#issuer), such as "[Quatloos](#quatloos)",
@@ -117,7 +117,7 @@ unzip bundle.zip
 
 ## Burn
 
-Destroy all digital assets in a payment. See [`issuer.burn(payment, optAmount)`](/ertp/api/issuer.md#issuer-burn-payment-optamount).
+Destroy all digital assets in a payment, e.g. as part of consuming it in an exchange. See [`issuer.burn(payment, optAmount)`](/ertp/api/issuer.md#issuer-burn-payment-optamount).
 
 ## Comparable
 
@@ -338,7 +338,7 @@ An imaginary currency Agoric documentation uses in examples.
 
 ## Non-fungible
 A non-fungible asset is one where each incidence of the asset has unique individual properties and
-is not interchangeable with another incidence. For example, if your asset is show tickets, it matters to the buyer
+is not interchangeable with another incidence. For example, if your asset is theater tickets, it matters to the buyer
 what the date and time of the show is, which row the seat is in, and where in the row the
 seat is (and likely other factors as well). You can't just give them any ticket in your supply,
 as they are not interchangeable (and may have different prices). See also [fungible](#fungible).

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -53,7 +53,7 @@ by [issuers](#issuer) and [mints](#mint), and represent the goods and currency c
 [purses](#purse) and [payments](#payment). They represent things like currency, stock, and the
 abstract right to participate in a particular exchange.
 
-An amount is comprised of a [brand](#brand) with an [value](#value). For example, "4 Quatloos"
+An amount is comprised of a [brand](#brand) with a [value](#value). For example, "4 Quatloos"
 is an amount with a value of "4" and a brand of the imaginary currency "Quatloos".
 
 **Important**: Amounts are *descriptions* of digital assets, not the actual assets. They have no
@@ -107,7 +107,7 @@ The installation operation returns
 an `installation`, which is an object with one method; `getBundle()`. You can access an installed contract's source
 code via `const { source } = await E(installation).getBundle();`.
 In many cases, the bundled source is a single reviewable string.
-In others, the bundle contains to base 64 encoded zip file that you can
+In others, the bundle contains a base64-encoded zip file that you can
 extract for review.
 ```
 jq -r .endoZipBase64 bundle.json | base64 -d > bundle.zip
@@ -316,7 +316,7 @@ records with values of [amounts](#amounts), [issuers](#issuer), etc.
 ## Mint
 
 [ERTP](#ertp) has a *mint* object, which creates digital assets. [ZCF](#zcf) provides a different interface to an ERTP mint, called a
-*ZCFMint*. Assets and AssetHolders created using ZcfMints can be used in all the same ways as assets created by other ERTP Mints.
+*ZCFMint*. Assets and AssetHolders created using ZCFMints can be used in all the same ways as assets created by other ERTP Mints.
 They interact with Purses, Payments, Brands, and Issuers in the same ways.
 
 - ERTP mints create digital assets and are the only ERTP objects with the authority to do so.

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -429,9 +429,8 @@ const myProposal = harden({
 asset they are willing to give/want to get, and how much of it.
 
 ## Purse
-Purses hold [amounts](#amounts) of a certain [mint](#mint) issued assets. Specifically amounts that are _stationary_.
-Purses can transfer part of their held balance to a [payment](#payment), which is usually used to transfer value.
-A purse's contents are all of the same [brand](#brand).
+A purse holds [amounts](#amounts) of assets issued by a particular [mint](#mint) that are all of the same [brand](#brand) and generally _stationary_.
+When transfer is desired, a purse can move part of its held balance to a [payment](#payment).
 
 For more information, see the [ERTP Guide's Purses section](/ertp/guide/purses-and-payments.md#purses-and-payments) and the
 [ERTP API's Purses section](/ertp/api/purse.md).

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -216,7 +216,7 @@ See [`E()`](#e) above.
 Part of an [offer](#offer) specifying how the offer can be cancelled/exited. There are three values:
 - `onDemand: null`: (Default) The offering party can cancel on demand.
 - `waived: null`: The offering party can't cancel and relies entirely on the smart contract to promptly finish their offer.
-- `afterDeadline`: The offer is automatically cancelled after a deadline, as determined by its timer and deadline properties.
+- `afterDeadline: {…}`: The offer is automatically cancelled after a deadline, as determined by its `deadline` and `timer` properties.
 
 ## Facet
 
@@ -426,7 +426,7 @@ what asset you want, what asset you will give for it, and how/when the offer mak
 const myProposal = harden({
   give: { Asset: AmountMath.make(quatloosBrand, 4)},
   want: { Price: AmountMath.make(moolaBrand, 15) },
-  exit: { 'onDemand' }
+  exit: { onDemand: null }
 })
 ```
 `give` and `want` use [keywords](#keywords) defined by the contract. Each specifies via an [amount](#amounts), a description of what

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -35,14 +35,25 @@ disappear from the total allocation.
 The AmountMath library executes the logic of how [amounts](#amounts) are changed when digital assets are merged, separated,
 or otherwise manipulated. For example, a deposit of 2 [Quatloos](#quatloos) into a purse that already has 3 Quatloos
 gives a new balance of 5 Quatloos. But a deposit of a non-fungible theater ticket into a purse that already holds
-five tickets is performed by combining arrays rather than by arithmetic.
+five tickets is performed by set union rather than by arithmetic.
 
-`AmountMath` has a single set of polymorphic methods that deal with two different asset kinds:
-- `AssetKind.NAT`: Used with [fungible](#fungible) assets. Each amount value is a natural number (non-negative integer). This is the default `AssetKind`.
-- `AssetKind.SET`: Used with [non-fungible](#non-fungible) assets. Each amount value is an
-  array of [comparable](#comparable) values (strings, numbers, objects, etc.).
+`AmountMath` has a single set of polymorphic methods that deal with different asset kinds:
+- `AssetKind.NAT`: Used with [fungible](#fungible) assets.
+  Each amount value is a natural number (non-negative integer).
+  This is the default `AssetKind`.
+- `AssetKind.SET`: Used with [non-fungible](#non-fungible) assets;
+  deprecated in favor of `AssetKind.COPY_SET` but still in wide use.
+  Each amount value is an array of [comparable](#comparable) values
+  subject to the same constraints as those of `AssetKind.COPY_SET`.
+- `AssetKind.COPY_SET`: Used with [non-fungible](#non-fungible) assets.
+  Each amount value is a set of [comparable](#comparable) values
+  (strings, numbers, objects, etc.).
   Values cannot include promises (they aren't comparable), and should not
   include privileged objects such as payments and purses.
+- `AssetKind.COPY_BAG`: Used with semi-fungible assets.
+  Each amount value is a [multiset](https://en.wikipedia.org/wiki/Multiset)
+  of [comparable](#comparable) values subject to the same constraints as
+  those of `AssetKind.COPY_SET` but allowed to be present more than once.
 
 For more information, see the [ERTP Guide's AmountMath section](/ertp/guide/amount-math.md)
 and the [ERTP API's AmountMath section](/ertp/api/amount-math.md).

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -168,7 +168,7 @@ the [`E()` section in the Distributed JavaScript page](/guides/js-programming/ev
 ## Endo
 
 What Node.js does for JavaScript, Endo does for [Hardened
-JavaScript](#hardened-javascript).
+JavaScript](#hardened-javascript-ses).
 Endo guest programs run in Hardened JavaScript and communicate with their host
 and other guests through hardened interfaces and object-to-object
 message-passing.
@@ -392,7 +392,7 @@ can immediately cause the [seat](#seat) to exit, getting back the amount it offe
 
 ## Payment
 
-Payments hold assets created by [Mints](#mint). Specifically assets intended for transfer
+Payments hold assets created by [mints](#mint), specifically assets intended for transfer
 from one party to another. All assets of a payment are of the same [brand](#brand).
 
 For more information, see the [ERTP Guide's Payments section](/ertp/guide/purses-and-payments.md#purses-and-payments)

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -53,8 +53,8 @@ by [issuers](#issuer) and [mints](#mint), and represent the goods and currency c
 [purses](#purse) and [payments](#payment). They represent things like currency, stock, and the
 abstract right to participate in a particular exchange.
 
-An amount is comprised of a [brand](#brand) with an [value](#value). For example, "4 quatloos"
-is an amount with a value of "4" and a brand of the imaginary currency "quatloos".
+An amount is comprised of a [brand](#brand) with an [value](#value). For example, "4 Quatloos"
+is an amount with a value of "4" and a brand of the imaginary currency "Quatloos".
 
 **Important**: Amounts are *descriptions* of digital assets, not the actual assets. They have no
 intrinsic value. For example, to make you an offer to buy a magic sword in a game,
@@ -88,7 +88,8 @@ communication method; private email, a DM or other private message, a phone call
 an email blast to a mailing list or many individuals, listing it on a website, etc.
 
 ## Brand
-Identifies the kind of [issuer](#issuer), such as "quatloos", "moola", etc. Brands are one of the two elements that
+Identifies the kind of [issuer](#issuer), such as "[Quatloos](#quatloos)",
+"[Moola](#moola)", etc. Brands are one of the two elements that
 make up an [amount](#amounts).
 For more information, see the [ERTP Guide's Brand section](/ertp/guide/amounts.md)
 and the [ERTP API's Brand section](/ertp/api/brand.md).
@@ -294,8 +295,8 @@ what the [wallet](#wallet) does.
 
 ## Issuer
 Issuers are a one-to-one relationship with both a [mint](#mint) and a [brand](#brand), so each issuer works
-with one and only one asset type, such as only working with quatloos or only working
-with moola. This association cannot change to another type.
+with one and only one asset type, such as only working with [Quatloos](#quatloos)
+or only working with [Moola](#moola). This association cannot change to another type.
 
 Issuers can create empty [purses](#purse) for
 their asset type, but cannot mint new [amounts](#amounts). Issuers can also transform

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -103,6 +103,9 @@ Others can get the value just by knowing the ID. You can make an ID known by any
 communication method&mdash;a DM or email or other private message, a phone call/voicemail,
 an email blast to a mailing list, publishing it on a website, etc.
 
+**Note**: Publishing an object to the board makes it publicly accessible. If this is not
+appropriate for an object, do not use the board to communicate access to it.
+
 ## Brand
 
 Identifies the kind of [issuer](#issuer), such as "[Quatloos](#quatloos)",

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -43,16 +43,16 @@ five tickets is performed by set union rather than by arithmetic.
   This is the default `AssetKind`.
 - `AssetKind.SET`: Used with [non-fungible](#non-fungible) assets;
   deprecated in favor of `AssetKind.COPY_SET` but still in wide use.
-  Each amount value is an array of [comparable](#comparable) values
+  Each amount value is an array of [key](#key) values
   subject to the same constraints as those of `AssetKind.COPY_SET`.
 - `AssetKind.COPY_SET`: Used with [non-fungible](#non-fungible) assets.
-  Each amount value is a set of [comparable](#comparable) values
+  Each amount value is a set of [key](#key) values
   (strings, numbers, objects, etc.).
-  Values cannot include promises (they aren't comparable), and should not
+  Values cannot include promises (they aren't keys), and should not
   include privileged objects such as payments and purses.
 - `AssetKind.COPY_BAG`: Used with semi-fungible assets.
   Each amount value is a [multiset](https://en.wikipedia.org/wiki/Multiset)
-  of [comparable](#comparable) values subject to the same constraints as
+  of [key](#key) values subject to the same constraints as
   those of `AssetKind.COPY_SET` but allowed to be present more than once.
 
 For more information, see the [ERTP Guide's AmountMath section](/ertp/guide/amount-math.md)
@@ -131,11 +131,7 @@ Destroy all digital assets in a payment, for example as part of consuming it in 
 
 ## Comparable
 
-A *comparable* is a [passable](#passable) containing no promises or errors, and can
-thus be synchronously compared for structural equivalence with another piece of data.
-If either side of the comparison contains promises and/or errors, equality is indeterminable.
-If both are fulfilled down to [presences](#presence) and local state, then either they're the
-same all the way down, or they represent different objects.
+Comparable is a deprecated synonym of [key](#key).
 
 ## Contract and Contract Instance
 In Agoric documentation, *contract* usually refers to a contract's source code that
@@ -308,6 +304,14 @@ its asset type is valid.
 
 For more information, see the [ERTP Guide's Issuer section](/ertp/guide/issuers-and-mints.md)
 and the [ERTP API's Issuer section](/ertp/api/issuer.md).
+
+## Key
+
+A *key* is a [passable](#passable) containing no promises or errors, and can
+thus be synchronously compared for structural equivalence with another piece of data.
+If either side of the comparison contains promises and/or errors, equality is indeterminable.
+If both are fulfilled down to [presences](#presence) and local state, then either they're the
+same all the way down, or they represent different objects.
 
 ## Keywords
 
@@ -492,7 +496,7 @@ Pixel(3,2), $3, or “Seat J12 for the show September 27th at 9:00pm”.
 [Fungible](#fungible) values are usually
 represented by natural numbers. Other values may be represented as strings naming a particular
 rights, or an array of arbitrary objects representing the rights at issue. The latter two examples
-are usually [non-fungible](#non-fungible) assets. Values must be [comparable](#comparable).
+are usually [non-fungible](#non-fungible) assets. Values must be [keys](#key).
 
 For more information, see the [ERTP Guide's Value section](/ertp/guide/amounts.md#values).
 

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -133,7 +133,7 @@ Destroy all digital assets in a payment, for example as part of consuming it in 
 
 Comparable is a deprecated synonym of [key](#key).
 
-## Contract and Contract Instance
+## Contract Installation and Contract Instance
 In Agoric documentation, *contract* usually refers to a contract's source code that
 defines how the contract works. A contract's source code is *installed* on Zoe. A
 contract is *instantiated* to create *contract instances*, which are the active
@@ -144,7 +144,7 @@ code defining how that agreement works. When the realtor has a new house to sell
 they instantiate a new instance of their standard contract for that specific property.
 If they have ten houses for sale, they have ten different contract instances.
 
-## CreatorInvitation
+## Creator Invitation
 
 An [invitation](#invitation) optionally returned by [`startInstance()`](/zoe/api/zoe.md#e-zoe-startinstance-installation-issuerkeywordrecord-terms) that the contract instance
 creator can use. It is usually used in contracts where the creator immediately

--- a/main/glossary/README.md
+++ b/main/glossary/README.md
@@ -162,10 +162,12 @@ See [here](https://github.com/Agoric/agoric-sdk/blob/master/packages/SwingSet/do
 
 ## E()
 
-(Also referred to as *eventual send*) `E()` is a local "bridge" function that invokes methods on remote objects, for example
-in another vat, machine, or blockchain. It takes a local representative (a [presence](#presence)) for a remote object as an argument and
-sends messages to it using normal message-sending syntax. The local proxy forwards all messages to the remote object to deal with.
-All `E()` calls return a promise for the eventual returned value. For more detail, see
+(Also referred to as *eventual send*) `E()` is a local "bridge" function that
+asynchronously invokes methods on local or remote objects, for example those
+in another vat, machine, or blockchain. It takes a local object or a [presence](#presence)
+for a remote object as its argument and
+sends messages to the object using normal message-sending syntax. The local proxy forwards all messages to the remote object to deal with.
+All `E()` calls return a promise for the eventual result. For more detail, see
 the [`E()` section in the Distributed JavaScript page](/guides/js-programming/eventual-send.md).
 
 ## Endo

--- a/main/zoe/api/zoe.md
+++ b/main/zoe/api/zoe.md
@@ -292,12 +292,12 @@ empty record.
 
 The optional `exit`'s value should be an `exitRule`, an object with three possible keys for
 key:value pairs:
-- `onDemand:null`:  (Default) The user can cancel on demand.
-- `waived:null`: The user can't cancel and relies entirely on the smart contract to promptly finish their offer.
+- `onDemand: null`: (Default) The offering party can cancel on demand.
+- `waived: null`: The offering party can't cancel and relies entirely on the smart contract to promptly finish their offer.
 - `afterDeadline`: The offer is automatically cancelled after a deadline, as determined 
-   by its `timer` and `deadline` properties. The timer is a timer, and the `deadline` is with respect to the 
-   timer. Some example timers use Unix epoch time, while others count block height. Note that `deadline`'s
-   value is a `BigInt`, not a `Number` (just append an "n" to the number you want to use to get its `BigInt`)
+  by its `timer` and `deadline` properties.
+  `timer` must be a timer, and `deadline` must be a [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) value interpreted with respect to the timer.
+  Some example timers use Unix epoch time, while others count block height.
 
 ```js
 const myProposal = harden({

--- a/main/zoe/guide/proposal.md
+++ b/main/zoe/guide/proposal.md
@@ -28,7 +28,7 @@ Proposals are records with `give`, `want`, and `exit` keys.
 const myProposal = harden({
   give: { Asset: AmountMath.make(quatloosBrand, 4n)},
   want: { Price: AmountMath.make(moolaBrand, 15n) },
-  exit: { 'onDemand'
+  exit: { onDemand: null },
 })
 ```
 `give` and `want` use keywords defined by the contract.
@@ -46,10 +46,11 @@ represented as `BigInts` rather than `Numbers`)
 intrinsic value. `payments` hold actual digital assets.
 
 `exit` determines how an offer can be can cancelled:
-- `'onDemand'`: (Default) Whenever the user wants.
-- `'waived'`: The user cannot cancel, relying on the contract to finish the offer.
-- `'afterDeadline'`: Cancelled automatically after a deadline. This requires two
-  more properties, a `timer` object and a deadline BigInt value.
+- `onDemand: null`: (Default) The offering party can cancel on demand.
+- `waived: null`: The offering party can't cancel and relies entirely on the smart contract to promptly finish their offer.
+- `afterDeadline: {…}`: The offer is automatically cancelled after a deadline,
+  as determined by its `timer` and `deadline` properties. See
+  [Proposals and payments](/zoe/api/zoe.md#proposals-and-payments).
 
 ## Escrowed Payments
 


### PR DESCRIPTION
Mostly editorial changes to increase readability and internal consistency and addition of hyperlinks, but there are a few fixes of e.g. broken link targets and invalid code.

This is probably best reviewed using the rich diff, at least for a first pass.