### PR TITLE
fix: removed unnecessary character

### DIFF
--- a/main/reference/zoe-api/zcfmint.md
+++ b/main/reference/zoe-api/zcfmint.md
@@ -6,13 +6,13 @@ methods.
 
 **ZCFMints** are created and returned by **Zoe Contract Facet's** **[zcf.makeZCFMint()](./zoe-contract-facet.md#zcf-makezcfmint-keyword-assetkind-displayinfo)** method.
 
-## aZCFMint.getIssuerRecord()
+## ZCFMint.getIssuerRecord()
   - Returns: **IssuerRecord**
 
 Returns an **IssuerRecord** containing the **[Issuer](/reference/ertp-api/issuer.md)** and
 **[Brand](/reference/ertp-api/brand.md)** associated with the **zcfMint**.
 
-## aZCFMint.mintGains(gains, zcfSeat?)
+## ZCFMint.mintGains(gains, zcfSeat?)
   - **gains** **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
   - **zcfSeat** **[ZCFSeat](./zcfseat.md)** - Optional.
   - Returns: **ZCFSeat**
@@ -23,7 +23,7 @@ Mint the *gains* **Amount** of assets and add them to
 that **seat**'s **[Allocation](./zoe-data-types.md#allocation)**. If a **seat** is provided,
 it is returned. Otherwise a new **seat** is returned.
 
-## aZCFMint.burnLosses(losses, zcfSeat?)
+## ZCFMint.burnLosses(losses, zcfSeat?)
   - **losses** **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
   - **zcfSeat** **[ZCFSeat](./zcfseat.md)** - Optional.
   - Returns: None.

--- a/main/reference/zoe-api/zcfseat.md
+++ b/main/reference/zoe-api/zcfseat.md
@@ -11,12 +11,12 @@ allocated to the offer. It also includes synchronous operations
 to manipulate the offer. The queries and operations are as follows:
 
 
-## aZCFSeat.getSubscriber()
+## ZCFSeat.getSubscriber()
 - Returns: **Subscriber**
 
 Returns the **Subscriber** for the seat.
 
-## aZCFSeat.getProposal()
+## ZCFSeat.getProposal()
   - Returns: **ProposalRecord**
 
 A **Proposal** is represented by a **ProposalRecord**. It is the rules
@@ -32,19 +32,19 @@ contract that they are entering when they make an offer. See
 const { want, give, exit } = sellerSeat.getProposal();
 ```
 
-## aZCFSeat.exit(completion)
+## ZCFSeat.exit(completion)
    - **completion** **Object**
    - Returns: None.
 
 Causes the **seat** to exit, concluding its existence. All **payouts**, if any,
 are made, and the **seat** object can no longer interact with the contract.
 The **completion** argument is usually a string, but this is not required. Its
-only use is for the notification sent to the contract instance's **done()** function. 
+only use is for the notification sent to the contract instance's **done()** function.
 Any other still open seats or outstanding promises and the contract instance continue.
 
-**Note**: You should not use **aZCFSeat.exit()** when exiting with an error. Use the method **[aZCFSeat.fail()](#azcfseat-fail-msg)** instead. 
+**Note**: You should not use **ZCFSeat.exit()** when exiting with an error. Use the method **[ZCFSeat.fail()](#ZCFseat-fail-msg)** instead.
 
-## aZCFSeat.fail(msg)
+## ZCFSeat.fail(msg)
    - **msg** **String**
    - Returns: None.
 
@@ -60,12 +60,12 @@ Agoric recommends you exit a seat with an error as follows
 throw seat.fail(Error('you did it wrong'));
 ```
 
-## aZCFSeat.hasExited()
+## ZCFSeat.hasExited()
   - Returns: **Boolean**
 
 Returns **true** if the **ZCFSeat** has exited, **false** if it is still active.
 
