### PR TITLE
fix: Cleanup the Dapp Guide

### DIFF
--- a/main/dapps/README.md
+++ b/main/dapps/README.md
@@ -17,7 +17,9 @@ A dapp is a *decentralized application* which typically has a browser-based user
 If you have installed the [Agoric CLI](../getting-started/before-using-agoric.md) and you just want to try running a dapp locally (on a simulated Agoric VM, not an actual public chain), you can:
 
 ```sh
-# Use `agoric init` to make a new local copy of a dapp template. Here we chose the Fungible Faucet Dapp. You can replace `my-fungible-faucet` with a name of your choice.
+# Use `agoric init` to make a new local copy of a dapp template.
+# Here we chose the Fungible Faucet Dapp.
+# You can replace `my-fungible-faucet` with a name of your choice.
 agoric init --dapp-template dapp-fungible-faucet my-fungible-faucet
 cd my-fungible-faucet
 # Install the project dependencies
@@ -29,7 +31,7 @@ agoric start --reset
 Leave this command running (it is your simulated environment).  Then,
 in a separate terminal, deploy the contract and API to the VM.
 
-```sh
+```sh secondary style2
 # Deploy a new instance of the contract to the VM
 agoric deploy contract/deploy.js
 # Reset the VM's API server
@@ -38,12 +40,12 @@ agoric deploy api/deploy.js
 
 Then in a third terminal:
 
-```sh
+```sh secondary style3
 # Start the user interface
 cd ui && yarn start
 ```
 
