### PR TITLE
fix: Express dates uniformly and reference agoric-sdk contents by permalink

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ VuePress automatically builds search functionality and individual page menus fro
 You must have **only one** `h1` per `.md` file. Be careful not to have too many `h2` and `h3` level headers 
 on one page and that they aren't too long. Otherwise the sidebar menu for the page will be cluttered and hard to read and use.
 
-Individual pages do not automatically display a sidebar menu for their headers (As of 03/2021, VuePress 
+Individual pages do not automatically display a sidebar menu for their headers (As of March 2021, VuePress
 documentation implies they do. We've filed a PR with them).
 To force an individual page sidebar menu, add the following YAML at the top of a page's source file (this file has this YAML at the top):
 ```js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,7 +294,7 @@ View your local documentation site at `localhost:8080/documentation/`
 In `[/.vuepress/config.js](/.vuepress/config.js)`, find the lines
 ```
 zoeVersion: 'Beta Release v1.0.0',
-zoeDocsUpdated: '2021-04-07'
+zoeDocsUpdated: 'Apr 7, 2021'
 ```
 Edit the values to be current. The current Zoe version is at line 
 3 [here](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/package.json).

--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -45,7 +45,13 @@ module.exports = {
     ]
   ],
 
-  plugins: ['check-md'],
+  plugins: [
+    'check-md',
+    [
+      '@vuepress/last-updated',
+      { dateOptions: { dateStyle: "medium", timeStyle: "long", timeZone: "Etc/UTC" } },
+    ],
+  ],
 
   /* --- DEFAULT THEME CONFIG --- */
   themeConfig: {
@@ -312,7 +318,7 @@ module.exports = {
     editLinkText: 'Help us improve this page!',
 
     zoeVersion: 'v0.18.1',
-    zoeDocsUpdated: '2021-09-13'
+    zoeDocsUpdated: 'Sep 13, 2021'
 
 
     /* --- SEARCH --- */

--- a/main/ertp/api/amount-math.md
+++ b/main/ertp/api/amount-math.md
@@ -68,11 +68,11 @@ In this case, you want to use the `brand` you got from the issuer (or from Zoe)
 as the optional parameter to compare the `amount` `brand`(s) to. If they are
 not equal, an error is thrown.
 
-## `makeLocalAmountMath(issuer)` DEPRECATED 20-03-2021
+## `makeLocalAmountMath(issuer)` DEPRECATED Mar 20, 2021
 
-## `AmountMath.getBrand()` DEPRECATED 20-03-2021
+## `AmountMath.getBrand()` DEPRECATED Mar 20, 2021
 
-## `AmountMath.getAmountMathKind()` DEPRECATED 20-03-2021
+## `AmountMath.getAmountMathKind()` DEPRECATED Mar 20, 2021
 
 ## `AmountMath.make(brand, allegedValue)`
 - `brand` `{Brand}`

--- a/main/getting-started/before-using-agoric.md
+++ b/main/getting-started/before-using-agoric.md
@@ -23,7 +23,7 @@ Then proceed to [starting a project](/getting-started/start-a-project.md).
 
 A more detailed explanation follows.
 
-::: tip Watch: Prepare Your Agoric Environment (Nov 2020)
+::: tip Watch: Prepare Your Agoric Environment (November 2020)
 This presentation is a good overview of the Agoric SDK setup process,
 though a few details are out of date:
 

--- a/main/getting-started/start-a-project.md
+++ b/main/getting-started/start-a-project.md
@@ -24,7 +24,7 @@ window will create their shared working directory.
     # Shell 3: web user interface
     ```
 
-::: tip Watch: Prepare Your Agoric Environment (Nov 2020)
+::: tip Watch: Prepare Your Agoric Environment (November 2020)
 This presentation includes starting a project, but note an outdated detail:
 
  - In the REPL `x~.go()` tildot support has been postponed; use `E(x).go()`.

--- a/main/guides/chainlink-integration.md
+++ b/main/guides/chainlink-integration.md
@@ -16,7 +16,7 @@ Using Chainlink on Agoric provides two main features:
 We have tested these features with [actual Chainlink oracle
 software](https://github.com/Agoric/dapp-oracle/blob/main/chainlink-agoric/README.md).
 
-**Note**: Chainlink has not yet (as of 2020-11-16) finished setting up an incentivized testnet for established Chainlink node operators to connect to Agoric.
+**Note**: Chainlink has not yet (as of Nov 16, 2020) finished setting up an incentivized testnet for established Chainlink node operators to connect to Agoric.
 
 ## Price Authority
 

--- a/main/guides/js-programming/README.md
+++ b/main/guides/js-programming/README.md
@@ -3,7 +3,7 @@
 The Agoric smart contract platform starts with a JavaScript framework
 for secure distributed computing.
 
-::: tip Watch: Distributed Programming for a Decentralized World (Aug 2019)
+::: tip Watch: Distributed Programming for a Decentralized World (August 2019)
 This 15 minute overview is the first in a
 [4-parts series](https://www.youtube.com/playlist?list=PLzDw4TTug5O1oHRbp2HkcvKABAY9FKsmG)
 of short talks on the Agoric Architecture that overlap substantially with the material in

--- a/main/guides/js-programming/eventual-send.md
+++ b/main/guides/js-programming/eventual-send.md
@@ -75,7 +75,7 @@ If an ordinary synchronous call (`obj.method()`) fails because the method doesn'
 consider that `obj` may be remote and try `E(obj).method()`.
 :::
 
-::: tip Watch: How Agoric Solves Reentrancy Hazards (Nov 2020)
+::: tip Watch: How Agoric Solves Reentrancy Hazards (November 2020)
 for more on eventual send and remote communication
 <iframe width="560" height="315" src="https://www.youtube.com/embed/38oTyVv_D9I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 :::

--- a/main/guides/js-programming/hardened-js.md
+++ b/main/guides/js-programming/hardened-js.md
@@ -1,6 +1,6 @@
 # Hardened JavaScript
 
-::: tip Watch: Object-capability Programming in Secure Javascript (Aug 2019)
+::: tip Watch: Object-capability Programming in Secure Javascript (August 2019)
 
 _The first 15 minutes cover much of the material below.
 The last 10 minutes are Q&A._

--- a/main/zoe/guide/contracts/atomic-swap.md
+++ b/main/zoe/guide/contracts/atomic-swap.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/atomicSwap.js) (Last updated: 12-SEP-2020)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/atomicSwap.js) (Last updated: Sep 12, 2020)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 If I want to trade one kind of asset for another kind, I could send

--- a/main/zoe/guide/contracts/automatic-refund.md
+++ b/main/zoe/guide/contracts/automatic-refund.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/automaticRefund.js)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/automaticRefund.js) (Last updated: Jan 31, 2022)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This is a very trivial contract to explain and test Zoe.

