### PR TITLE
reword multiple PSMs re software component

### DIFF
--- a/main/guides/zoe/actual-contracts/PSM.md
+++ b/main/guides/zoe/actual-contracts/PSM.md
@@ -20,7 +20,8 @@ in which case only one PSM will be instantiated.
 
 ## Instantiating the PSM
 
-There will be one instance of the PSM for each supported external stable token. 
+Each PSM instance pairs IST with one other token. To allow trading IST with
+multiple tokens, instantiate the PSM contract once for each.
 
 ## Creating an Offer
 


### PR DESCRIPTION
Phrase it in the ever-present tense to document the software component independent of how it may be deployed in a particular blockchain.