### PR TITLE
docs: rename HEAD to master in urls in md files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,21 +13,21 @@ process is:
    self-proofreading is required, later reviewers should not expect perfection.
 3. If you deleted or added docs that either need to be removed from or added to the site menus (top menubar or sidebars),
    edit the menus and test on your local server.
-4. Check your changed docs in a local copy of the repo and local documentation 
-   server. Includes that they build and run successfully, pass link checking and (for now) spellchecking. 
+4. Check your changed docs in a local copy of the repo and local documentation
+   server. Includes that they build and run successfully, pass link checking and (for now) spellchecking.
 5. Do a Draft PR and have it reviewed by others. The PR body describes what the purpose of the PR is, which
-   files are being altered for what reasons, and any related material still outstanding (so reviewers know 
+   files are being altered for what reasons, and any related material still outstanding (so reviewers know
    if the PR is meant to be comprehensive or if it is part of a series of PRs).
    1. Component version tags (e.g., Zoe version, ERTP version) have been updated appropriately.
-   2. PR contains only the files to be reviewed. No additional files are in the PR that are not intended to be changed or reviewed. 
-   3. PRs contain no meta-comments or open questions. They can appear in DRAFT PRs but not real PRs. 
+   2. PR contains only the files to be reviewed. No additional files are in the PR that are not intended to be changed or reviewed.
+   3. PRs contain no meta-comments or open questions. They can appear in DRAFT PRs but not real PRs.
       Such questions can also just be added as comments on a newly opened PR.
    4. If the PR cannot be approved as is (because there's known issues) then it must be a draft PR
 6. When all issues from the initial review are resolved, convert the PR from Draft to Ready For Review.
 7. Reviewers approve PR, you merge it with `main`.
 8. Pull Requests automatically run tests on their committed files.
-9. [VuePress](https://vuepress.vuejs.org/guide/#how-it-works) automatically 
-   processes any new or changed files for display. 
+9. [VuePress](https://vuepress.vuejs.org/guide/#how-it-works) automatically
+   processes any new or changed files for display.
 10. The [Agoric website's Documentation Section](https://agoric.com/documentation/) displays
    the VuePress processed files, which have been converted to HTML.
 
@@ -52,37 +52,37 @@ section of the Agoric website. The homepage uses the default VuePress homepage t
 ### Folders and Projects
 
 Each project gets its own folder, often with `/api` and `/guide` subfolders as warranted. For example, we have `/main/ertp/api/` and `/main/ertp/guide/` as
-well as `/main/zoe/api/` and `/main/zoe/guide/`. Projects can have additional subfolders as needed. 
+well as `/main/zoe/api/` and `/main/zoe/guide/`. Projects can have additional subfolders as needed.
 
 Each folder should have its own `README.md`, which is an effective `index.html` equivalent in terms of rendering when someone navigates to
-the folder's URL. See the next section for an explanation of how VuePress uses READMEs. 
+the folder's URL. See the next section for an explanation of how VuePress uses READMEs.
 
 Images, diagrams, and similar content-supporting files should go in an `assets` subfolder under the appropriate project folder.
-For example, if you have a `process.svg` image file with a diagram for the Zoe Guide's Invitations page, it 
-should be stored in `main/zoe/guide/assets/process.svg` and appear in the page via an image link of `./assets/process.svg` 
+For example, if you have a `process.svg` image file with a diagram for the Zoe Guide's Invitations page, it
+should be stored in `main/zoe/guide/assets/process.svg` and appear in the page via an image link of `./assets/process.svg`
 
 Note that `assets` should store all the auxiliary files for the files in its parent folder. Don't make an `assets` folder
 or similar for individual files/pages.
 
 ### README files
 
-VuePress converts Markdown files to an HTML file with the same base name. `README.md` files are an exception; they're 
-renamed `index.html`, since that's the default file web servers expect to find in each directory. Navigating 
+VuePress converts Markdown files to an HTML file with the same base name. `README.md` files are an exception; they're
+renamed `index.html`, since that's the default file web servers expect to find in each directory. Navigating
 to `https://agoric.com/documentation/ertp/guide/` displays the VuePress processed `/main/ertp/guide/README.md`.
-While it may seem odd, VuePress expects multiple `README.md` files in a repo; most folders will have one. 
+While it may seem odd, VuePress expects multiple `README.md` files in a repo; most folders will have one.
 
 The root README.md file must start with an H1 (`#` in Markdown) header. In fact, all our doc pages should start
 with that. But for READMEs, it's needed to generate search indexes and sidebars.
 
 All directories/folders should have a `README.md` file, even if it's empty. They provide a landing page for
-the folder in the VuePress processed documentation structure. 
+the folder in the VuePress processed documentation structure.
 
 Lines with no special treatment are converted into standard HTML paragraph tags.
 
 ### Sectioning Pages
 
-VuePress automatically builds search functionality and individual page menus from `h1`, `h2`, and `h3` headers (i.e. Markdown's `#`, `##`, and `###` commands). 
-You must have **only one** `h1` per `.md` file. Be careful not to have too many `h2` and `h3` level headers 
+VuePress automatically builds search functionality and individual page menus from `h1`, `h2`, and `h3` headers (i.e. Markdown's `#`, `##`, and `###` commands).
+You must have **only one** `h1` per `.md` file. Be careful not to have too many `h2` and `h3` level headers
 on one page and that they aren't too long. Otherwise the sidebar menu for the page will be cluttered and hard to read and use.
 
 Individual pages do not automatically display a sidebar menu for their headers (As of March 2021, VuePress
@@ -140,17 +140,17 @@ Next, your Markdown links should be to the `.md` Markdown files in the Doc repo.
 both the `.md` files and links to them to be `.html`.
 
 In general, use relative links instead of absolute ones for any links to files or folders in the Documentation repo. Relative links
-open in the same browser tab when clicked on, absolute links open a new tab. 
+open in the same browser tab when clicked on, absolute links open a new tab.
 
-However, there's a trick you can use that's easier than writing a complicated relative link. 
+However, there's a trick you can use that's easier than writing a complicated relative link.
 While it's easy enough to, say, write a relative link to something in
 the same folder as the file you're writing (something like `(./assets/my-diagram.svg)` to include an image), it can be
 difficult to remember/figure out what the right syntax is for relative linking to a file two folders up, in a different upper folder, and then
-two levels down from there on a different branch of the file structure. 
+two levels down from there on a different branch of the file structure.
 
-Instead, VuePress considers `main` the top of the file hierarchy. So you can always get to, say, a Glossary entry 
+Instead, VuePress considers `main` the top of the file hierarchy. So you can always get to, say, a Glossary entry
 by just linking to `(/glossary/#allocation)`; its path starting at `main`. Any path starting with just `/` starts
-at `main`. These links also open in the same browser tab. 
+at `main`. These links also open in the same browser tab.
 
 VuePress turns every header in a Markdown file into an HTML anchor you can link to, so clicking such a link takes you directly to
 that file location (called *slugifying* by WordPress and other blogging platforms). A header link consists of its file
@@ -170,11 +170,11 @@ These GitHub Actions run on every pull request and commit to `main`:
 
 - Check links
 - Test the build
-  - Tests for build errors and does HTML5 validation. 
+  - Tests for build errors and does HTML5 validation.
 - Lint and Test Snippets
   - Tests the imported code snippets. Code included inline is **not** tested or run.
 - Spellcheck - **Does not work yet. Until finished, please check your docs in an external spellchecker before merging.**
-  - Checks Markdown files against a dictionary and a local wordlist. 
+  - Checks Markdown files against a dictionary and a local wordlist.
 
 ### Spellcheck
 
@@ -183,7 +183,7 @@ These GitHub Actions run on every pull request and commit to `main`:
 This is currently only available in Github Actions on Pull Requests.
 Any words that do fail spell check are shown in the logs of
 the Github Action. Please either fix the words or add them to the list
-in `Agoric/documentation/.wordlist.txt`. When entering new words, please keep the list 
+in `Agoric/documentation/.wordlist.txt`. When entering new words, please keep the list
 in alphabetical order for the convenience of future maintainers.
 
 ![](./contributing-assets/spellcheck-results.png)
@@ -192,7 +192,7 @@ in alphabetical order for the convenience of future maintainers.
 
 Code snippets are not short inline code bits like `const x = 2 + 2;`. In fact,
 you cannot insert a code snippet in line. They are for where you want to
-do an effective code block (i.e. one that starts with a line consisting of 
+do an effective code block (i.e. one that starts with a line consisting of
 three backquotes and an appended 'js' and ends with a line consisting of three backquotes).
 
 The code used for code snippets is held to a similar standard of correctness as actual
@@ -207,13 +207,13 @@ agoric-sdk release.
 To import code snippets into the documentation, if there isn't
 already an appropriate file, create a file
 somewhere under the top-level `Agoric/documentation/snippets/` directory,
-possibly in a subdirectory. 
+possibly in a subdirectory.
 Essentially, you want a parallel structure to the docs file structure
 under `main`, with a separate snippets subfolder under `snippets` for each doc content
-subfolder. This is similar to having one test hierarchy. 
+subfolder. This is similar to having one test hierarchy.
 
 As more files are converted to using snippets, you'll increasingly just
-modify existing snippet files instead of creating new ones. 
+modify existing snippet files instead of creating new ones.
 
 Put the agoric-sdk code you want to use in its appropriate snippets file.
 Remember, the code must be able to run without errors. For it to do so,
@@ -244,7 +244,7 @@ To include a defined snippet in a Markdown file, put a
 line like `<<< @/snippets/test-intro-zoe.js#install` in it.
 Replace the `test-intro-zoe.js` with the filename in the snippets file.
 Replace the `install` with the name of the region you want included from
-the file. 
+the file.
 
 The tests should be in the snippets directory. Actually the snippet files and the test files ended up being the same file because that was the cleanest way to go. The snippet files should all be named test-original-filename.js where original-filename is the markdown filename, like amounts of ertp/guide/amounts.md
 
@@ -258,20 +258,20 @@ Note that the PR will automatically test and lint files. The above is for local 
 
 ### Check Links
 
-To check internal VuePress links locally, run the shell command `yarn check-links` from anywhere in the 
+To check internal VuePress links locally, run the shell command `yarn check-links` from anywhere in the
 root of the local repo folder or below.
 
-Note this does **not** check either external links or router-links. Output is the text of any 
+Note this does **not** check either external links or router-links. Output is the text of any
 broken links, and what file and line number they're at.
 
 ## Local Install, Build, and Run
 
-1. **Clone**: Clone the Documentation repo to your local machine. We suggest using 
+1. **Clone**: Clone the Documentation repo to your local machine. We suggest using
 Sourcetree to manage your local and remote copies and the various commits
 and pull requests you'll make while debugging. The following steps should all
 be run from the directory you cloned the repo into.
 
-2. **Install**: To ensure using the latest agoric-sdk 
+2. **Install**: To ensure using the latest agoric-sdk
 version when running code snippets, from a shell, run
 ```shell
 agoric install
@@ -284,7 +284,7 @@ yarn docs:build
 ```shell
 yarn docs:dev
 ```
-Most edit changes are immediately reflected in the browser, but 
+Most edit changes are immediately reflected in the browser, but
 applying site config changes may require stopping and restarting this program.
 
 View your local documentation site at `localhost:8080/documentation/`
@@ -297,7 +297,7 @@ zoeVersion: 'Beta Release v1.0.0',
 zoeDocsUpdated: 'Apr 7, 2021'
 ```
 Edit the values to be current. The current Zoe version is the "version" field of
-[Zoe's package.json](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/package.json),
+[Zoe's package.json](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/package.json),
 normally on line 3.
 
 ## Editing Site Menus
@@ -312,7 +312,7 @@ sidebar menu.
 
 For example, "Introduction to Zoe" appears in two sidebar menus. One for Zoe docs, and one for
 Getting Started docs. So if you're viewing either a Zoe API doc or the "Before Starting an Agoric Project"
-doc in Getting Started, you'll see "Introduction to Zoe" as an item in both of the two different sidebar menus. 
+doc in Getting Started, you'll see "Introduction to Zoe" as an item in both of the two different sidebar menus.
 
 But if you're viewing "Introduction to Zoe" itself, you'll always see the Getting Started sidebar menu. There's
 no way to have it sometimes (appropriately) display the Zoe sidebar menu instead.
@@ -336,9 +336,9 @@ Each entry is an object with three or four properties:
   submenu item. Of the form `link: '/zoe/guide'` where the opening `/` starts the path at `main/`. In this
   case, no filename was given, so it defaults to `guide`'s `README.md` file. If not present, the menubar
   entry is not clickable.
-- `items`: Optional. An array of submenu item objects, each of which is a single submenu item of its 
+- `items`: Optional. An array of submenu item objects, each of which is a single submenu item of its
   parent navbar item. Not present if the item doesn't have a submenu.
-  
+
 To add an entry to the top menubar, just add a menu item object to the array. We suggest copying a
 similar one, adding the copy, and editing the copy's property values to be those of the new item and
 its submenus. To delete an entry, just remove its object from the menubar item array.
@@ -356,19 +356,19 @@ module.exports = [
         // Submenu item
       }
     ]
-  },     
+  },
   {
     text: 'Learn More',
     ariaLabel: 'Learn More Menu',
     items: [
       {
         // Submenu item
-      },      
+      },
       {
         // Submenu item
       }
     ]
-  },  
+  },
 ]
 ```
 #### Configuring the top menubar submenus
@@ -395,7 +395,7 @@ property values to be what you want for the new item. To delete a submenu item, 
 entry from the `items` array.
 ```js
 {
-    text: 'ERTP', 
+    text: 'ERTP',
     ariaLabel: 'ERTP Menu',
     link: '/ertp/guide/',
     items: [
@@ -449,19 +449,19 @@ Below is an abridged version of the ERTP sidebar. Each item entry has five prope
 - `path`: Where you go if you click on this menu item. As usual, the leading `/` denotes a path
   starting at `main`. Note the full file name is given, including the `.md` suffix (which VuePress
   will change to `.html` during its processing).
-- `collapsible`: Can this item be collapsed? So far, we don't have any collapsible items, so 
+- `collapsible`: Can this item be collapsed? So far, we don't have any collapsible items, so
   always give this property the value `false`.
 - `sideBarDepth`: How many levels can the sidebar show? The site-level
   default is 2, which displays h3 and is the max, but if fewer levels
   are desired, the setting can be overridden at the sidebar item
   level. More information
   [here](https://vuepress.vuejs.org/theme/default-theme-config.html#nested-header-links).
-  
+
 - `children`: An array of submenu items for this sidebar menu item. You just need to specify
   the file paths to where you want to go when the submenu item is clicked. VuePress uses the
   file's (including default README.md files for folders) H1 level header text for the sidebar text.
   You can also specify what text to use using the form `{ title: 'Mint', path: '/api/mint' }`.
-  
+
 ```js
       '/ertp/': [
         {
@@ -485,13 +485,13 @@ Below is an abridged version of the ERTP sidebar. Each item entry has five prope
         },
       ],
 ```
-When viewing a page, VuePress has automatically constructed a sidebar menu entry for that page 
+When viewing a page, VuePress has automatically constructed a sidebar menu entry for that page
 consisting of all `h1`, `h2`, and `h3` header titles on the page.
 
 ## Redirecting links
 
 If you reorganize part of the Documentation repo or delete/deprecate a file in favor of a replacement,
-you should establish a site URL redirect from the old file to the new one, in case anyone external to 
+you should establish a site URL redirect from the old file to the new one, in case anyone external to
 Agoric has made a link or bookmarked the old file.
 
 Go to (or create if not there) `documentation/main/.vuepress/enhanceApp.js` As of March 2021, ours
@@ -516,4 +516,3 @@ The general format should be self-explanatory. However, there are two things you
   one where it ends with `/`. For each individual file that is not a `README.md`, there are two ways to access it.
   So we cover both ways. No entry has a `.md` extension. The redirect happens after VuePress' build step, so there
   are no longer any Markdown files; they've been converted to .html. So that's what's redirected.
-  

--- a/main/guides/js-programming/hardened-js.md
+++ b/main/guides/js-programming/hardened-js.md
@@ -278,7 +278,7 @@ or not:
    - `require` (Use `import` module syntax instead.)
    - `localStorage`
       - [SwingSet](../platform/#swingset) orthogonal persistence means state lives indefinitely in ordinary variables and data structures and need not be explicitly written to storage.
-      - For high cardinality data, see [the `@agoric/store` package](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/store).
+      - For high cardinality data, see [the `@agoric/store` package](https://github.com/Agoric/agoric-sdk/tree/master/packages/store).
    - `global` (Use `globalThis` instead.)
  - authority-free but host-defined:
    - `Buffer`

--- a/main/guides/zoe/contract-requirements.md
+++ b/main/guides/zoe/contract-requirements.md
@@ -1,9 +1,9 @@
-# Contract Requirements 
+# Contract Requirements
 
 <Zoe-Version/>
 
 When writing a smart contract to run on Zoe, you need
-to know the proper format and other expectations. 
+to know the proper format and other expectations.
 
 A Zoe smart contract is a  JavaScript module that exports a `start` function
 and may import other code, including:
@@ -23,10 +23,10 @@ A Zoe contract will be bundled up, so you should feel free to divide
 your contract into multiple files (perhaps putting helper functions in a
 separate file, for example) and import them.
 
-A Zoe contract needs to be able to run under [Agoric's SES shim for Hardened JavaScript](https://github.com/endojs/endo/tree/HEAD/packages/ses). Some legacy
+A Zoe contract needs to be able to run under [Agoric's SES shim for Hardened JavaScript](https://github.com/endojs/endo/tree/master/packages/ses). Some legacy
 JavaScript code is incompatible with Hardened JavaScript, because Lockdown freezes the
 JavaScript objects you start out with (the primordials, such as `Object`), and some legacy code tries to
-mutate these. 
+mutate these.
 
 If you add this type annotation, TypeScript-aware tools
 (IDEs like vsCode and WebStorm) will inform the developer about parameters
@@ -60,12 +60,12 @@ The contract must return a record with any (or none) of the following:
 that calls `E(zoe).startInstance()`; i.e. the party that was the creator of the current
 contract `instance`. It might create `invitations` for other parties, or take actions that
 are unrelated to making offers.
-- **creatorInvitation**: A Zoe `invitation` only given to the entity that 
-calls `E(zoe).startInstance()`; i.e. the party that was the creator of the current 
-contract `instance`. This is usually used when a party has to make an offer first, 
+- **creatorInvitation**: A Zoe `invitation` only given to the entity that
+calls `E(zoe).startInstance()`; i.e. the party that was the creator of the current
+contract `instance`. This is usually used when a party has to make an offer first,
 such as escrowing the underlying good for sale in an auction or covered call.
-- **publicFacet**: An object available through Zoe to anyone who knows the contract `instance`. 
-Use the `publicFacet` for general queries and actions, such as getting the current price 
+- **publicFacet**: An object available through Zoe to anyone who knows the contract `instance`.
+Use the `publicFacet` for general queries and actions, such as getting the current price
 or creating public `invitations`.
 
 The contract can contain arbitrary JavaScript code, but there are a few things you'll want

--- a/main/guides/zoe/contracts/atomic-swap.md
+++ b/main/guides/zoe/contracts/atomic-swap.md
@@ -4,16 +4,16 @@
 
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/atomicSwap.js) (Last updated: Sep 12, 2020)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 If I want to trade one kind of asset for another kind, I could send
 you the asset and ask you to send the other kind back. But, you
 could behave opportunistically by receiving my asset and giving
-nothing back. 
+nothing back.
 
-To solve this problem, Zoe-based swap contracts let users 
-securely trade one kind of digital asset for another kind. 
-By using Zoe for escrow and offer safety, they insure no 
+To solve this problem, Zoe-based swap contracts let users
+securely trade one kind of digital asset for another kind.
+By using Zoe for escrow and offer safety, they insure no
 user can ever behave opportunistically.
 
 In our `atomicSwap` contract, anyone can securely swap with a counterparty.
@@ -37,8 +37,8 @@ const { creatorInvitation } =
 Then Alice escrows her offer with Zoe. She passes in two
 things; the actual ERTP payments of her offer, and a
 `proposal`. Zoe uses the proposal to protect Alice from the
-smart contract (which may have been written by someone else) 
-and other participants. 
+smart contract (which may have been written by someone else)
+and other participants.
 
 A proposal has three parts:
 - `give`: What this party will give to the swap. Used by Zoe to enforce offer safety (Alice will get back what she gave or what she wanted).
@@ -59,7 +59,7 @@ const aliceProposal = harden({
 const alicePayment = await E(aliceMoolaPurse).withdraw(threeMoola);
 ```
 
-For Alice to escrow with Zoe, she needs to use her invitation.  
+For Alice to escrow with Zoe, she needs to use her invitation.
 Then she makes her offer and receives a `seat`. The `seat`
 gives her access to the offer's result and her payouts.
 
@@ -100,8 +100,8 @@ assert(AmountMath.isEqual(bobInvitationValue.price, simoleans(7)), details`wrong
 ```
 
 Bob decides to exercise the invitation, and to escrow his payments. He then
-uses his invitation to make an offer, the same way that Alice used hers. 
-But Bob has written his proposal to match Alice's (notice that the `give` 
+uses his invitation to make an offer, the same way that Alice used hers.
+But Bob has written his proposal to match Alice's (notice that the `give`
 and `want` clauses are reversed from Alice's proposal):
 
 ```js secondary style2
@@ -133,7 +133,7 @@ const moolaRefundAmount = aliceMoolaPurse.deposit(aliceAssetPayout);
 const simoleanGainAmount = aliceSimoleansPurse.deposit(alicePricePayout);
 ```
 
-Bob's payout is also available. Since he already knows what Alice's offer was, 
+Bob's payout is also available. Since he already knows what Alice's offer was,
 he doesn't need to look for a simolean refund.
 
 ```js secondary style2

--- a/main/guides/zoe/contracts/automatic-refund.md
+++ b/main/guides/zoe/contracts/automatic-refund.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/automaticRefund.js) (Last updated: Jan 31, 2022)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This is a very trivial contract to explain and test Zoe.
 AutomaticRefund just gives you back what you put in. AutomaticRefund

--- a/main/guides/zoe/contracts/barter-exchange.md
+++ b/main/guides/zoe/contracts/barter-exchange.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/a564c6081976d7b66b3cdf54e0ba8903c8f1ee6d/packages/zoe/src/contracts/barterExchange.js) (Last updated: Sep 14, 2020)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 Barter Exchange takes offers for trading arbitrary goods for one another.
 
@@ -16,7 +16,7 @@ registration of issuers, it can handle trades between goods of any
 type. It's like conventional "barter" in that there's no common
 currency. "I have cantaloupes and am looking for pillow cases." It
 keeps an order book, and each time it receives a new offer, it looks
-for matches throughout the order book. 
+for matches throughout the order book.
 
 The Barter Exchange only accepts offers that look like
 `{ give: { In: amount }, want: { Out: amount}` }

--- a/main/guides/zoe/contracts/constantProductAMM.md
+++ b/main/guides/zoe/contracts/constantProductAMM.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/7d141a47b311363f099f496d4ed9b4d0f28c8fff/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js) (Last updated: Aug 15, 2022)
-##### [View contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 
 The Constant Product AMM is an automated market maker (AMM) that supports multiple
@@ -71,7 +71,7 @@ const quote = E(publicFacet).getOutputPrice(
   AmountMath.makeEmpty(ATMBrand),
 );
   ```
-  
+
 Let's assume the quote says she needs to provide 216 ATM. Sara believes the
 price is somewhat volatile, and she doesn't want to make repeated calls, so she pads
 her offer. If the appropriate pools don't exist, she'll get an error (`brands were

--- a/main/guides/zoe/contracts/covered-call.md
+++ b/main/guides/zoe/contracts/covered-call.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/coveredCall.js) (Last updated: Sep 12, 2020)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 The owner of an asset can use a covered call to give someone else the right
 to buy the asset at a certain price, called the strike price. That right
@@ -148,7 +148,7 @@ const swapIssuerKeywordRecord = harden({
 const bobSwapSeat =
   await E(zoe).startInstance(swapInstallation, swapIssuerKeywordRecord);
 ```
-  
+
 Bob specifies that he wants to swap the invitation for 1 buck, and escrows
 the covered call invitation. In exchange, he gets a swap invitation he can
 share.

--- a/main/guides/zoe/contracts/escrow-to-vote.md
+++ b/main/guides/zoe/contracts/escrow-to-vote.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/test/unitTests/contracts/escrowToVote.js) (Last updated: Jan 31, 2022)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This contract implements coin voting. There are two roles: the
 Secretary, who can determine the question (a string), make voting

--- a/main/guides/zoe/contracts/fundedCallSpread.md
+++ b/main/guides/zoe/contracts/fundedCallSpread.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/callSpread/fundedCallSpread.js) (Last updated: Feb 20, 2022)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This contract implements a fully collateralized call spread. You can use a call spread as a
 [financial building block](https://youtu.be/m5Pf2d1tHCs) to create futures, puts, calls, and event

--- a/main/guides/zoe/contracts/loan.md
+++ b/main/guides/zoe/contracts/loan.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/loan/index.js) (Last updated: Nov 23, 2021)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 The basic loan contract has two parties, a *lender* and a *borrower*.
 It lets the borrower add collateral of a particular brand and get a
@@ -16,7 +16,7 @@ The loan does not have a distinct end time. Rather, if the
 value of the collateral changes such that insufficient margin is
 provided, the collateral is liquidated, and the loan is closed. At any
 time, the borrower can add collateral or repay the loan with interest,
-closing the loan. 
+closing the loan.
 
 Note that all collateral must be of the same brand and all of the
 loaned amount and interest must be of the same (separate) brand.
@@ -28,7 +28,7 @@ loaned amount and interest must be of the same (separate) brand.
    drops below `mmr`, liquidation can occur.
 * [`priceAuthority`](/guides/zoe/price-authority.md) - used for getting the current value of
    collateral and setting liquidation triggers.
-* `autoswapInstance` - The running contract instance for 
+* `autoswapInstance` - The running contract instance for
    [AMM](./constantProductAMM.md) installation. The `publicFacet`
    of the instance is used to make an invitation to sell the
    collateral on liquidation.
@@ -104,7 +104,7 @@ The contract shuts down under any one of 3 conditions:
 3. An error occurs when trying to use the priceAuthority.
    * The lender gets the collateral, and the borrower keeps their loan.
 
-## Debt and Interest Calculation 
+## Debt and Interest Calculation
 
 Interest is calculated and compounded when the
 `periodNotifier` pushes a new value. The interest rate per period
@@ -120,7 +120,7 @@ recalculated: (`E(borrowFacet).getLastCalculationTimestamp()`).
 
 Liquidation is scheduled using the `priceAuthority` parameter.
 Specifically, the contract gets a promise resolved when the value of the
-collateral falls below a trigger value defined by the `mmr` parameter: 
+collateral falls below a trigger value defined by the `mmr` parameter:
 
 <<< @/snippets/zoe/contracts/test-loan.js#liquidate
 
@@ -138,4 +138,3 @@ Actual liquidation is done through an AMM
 regardless of its current price.
 Even if the price is worse or better than what our `priceAuthority`
 quoted, we still liquidate.
-

--- a/main/guides/zoe/contracts/mint-and-sell-nfts.md
+++ b/main/guides/zoe/contracts/mint-and-sell-nfts.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/mintAndSellNFT.js) (Last updated: Jan 31, 2022)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This contract mints non-fungible tokens and creates a selling contract
 instance to sell the tokens in exchange for some sort of money.

--- a/main/guides/zoe/contracts/mint-payments.md
+++ b/main/guides/zoe/contracts/mint-payments.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/mintPayments.js) (Last updated: Jan 31, 2022)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This very simple contract shows how to create a new issuer kit and
 mint payments from it. The contract pays out new tokens to anyone who

--- a/main/guides/zoe/contracts/oracle.md
+++ b/main/guides/zoe/contracts/oracle.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4c4da6a7ae76aebbff2af48613008978eb04462b/packages/zoe/src/contracts/oracle.js) (Last updated: Jan 31, 2022)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 **NOTE: You almost certainly do not want to use this contract directly.
 Instead, please read the [Chainlink integration
@@ -26,7 +26,7 @@ documentation](/guides/chainlink-integration.md).
 ## Making a Free Query
 
 To make a free query, obtain the `publicFacet` for the oracle contract
-instance. 
+instance.
 
 <<< @/snippets/zoe/contracts/test-oracle.js#freeQuery
 
@@ -57,7 +57,7 @@ a `creatorFacet`.
 You will need to use the creatorFacet to initialize an
 `oracleHandler`. The `oracleHandler` is what will actually be queried,
 so we do not want to put it in the contract terms, which are publicly
-accessible. 
+accessible.
 
 <<< @/snippets/zoe/contracts/test-oracle.js#initialize
 
@@ -66,5 +66,3 @@ accessible.
 The contract expects all `oracleHandlers` to offer the following API:
 
 <<< @/snippets/zoe/contracts/test-oracle.js#API
-
-

--- a/main/guides/zoe/contracts/otc-desk.md
+++ b/main/guides/zoe/contracts/otc-desk.md
@@ -3,12 +3,12 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/otcDesk.js) (Last updated: Mar 1, 2022)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 ![Building a Composable DeFi Contract](./assets/title.jpg)
 
 This is the OTC Desk contract from the ["Building a
-Composable DeFi Contract" episode of Cosmos Code With 
+Composable DeFi Contract" episode of Cosmos Code With
 Us](https://cosmos.network/series/code-with-us/building-a-composable-defi-contract).
 
 [Watch the replay of the

--- a/main/guides/zoe/contracts/pricedCallSpread.md
+++ b/main/guides/zoe/contracts/pricedCallSpread.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/callSpread/pricedCallSpread.js) (Last updated: Feb 20, 2022)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This contract implements a fully collateralized call spread. You can use a call spread as a
 [financial building block](https://youtu.be/m5Pf2d1tHCs) to create futures, puts, calls, and event

--- a/main/guides/zoe/contracts/second-price-auction.md
+++ b/main/guides/zoe/contracts/second-price-auction.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/a564c6081976d7b66b3cdf54e0ba8903c8f1ee6d/packages/zoe/src/contracts/auction/secondPriceAuction.js) (Last updated: Sep 14, 2020)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 In a second-price auction, the winner is the participant with the highest bid, but
 the winner only pays the price corresponding to the second highest

--- a/main/guides/zoe/contracts/sell-items.md
+++ b/main/guides/zoe/contracts/sell-items.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/src/contracts/sellItems.js) (Last updated: Feb 4, 2022)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 Sell items in exchange for money. Items may be fungible or
 non-fungible and multiple items may be bought at once. Money must be

--- a/main/guides/zoe/contracts/simple-exchange.md
+++ b/main/guides/zoe/contracts/simple-exchange.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/f29591519809dbadf19db0a26f38704d87429b89/packages/zoe/src/contracts/simpleExchange.js) (Last updated: Sep 12, 2020)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 The "simple exchange" is a very basic, un-optimized exchange. It
 has an order book for one asset, priced in a second asset. The order
@@ -24,8 +24,8 @@ accepted in either direction.
 { give: { Asset: simoleans(5) }, want: { Price: quatloos(3) } }
 { give: { Price: quatloos(8) }, want: { Asset: simoleans(3) } }
 ```
-Note: Here we used a shorthand for assets whose values are 5 simoleons, 3 
-quatloos, 8 quatloos, and 3 simoleons. Elsewhere this might have been done 
+Note: Here we used a shorthand for assets whose values are 5 simoleons, 3
+quatloos, 8 quatloos, and 3 simoleons. Elsewhere this might have been done
 by creating `amounts` inline (i.e. `AmountMath.make(quatloosBrand, 8n)`). Or by
 creating `amounts` outside the proposal and assigning them to variables.
 For example, `const quatloos8 = AmountMath.make(quatloosBrand, 8n);` and then using

--- a/main/guides/zoe/contracts/use-obj-example.md
+++ b/main/guides/zoe/contracts/use-obj-example.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/4e0aece631d8310c7ab8ef3f46fad8981f64d208/packages/zoe/test/unitTests/contracts/useObjExample.js) (Last updated: Jan 31, 2022)
-##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This contract is an example of associating a particular ability
 with ownership of a non-fungible token (NFT). In this case, ownership

--- a/main/guides/zoe/contracts/vault.md
+++ b/main/guides/zoe/contracts/vault.md
@@ -3,7 +3,7 @@
 <Zoe-Version/>
 
 ##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/7d141a47b311363f099f496d4ed9b4d0f28c8fff/packages/inter-protocol/src/vaultFactory/vaultFactory.js) (Last updated: Aug 15, 2022)
-##### [View contracts on Github](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts)
+##### [View contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 
 The Vault is the primary mechanism for making `IST` (the Agoric stable-value
@@ -110,4 +110,3 @@ The Vault's public API includes `makeVaultInvitation()` and
 `getAmm()` returns the public facet of the AMM. `getRunIssuer()` provides access
 to the issuer of `IST` so anyone can hold, spend and recognize IST.
 `makeVaultInvitation()` is described above under [Borrowers](#borrowers)
-

--- a/main/guides/zoe/price-authority.md
+++ b/main/guides/zoe/price-authority.md
@@ -7,9 +7,9 @@ various time and price conditions.
 ## Examples
 
 To see a `priceAuthority` in use, see the [Loan
-contract](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts/loan)
+contract](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts/loan)
 and the [Call Spread
-contracts](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe/src/contracts/callSpread).
+contracts](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts/callSpread).
 
 ## Receiving a Quote
 
@@ -48,13 +48,12 @@ requested.
 
 ## Mutable Price Quotes
 
-`MutableQuote`'s method `getPromise()` returns a `Promise` for a `PriceQuote`, 
-which is the same as what is returned by the `quoteWhenLTE()` API method and variants. 
+`MutableQuote`'s method `getPromise()` returns a `Promise` for a `PriceQuote`,
+which is the same as what is returned by the `quoteWhenLTE()` API method and variants.
 Effectively, the non-mutable price quote methods return a single `PriceQuote`, while
-the mutable price quote methods return a reusable object which can be manipulated 
-by changing its trigger levels or by cancelling it. 
+the mutable price quote methods return a reusable object which can be manipulated
+by changing its trigger levels or by cancelling it.
 
 ## API Reference
 
 The Price Authority API reference is a section of the [Zoe API reference](/reference/zoe-api/contract-support/price-authority.md)
-

--- a/main/reference/ertp-api/ertp-data-types.md
+++ b/main/reference/ertp-api/ertp-data-types.md
@@ -4,12 +4,12 @@ ERTP introduces and uses several data types.
 
 ## Amount
 
-An **Amount** is a description of digital assets, answering the 
-questions "how much?" and "of what kind?". It is a **[Value](#value)** ("how much?") 
+An **Amount** is a description of digital assets, answering the
+questions "how much?" and "of what kind?". It is a **[Value](#value)** ("how much?")
 labeled with a **[Brand](./brand.md)** ("of what kind?"). The **[AmountMath](./amount-math.md)** object
 introduces a library of methods that can be used to manipulate and analyze **Amounts**.
 
-Note that **Amounts** can describe either fungible or non-fungible assets. 
+Note that **Amounts** can describe either fungible or non-fungible assets.
 
 ```js
 someAmount: {
@@ -24,7 +24,7 @@ An **AmountShape** is a description of non-fungible digital assets. Similar to *
 **AmountShape** has 2 properties: a **[Brand](./brand.md)**, which states what kind of asset this is,
 and a **ValueShape**, which is an object containing however many properties are required to describe
 this non-fungible asset. Note that an asset's **ValueShape** is defined by the *elementShape* parameter
-when the asset's **[Issuer](./issuer.md)** is created via the 
+when the asset's **[Issuer](./issuer.md)** is created via the
 **[makeIssuerKit()](./issuer.md#makeissuerkit-allegedname-assetkind-displayinfo-optshutdownwithfailure-elementshape)** function.
 
 ```js
@@ -52,10 +52,10 @@ There are several kinds of Assets.
 - **AssetKind.COPY_SET** : Used with non-fungible assets where there can't be duplicates (e.g., assigned seats in a stadium). **Values** are arrays of objects.
 - **AssetKind.COPY_BAG** : Used with non-fungible assets where there can be duplicates. (e.g., weapons in a computer game). **Values** are arrays of objects.
 
-Even though very different mathematical processes are performed, 
+Even though very different mathematical processes are performed,
 **[AmountMath](./amount-math.md)** methods work for all kinds of assets.
 
-Use **[makeIssuerKit()](./issuer.md#makeissuerkit-allegedname-assetkind-displayinfo-optshutdownwithfailure-elementshape)** to specify which **AssetKind** 
+Use **[makeIssuerKit()](./issuer.md#makeissuerkit-allegedname-assetkind-displayinfo-optshutdownwithfailure-elementshape)** to specify which **AssetKind**
 your contract uses. See the **[Issuer](./issuer.md)** documentation for details on how to use this method.
 
 ```js
@@ -70,9 +70,9 @@ A **DisplayInfo** data type is associated with a **[Brand](./brand.md)** and giv
 to display that **Brand**'s **[Amounts](#amount)**. **DisplayInfo** has one optional property,
 **decimalPlaces**, which takes a non-negative integer value.
 
-The **decimalPlaces** property tells the [display software](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/ui-components)
+The **decimalPlaces** property tells the [display software](https://github.com/Agoric/agoric-sdk/tree/master/packages/ui-components)
 how many places to move the decimal point over to the left so as to display the value
-in the commonly used denomination (e.g., display "10.00 dollars" rather than "1000 cents"). 
+in the commonly used denomination (e.g., display "10.00 dollars" rather than "1000 cents").
 
 Fungible digital assets are represented in integers, in their smallest unit.
 For example, the smallest unit for a US dollar might be either *dollar* or *cent*.
@@ -80,13 +80,9 @@ If it's *dollar*, **decimalPlaces** would be **0**. If it's *cent*, **decimalPla
 would be **2**. Similarly, if you want the smallest unit of ether (the cryptocurrency coin used on the Ethereum network) to be *wei* (one ether = 10<sup>18</sup> wei), then **decimalPlaces** would be **18**.
 
 Non-fungible assets have values that are arrays, so you shouldn't specify a **decimalPlaces** value
-for them. 
+for them.
 
 **decimalPlaces** should be used for display purposes only. Any
 other use is an anti-pattern.
 
 **DisplayInfo** also has an **[AssetKind](#assetkind)** property. Its value specifies the kind of the associated asset.
-
-
-
-

--- a/main/reference/repl/networking.md
+++ b/main/reference/repl/networking.md
@@ -14,9 +14,9 @@ vaguely like the BSD socket API. This code can:
 The type of connection is limited by the host in which the vat is running. Chain-based machines must operate in a platonic realm of replicated consensus, so their network options are limited to protocols like IBC, which allow one gestalt chain to talk to other chain-like entities. Each such entity is defined by an evolving set of consensus rules, which typically include a current set of validator public keys and a particular history of hashed block identifiers.
 
 **CAVEAT:** IBC uses
-[Connection](https://github.com/cosmos/ibc/tree/master/spec/core/ics-003-connection-semantics/README.md)
+[Connection](https://github.com/cosmos/ibc/tree/main/spec/core/ics-003-connection-semantics/README.md)
 to mean a chain-to-chain hop, and
-[Channel](https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics/README.md)
+[Channel](https://github.com/cosmos/ibc/tree/main/spec/core/ics-004-channel-and-packet-semantics/README.md)
 to mean a Port-to-Port pathway through a series of hops.
 This is unfortunate, because IBC "Channels" correspond most precisely to
 TCP "connections", and most discussions of network APIs (including this one,

--- a/main/reference/repl/networking.md
+++ b/main/reference/repl/networking.md
@@ -14,9 +14,9 @@ vaguely like the BSD socket API. This code can:
 The type of connection is limited by the host in which the vat is running. Chain-based machines must operate in a platonic realm of replicated consensus, so their network options are limited to protocols like IBC, which allow one gestalt chain to talk to other chain-like entities. Each such entity is defined by an evolving set of consensus rules, which typically include a current set of validator public keys and a particular history of hashed block identifiers.
 
 **CAVEAT:** IBC uses
-[Connection](https://github.com/cosmos/ibc/tree/HEAD/spec/core/ics-003-connection-semantics/README.md)
+[Connection](https://github.com/cosmos/ibc/tree/master/spec/core/ics-003-connection-semantics/README.md)
 to mean a chain-to-chain hop, and
-[Channel](https://github.com/cosmos/ibc/tree/HEAD/spec/core/ics-004-channel-and-packet-semantics/README.md)
+[Channel](https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics/README.md)
 to mean a Port-to-Port pathway through a series of hops.
 This is unfortunate, because IBC "Channels" correspond most precisely to
 TCP "connections", and most discussions of network APIs (including this one,


### PR DESCRIPTION
At https://github.com/endojs/endo/pull/1469#discussion_r1089011161 @turadg explains advantages of docs urls using `master` rather than `HEAD`. Although he says "not worth another commit", the advantages seem compelling enough to be worth one.

Recommend reviewing with "Hide whitespace"

See https://github.com/endojs/endo/pull/1473