--- a/main/zoe/guide/contracts/autoswap.md
+++ b/main/zoe/guide/contracts/autoswap.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/2a8b0fc2ece7344604bcc23b295367cd871f6995/packages/zoe/src/contracts/autoswap.js) (Last updated: 2020-9-14)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/2a8b0fc2ece7344604bcc23b295367cd871f6995/packages/zoe/src/contracts/autoswap.js) (Last updated: Sep 14, 2020)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 Autoswap is a contract that maintains a pool of assets (the 'liquidity pool') that

--- a/main/zoe/guide/contracts/barter-exchange.md
+++ b/main/zoe/guide/contracts/barter-exchange.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/a564c6081976d7b66b3cdf54e0ba8903c8f1ee6d/packages/zoe/src/contracts/barterExchange.js) (Last updated: 2020/9/14)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/a564c6081976d7b66b3cdf54e0ba8903c8f1ee6d/packages/zoe/src/contracts/barterExchange.js) (Last updated: Sep 14, 2020)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 Barter Exchange takes offers for trading arbitrary goods for one another.

--- a/main/zoe/guide/contracts/constantProductAMM.md
+++ b/main/zoe/guide/contracts/constantProductAMM.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/vpool-xyk-amm/multipoolMarketMaker.js) (Last updated: 2021-10-26)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/vpool-xyk-amm/multipoolMarketMaker.js) (Last updated: Oct 26, 2021)
 ##### [View contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 

--- a/main/zoe/guide/contracts/constantProductAMM.md
+++ b/main/zoe/guide/contracts/constantProductAMM.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/15322a1f65bb67e1865f8276600a76171696dc74/packages/zoe/src/contracts/vpool-xyk-amm/multipoolMarketMaker.js) (Last updated: Feb 17, 2022)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js) (Last updated: Feb 17, 2022)
 ##### [View contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 

--- a/main/zoe/guide/contracts/constantProductAMM.md
+++ b/main/zoe/guide/contracts/constantProductAMM.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/vpool-xyk-amm/multipoolMarketMaker.js) (Last updated: Oct 26, 2021)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/15322a1f65bb67e1865f8276600a76171696dc74/packages/zoe/src/contracts/vpool-xyk-amm/multipoolMarketMaker.js) (Last updated: Feb 17, 2022)
 ##### [View contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 

--- a/main/zoe/guide/contracts/covered-call.md
+++ b/main/zoe/guide/contracts/covered-call.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/coveredCall.js) (Last updated: 9/12/2020)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/coveredCall.js) (Last updated: Sep 12, 2020)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 The owner of an asset can use a covered call to give someone else the right

--- a/main/zoe/guide/contracts/escrow-to-vote.md
+++ b/main/zoe/guide/contracts/escrow-to-vote.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/test/unitTests/contracts/escrowToVote.js)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/test/unitTests/contracts/escrowToVote.js) (Last updated: Jan 31, 2022)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This contract implements coin voting. There are two roles: the

