### PR TITLE
fix: missing await revealed by #7112

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
       "es6": true
     },
     "globals": {
+      "assert": "readonly",
       "harden": "readonly"
     },
     "rules": {

--- a/snippets/ertp/guide/test-issuers-and-mints.js
+++ b/snippets/ertp/guide/test-issuers-and-mints.js
@@ -157,7 +157,7 @@ test('ertp guide issuers and mints payment methods', async t => {
   // total amounts in badQuatloosAmounts equal 20, when it should equal 1000
   const badQuatloosAmounts = Array(2).fill(AmountMath.make(quatloosBrand, 10n));
   // throws error
-  t.throwsAsync(
+  await t.throwsAsync(
     () =>
       quatloosIssuer.splitMany(
         anotherQuatloosPayment,


### PR DESCRIPTION
Add in an `await` missing from a test case.

I think this missing `await` accounts for the error seen at https://github.com/Agoric/agoric-sdk/actions/runs/4329187639/jobs/7559543922 of PR https://github.com/Agoric/agoric-sdk/pull/7112