### PR TITLE
fix: use legacy openssl algs, since vuepress is not using webpack5

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "node": ">=11.0"
   },
   "scripts": {
-    "docs:dev": "vuepress dev main",
-    "docs:build": "vuepress build main",
-    "docs:build-cf": "vuepress build main && cp _redirects main/.vuepress/dist/",
-    "docs:build-root": "yarn docs:build && yarn docs:re-root && cp _redirects main/.vuepress/dist-root/",
+    "docs:dev": "NODE_OPTIONS=--openssl-legacy-provider vuepress dev main",
+    "docs:build": "NODE_OPTIONS=--openssl-legacy-provider vuepress build main",
+    "docs:build-cf": "NODE_OPTIONS=--openssl-legacy-provider vuepress build main && cp _redirects main/.vuepress/dist/",
+    "docs:build-root": "NODE_OPTIONS=--openssl-legacy-provider yarn docs:build && yarn docs:re-root && cp _redirects main/.vuepress/dist-root/",
     "docs:re-root": "cd main && mkdir -p .vuepress/dist-root/ && cp -rp .vuepress/dist/ .vuepress/dist-root/documentation/",
     "check-links": "vuepress check-md main",
     "test": "ava",


### PR DESCRIPTION
Unfortunately, since vuepress is using webpack4, the OpenSSL provider needs to be set to legacy when building.  Once vuepress upgrades to webpack5, the legacy provider workaround can be removed.