-You can then navigate to http://localhost:3000 to view your dapp.
+You can then navigate to [http://localhost:3000](http://localhost:3000) to view your dapp.
 
 ## Modifying this Dapp
 

--- a/main/dapps/README.md
+++ b/main/dapps/README.md
@@ -55,9 +55,9 @@ In the Agoric system, components are written in Javascript.
 
 The following are the important directories in an Agoric Dapp project:
 
-- [`contract`](#contract-directory) define and deploy the on-chain contract
-- [`api`](#api) define and deploy the chain-connected server's `/api` HTTP endpoint
-- [`ui`](#ui) the browser user interface that connects between the user's personal wallet and the API server
+- [`contract/`](#contract-directory) defines the on-chain smart contract.
+- [`api/`](#api) defines the chain-connected server's `/api` HTTP endpoint.
+- [`ui/`](#ui) defines the browser user interface connecting users' personal wallets and the API server.
 
 Other files and directories in this toplevel folder should not typically be modified.
 
@@ -66,7 +66,7 @@ Other files and directories in this toplevel folder should not typically be modi
 In the `contract` directory, you can find the following files to edit:
 
 - `init` contract initialization modules, starting with `init/custom-deploy.js`
-- `src` contract source code, starting with `src/contract.js`
+- `src/` contract source code, starting with `src/contract.js`
 
 Other files and folders that you don't typically need to edit:
 
@@ -77,7 +77,7 @@ Other files and folders that you don't typically need to edit:
 
 In the `api` directory, you can find the following files to edit:
 
-- `src` /api endpoint handler, starting with `src/handler.js`
+- `src/` handler for /api HTTP endpoints, starting with `src/handler.js`
 
 Other files and folders that you don't typically need to edit:
 

--- a/main/dapps/README.md
+++ b/main/dapps/README.md
@@ -65,13 +65,11 @@ Other files and directories in this top-level folder should not typically be mod
 
 In the `contract` directory, you can find the following files to edit:
 
-- `init` contract initialization modules, starting with `init/custom-deploy.js`
 - `src/` contract source code, starting with `src/contract.js`
 
 Other files and folders that you don't typically need to edit:
 
 - `deploy.js` generic Agoric contract deployment script
-- `lib` library modules provided by Agoric and used by the contract
 
 ### API
 

--- a/main/dapps/README.md
+++ b/main/dapps/README.md
@@ -59,7 +59,7 @@ The following are the important directories in an Agoric Dapp project:
 - [`api/`](#api) defines the chain-connected server's `/api` HTTP endpoint.
 - [`ui/`](#ui) defines the browser user interface connecting users' personal wallets and the API server.
 
-Other files and directories in this toplevel folder should not typically be modified.
+Other files and directories in this top-level folder should not typically be modified.
 
 ### Contract directory
 

--- a/main/getting-started/deploying.md
+++ b/main/getting-started/deploying.md
@@ -12,9 +12,9 @@ and `api/deploy.js` scripts. You can use the deploy scripts created when you cop
 Dapp into your directory as they are, or you can modify the scripts as suggested later in this document.
 
 Remember, your Dapp has three primary subdirectories:
-- `contract/`which contains files relating to your smart contract itself.
-- `api/`which contains files enabling the UI frontend to communicate via HTTP/WebSocket to an on-chain backend contract instance and start your Dapp contract instance and backend.
-- `ui/` which contains files relating to your contract's user interface.
+- `contract/` contains files defining your on-chain smart contract.
+- `api/` contains files enabling the UI frontend to communicate via HTTP/WebSocket to an on-chain backend contract instance and start your Dapp contract instance and backend.
+- `ui/` contains files relating to your contract's browser user interface.
 
 ## How it works
 
@@ -53,7 +53,7 @@ which is our example of a typical contract deploy script.
 
 Deploying the `dapp-fungible-faucet` contract (e.g., with `agoric deploy contract/deploy.js` after `agoric init` 
 copied it into a local directory) installs it on chain, and generates the 
-file `./ui/public/conf/installationConstants.js`with contents like:
+file `ui/public/conf/installationConstants.js` with contents like:
 ```js
 // GENERATED FROM dapp-fungible-faucet/contract/deploy.js
 export default {
@@ -85,7 +85,7 @@ range of the above custom setup actions:
 * [`dapp-simple-exchange`](https://github.com/Agoric/dapp-simple-exchange/blob/main/api/deploy.js)
 
 Application deployment steps may include:
-* Bundle the `api` code and deploy it to the running local "api" process (ag-solo)
+* Bundle the `api/` code and deploy it to the running local "api" process (ag-solo)
 * Include the contract installation configuration information in the bundle
 * Create new currencies and add them to the application's wallet
 

--- a/main/getting-started/deploying.md
+++ b/main/getting-started/deploying.md
@@ -8,8 +8,8 @@ has two primary uses:
 * Deploy and setup an application program to a local server running an Agoric process
 
 Use the `agoric deploy` command to run your Dapp's `contract/deploy.js` 
-and `api/deploy.js` scripts. You can use the deploy scripts created when you copied an existing 
-Dapp into your directory as they are, or you can modify the scripts as suggested later in this document.
+and `api/deploy.js` scripts. You can use the deploy scripts copied from an existing 
+Dapp as they are, or you can modify them as suggested later in this document.
 
 Remember, your Dapp has three primary subdirectories:
 - `contract/` contains files defining your on-chain smart contract.
@@ -19,20 +19,19 @@ Remember, your Dapp has three primary subdirectories:
 ## How it works
 
 All deployment happens via the local running Agoric process. This is usually the `ag-solo` process, 
-and frequently referred to as that or just as `ag-solo`. It is also sometimes described as/called an Agoric VM or a local server.
+sometimes described as an Agoric VM or a local server.
 
-`ag-solo` communicates with either a locally running or remote chain. The local process has a `home` object, which contains 
-references to services on-chain, including `zoe`, the `board` for
-sharing objects, and an application user's `wallet`. Developers can
-use these service references to call the service's associated API commands.
+`ag-solo` communicates with either a locally running or remote chain.
+The local process has a `home` object, which contains references to services on-chain
+that can be used to call associated API commands.
+Such references include `zoe`, the `board` for sharing objects, and the application user's `wallet`.
 
-Deploying to the chain first uploads the bundled contract source code to the local Agoric process (`ag-solo`).
-The deployment script then uses the `home` object to access `zoe` which installs the code on chain. 
+Each `deploy.js` runs in its own temporary process connected to `ag-solo`, through which it can reach the chain.
+It first uploads bundled contract source code to `ag-solo`,
+then goes through the `home` object to access `zoe` and uses that to install the code on-chain.
 
-Via the REPL associated with the wallet, developers can use all the on-chain commands that deployment scripts use to deploy 
-contracts and Dapps.
-
-Each `deploy.js` runs in its own temporary process, connected to `ag-solo`, through which it can reach the chain.
+All on-chain commands that deployment scripts use to deploy contracts and Dapps
+are also available to developers via the REPL associated with their wallet.
 
 ## Contract deployment
 
@@ -71,12 +70,12 @@ you need to customize the Agoric API server deployment and setup much more
 for your particular application and contract. Some Dapps use a singleton contract instance 
 which presumes that it will be installed once and serve all customers (as opposed to an auction
 or swap contract, which is installed once, but instantiated separately for each sale it manages).
-A singleton potentially must:
-- Be created 
+A singleton may need to:
+- Be instantiated 
 - Find and connect to on-chain resources such as issuers for specific currencies
 - Create new on-chain resources like new currencies or NFTs
 - Create new Purses for the application to use
-- Seed the on-chain contract with initial orders or configuration.
+- Seed the on-chain contract instance with initial orders or configuration.
 
 These example contract `api/deploy.js` scripts show some of the 
 range of the above custom setup actions:
@@ -85,12 +84,12 @@ range of the above custom setup actions:
 * [`dapp-simple-exchange`](https://github.com/Agoric/dapp-simple-exchange/blob/main/api/deploy.js)
 
 Application deployment steps may include:
-* Bundle the `api/` code and deploy it to the running local "api" process (ag-solo)
+* Bundle the `api/` code and deploy it to the running local `ag-solo`
 * Include the contract installation configuration information in the bundle
 * Create new currencies and add them to the application's wallet
 
 Steps for contracts that use a singleton instance for all clients may further include:
-* Instantiate a contract instance using the installation created when the contract deployed
+* Instantiate a contract instance using the installation created by contract deployment
 * Use the invitation from that instance creation to configure the new instance
 * Register the contract instance's `instance` with the Board
 * Record the contract instance's Board ID in a configuration file

--- a/main/getting-started/start-a-project.md
+++ b/main/getting-started/start-a-project.md
@@ -9,19 +9,19 @@ Do not use for production purposes.
 Now that you have [installed the Agoric SDK](/getting-started/before-using-agoric.md),
 let's try out your first Agoric _Dapp_ (decentralized application).
 
-We'll be running **three shell windows**, and
+We'll be running **three terminal windows**, and
 [dapp template initialization](#initialize-demo-from-dapp-template) in the first
 window will create their shared working directory.
 
 
- 1. ```shell
-    # Shell 1: main command shell
+ 1. ```sh
+    # Terminal 1: simulated blockchain and "solo" client
     ```
- 2. ```shell secondary style2
-    # Shell 2: simulated blockchain and "solo" client
+ 2. ```sh secondary style2
+    # Terminal 2: contract interaction
     ```
- 3. ```shell secondary style3
-    # Shell 3: web user interface
+ 3. ```sh secondary style3
+    # Terminal 3: web user interface
     ```
 
 ::: tip Watch: Prepare Your Agoric Environment (November 2020)
@@ -38,11 +38,11 @@ Use the [Agoric CLI](/guides/agoric-cli/commands.md) to fetch from a Dapp templa
 and put it in a `demo` directory _not located in your `agoric-sdk` clone_:
 
 
-```shell
-# Shell 1
+```sh
+# Terminal 1
 # Don't use your agoric-sdk clone as the parent of the demo directory.
 # It doesn't have to be your home directory; any other directory will do.
-cd
+cd $HOME
 agoric init demo
 ```
 
@@ -54,8 +54,8 @@ Learn more about the [available dapp templates](/dapps/dapp-templates.md).
 
 ### Install the Agoric SDK in the Dapp
 
-```shell
-# Shell 1
+```sh
+# Terminal 1
 cd demo
 agoric install
 ```
@@ -66,10 +66,11 @@ It may take a minute or so to install all the dependencies.
 On a Mac, you must first install
 [Xcode](https://apps.apple.com/us/app/xcode/id497799835)
 :::
+
 ## Start the Agoric Solo Client and Simulated Blockchain
 
-```shell secondary style2
-# Shell 2
+```sh
+# Terminal 1
 cd demo # if not already there
 agoric start
 
@@ -80,14 +81,15 @@ agoric start
 agoric start --reset
 ```
 
-Leave this process and its logs running in its own shell window.
+Leave this process and its logs running in its own terminal window.
 ## Deploy the Contract and API
 
-Deploy the contract to the simulated blockchain
+In a separate terminal, deploy the contract to the simulated blockchain
 and the API to the solo client.
 
-```shell
-# Shell 1
+```sh secondary style2
+# Terminal 2
+cd demo # if not already there
 agoric deploy ./contract/deploy.js ./api/deploy.js
 ```
 
@@ -99,20 +101,21 @@ in detail later.
 The web user interface communicates with the API in
 the solo client as well as the wallet (below).
 
-```shell secondary style3
-# Shell 3
+```sh secondary style3
+# Terminal 3
 cd demo # if not already there
 cd ui && yarn start
 ```
 
-Leave this running in its own shell window and
+Leave this running in its own terminal window and
 visit [http://localhost:3000](http://localhost:3000)
 in a web browser.
 
 ## Open the Agoric Wallet and REPL
 
-```shell
-# Shell 1
+```sh secondary style2
+# Terminal 2
+cd demo # if not already there
 agoric open --repl
 ```
 


### PR DESCRIPTION
Mostly phrasing/style improvements. The most substantial change is removal of lines mentioning nonexistent `init` and `lib` directories in the (default) Dapp template.