--- a/main/zoe/guide/contracts/fundedCallSpread.md
+++ b/main/zoe/guide/contracts/fundedCallSpread.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/callSpread/fundedCallSpread.js)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/callSpread/fundedCallSpread.js) (Last updated: Feb 20, 2022)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This contract implements a fully collateralized call spread. You can use a call spread as a

--- a/main/zoe/guide/contracts/loan.md
+++ b/main/zoe/guide/contracts/loan.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts/loan)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/loan/index.js) (Last updated: Nov 23, 2021)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 The basic loan contract has two parties, a *lender* and a *borrower*.

--- a/main/zoe/guide/contracts/mint-and-sell-nfts.md
+++ b/main/zoe/guide/contracts/mint-and-sell-nfts.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/mintAndSellNFT.js)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/mintAndSellNFT.js) (Last updated: Jan 31, 2022)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This contract mints non-fungible tokens and creates a selling contract

--- a/main/zoe/guide/contracts/mint-payments.md
+++ b/main/zoe/guide/contracts/mint-payments.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/mintPayments.js)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/mintPayments.js) (Last updated: Jan 31, 2022)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This very simple contract shows how to create a new issuer kit and

--- a/main/zoe/guide/contracts/oracle.md
+++ b/main/zoe/guide/contracts/oracle.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/oracle.js) (Last updated: Nov 5, 2020)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4c4da6a7ae76aebbff2af48613008978eb04462b/packages/zoe/src/contracts/oracle.js) (Last updated: Jan 31, 2022)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 **NOTE: You almost certainly do not want to use this contract directly.

--- a/main/zoe/guide/contracts/oracle.md
+++ b/main/zoe/guide/contracts/oracle.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/oracle.js) (Last updated: 5-NOV-2020)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/oracle.js) (Last updated: Nov 5, 2020)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 **NOTE: You almost certainly do not want to use this contract directly.

--- a/main/zoe/guide/contracts/otc-desk.md
+++ b/main/zoe/guide/contracts/otc-desk.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/otcDesk.js)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/otcDesk.js) (Last updated: Mar 1, 2022)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 ![Building a Composable DeFi Contract](./assets/title.jpg)

--- a/main/zoe/guide/contracts/pricedCallSpread.md
+++ b/main/zoe/guide/contracts/pricedCallSpread.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/callSpread/pricedCallSpread.js)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/callSpread/pricedCallSpread.js) (Last updated: Feb 20, 2022)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This contract implements a fully collateralized call spread. You can use a call spread as a

--- a/main/zoe/guide/contracts/second-price-auction.md
+++ b/main/zoe/guide/contracts/second-price-auction.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/a564c6081976d7b66b3cdf54e0ba8903c8f1ee6d/packages/zoe/src/contracts/auction/secondPriceAuction.js) (Last updated: 2020/9/14)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/a564c6081976d7b66b3cdf54e0ba8903c8f1ee6d/packages/zoe/src/contracts/auction/secondPriceAuction.js) (Last updated: Sep 14, 2020)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 In a second-price auction, the winner is the participant with the highest bid, but

--- a/main/zoe/guide/contracts/sell-items.md
+++ b/main/zoe/guide/contracts/sell-items.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/sellItems.js)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/sellItems.js) (Last updated: Feb 4, 2022)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 Sell items in exchange for money. Items may be fungible or

--- a/main/zoe/guide/contracts/simple-exchange.md
+++ b/main/zoe/guide/contracts/simple-exchange.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/simpleExchange.js) (Last updated: 2020-9-12)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/simpleExchange.js) (Last updated: Sep 12, 2020)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 The "simple exchange" is a very basic, un-optimized exchange. It

--- a/main/zoe/guide/contracts/treasury.md
+++ b/main/zoe/guide/contracts/treasury.md
@@ -1,5 +1,11 @@
 # Treasury contract
 
+<Zoe-Version/>
+
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/run-protocol/src/vaultFactory/vaultFactory.js) (Last updated: Mar 11, 2022)
+##### [View contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
+
+
 The Treasury is the primary mechanism for making `RUN` (the Agoric stable-value
 currency) available to participants in the economy. It does this by issuing
 loans against supported types of collateral. The creator of the contract can

--- a/main/zoe/guide/contracts/use-obj-example.md
+++ b/main/zoe/guide/contracts/use-obj-example.md
@@ -2,7 +2,7 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/test/unitTests/contracts/useObjExample.js)
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/test/unitTests/contracts/useObjExample.js) (Last updated: Jan 31, 2022)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This contract is an example of associating a particular ability


### PR DESCRIPTION
* Express full dates as "mmm d, yyyy" (strftime `%b %-d, %Y`), e.g. "Nov 5, 1955".
* Express months as "mmmm yyyy" (strftime `%B %Y`), e.g. "October 1985".

The styles were taken from existing content, but I'd be happy to change to any other unambiguous convention.