-## aZCFSeat.getAmountAllocated(keyword, brand)
+## ZCFSeat.getAmountAllocated(keyword, brand)
   - **keyword** **[Keyword](./zoe-data-types.md#keyword)**
   - **brand** **[Brand](/reference/ertp-api/brand.md)**
   - Returns: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
@@ -73,14 +73,14 @@ Returns **true** if the **ZCFSeat** has exited, **false** if it is still active.
 Returns the **Amount** from the part of the **[Allocation](./zoe-data-types.md#allocation)** that matches the
 *keyword* and *brand*. If the *keyword* is not in the **Allocation**, it
 returns an empty **Amount** of the *brand* argument. (After
-**aZCFSeat.exit()** has been called, it continues to report the final allocation balance, 
+**ZCFSeat.exit()** has been called, it continues to report the final allocation balance,
 which was transferred to a payout.)
 
 This is similar to the next method, **getCurrentAllocation()**. **getAmountAllocated()**
 gets the **Allocation** of one **Keyword** at a time, while **getCurrentAllocation()** returns
 all the current **Allocations** at once.
 
-## aZCFSeat.getCurrentAllocation()
+## ZCFSeat.getCurrentAllocation()
   - Returns: **[Allocation](./zoe-data-types.md#allocation)**
 
 An **Allocation** is an **AmountKeywordRecord** of key-value pairs where
@@ -108,13 +108,13 @@ An **Allocation** example:
 }
 ```
 
-## aZCFSeat.getStagedAllocation()
+## ZCFSeat.getStagedAllocation()
   - Returns: **[Allocation](./zoe-data-types.md#allocation)**
 
 Gets and returns the **stagedAllocation**, which is the **Allocation** committed if the seat is
 reallocated over, if offer safety holds, and rights are conserved.
 
-## aZCFSeat.isOfferSafe(newAllocation)
+## ZCFSeat.isOfferSafe(newAllocation)
    - **newAllocation** **[Allocation](./zoe-data-types.md#allocation)**
    - Returns **Boolean**
 
@@ -126,53 +126,53 @@ It checks whether **newAllocation** fully satisfies
 **proposal.want**. Both can be fully satisfied. See the ZoeHelper
 [**satisfies()**](./zoe-helpers.md#satisfies-zcf-seat-update) method for more details.
 
-## aZCFSeat.incrementBy(amountKeywordRecord)
+## ZCFSeat.incrementBy(amountKeywordRecord)
   - **amountKeywordRecord** **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
   - Returns: **AmountKeyRecord**
 
-Adds the **amountKeywordRecord** argument to the **ZCFseat**'s staged allocation and returns the 
+Adds the **amountKeywordRecord** argument to the **ZCFseat**'s staged allocation and returns the
 same **amountKeywordRecord** so it can be reused in another call. Note that this lets
-**zcfSeat1.incrementBy(zcfSeat2.decrementBy(amountKeywordRecord))** work as a usage pattern. 
+**zcfSeat1.incrementBy(zcfSeat2.decrementBy(amountKeywordRecord))** work as a usage pattern.
 
 Note that you can add amounts to original or staged allocations which do not have the
 specified **[Keyword](./zoe-data-types.md#keyword)** for the amount. The result is for the **Keyword** and amount to become part
 of the allocation. For example, if we start with a new, empty, allocation:
 ```js
 // Make an empty seat.
-const { zcfSeat: zcfSeat1 } = zcf.makeEmptySeatKit();  
+const { zcfSeat: zcfSeat1 } = zcf.makeEmptySeatKit();
 // The allocation is currently empty, i.e. `{}`
 const stagedAllocation = zcfSeat1.getStagedAllocation();
 const empty = AmountMath.makeEmpty(brand, AssetKind.NAT);
 // Try to incrementBy empty. This succeeds, and the keyword is added
 // with an empty amount.
-zcfSeat1.incrementBy({ IST: empty }); 
+zcfSeat1.incrementBy({ IST: empty });
 t.deepEqual(zcfSeat1.getStagedAllocation(), { IST: empty  });
 ```
-While this incremented the allocation by an empty amount, any amount would have been added to the 
-allocation in the same way. 
+While this incremented the allocation by an empty amount, any amount would have been added to the
+allocation in the same way.
 
 
-## aZCFSeat.decrementBy(amountKeywordRecord)
+## ZCFSeat.decrementBy(amountKeywordRecord)
   - **amountKeywordRecord** **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
   - Returns: **AmountKeywordRecord**
 
 Subtracts the **amountKeywordRecord** argument from the **ZCFseat**'s staged allocation and returns the
 same **amountKeywordRecord** so it can be used in another call.  Note that this lets
-**zcfSeat1.incrementBy(zcfSeat2.decrementBy(amountKeywordRecord))** work as a usage pattern.  
+**zcfSeat1.incrementBy(zcfSeat2.decrementBy(amountKeywordRecord))** work as a usage pattern.
 
-The amounts to subtract cannot be greater than the staged allocation (i.e., negative 
+The amounts to subtract cannot be greater than the staged allocation (i.e., negative
 results are not allowed).
 
-**decrementBy()** has different behavior from **incrementBy()** if the original or staged allocation 
+**decrementBy()** has different behavior from **incrementBy()** if the original or staged allocation
 does not have the **[Keyword](./zoe-data-types.md#keyword)** specified for an amount in the **amountKeywordRecord** argument. There are two
-cases to look at; when the corresponding amount to subtract is empty and when it isn't. 
+cases to look at; when the corresponding amount to subtract is empty and when it isn't.
 ```js
 // Make an empty seat.
-const { zcfSeat: zcfSeat1 } = zcf.makeEmptySeatKit();  
+const { zcfSeat: zcfSeat1 } = zcf.makeEmptySeatKit();
 // The allocation is currently {}
 const stagedAllocation = zcfSeat1.getStagedAllocation();
 const empty = AmountMath.makeEmpty(brand, AssetKind.NAT);
-// decrementBy empty does not throw, and does not add a keyword 
+// decrementBy empty does not throw, and does not add a keyword
 zcfSeat1.decrementBy({ IST: empty });
 t.deepEqual(zcfSeat1.getStagedAllocation(), {});
 ```
@@ -181,12 +181,12 @@ the operation was to try to subtract it from the allocation. Subtracting somethi
 does not add it to the original value. For example, if I tell you I'm taking away the Mona Lisa from
 you and you are not the Louvre and don't have it, you still don't have it after I try to take it away.
 In the above example, trying to take away an empty amount from an empty allocation is effectively a
-null operation; the allocation is still empty, didn't add the new **Keyword**, and no error is thrown. 
+null operation; the allocation is still empty, didn't add the new **Keyword**, and no error is thrown.
 
 However, decrementing a non-empty amount from an empty allocation has a different result. For example:
 ```js
 // Make an empty seat.
-const { zcfSeat: zcfSeat1 } = zcf.makeEmptySeatKit();  
+const { zcfSeat: zcfSeat1 } = zcf.makeEmptySeatKit();
 // The allocation is currently {}
 const stagedAllocation = zcfSeat1.getStagedAllocation();
 // decrementBy throws for a keyword that does not exist on the stagedAllocation and a non-empty amount
@@ -196,13 +196,13 @@ It throws an error because you cannot subtract something from nothing. So trying
 allocation by a non-empty amount is an error, while decrementing an empty allocation by an empty amount
 is effectively a null operation with no effects.
 
-## aZCFSeat.clear()
+## ZCFSeat.clear()
   - Returns: None.
 
 Deletes the **ZCFSeat**'s current staged allocation, if any.
 
 
-## aZCFSeat.hasStagedAllocation()
+## ZCFSeat.hasStagedAllocation()
   - Returns: **Boolean**
 
 Returns **true** if there is a staged allocation, i.e., whether **ZCFSeat.incrementBy()** or


### PR DESCRIPTION
While referencing the documentation I noticed an unnecessary character, "a", preceding "ZCFSeat". I did not seek out any other instances of this in the documentation - this PR only addresses what I came across a moment ago. 

It's not extensive, but I felt it was worth opening a PR to resolve this quickly.

### Link to live issue
[ZCFSeat - docs.agoric.com](https://docs.agoric.com/reference/zoe-api/zcfseat.html)

### Screengrab of issue
https://user-images.githubusercontent.com/6646552/228098212-76c40f81-f9f4-47df-ba2f-3ce6c3fa8904.mp4




