### PR TITLE
package.json: set 'engines' to same value as SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Documentation of Agoric products",
   "type": "module",
   "engines": {
-    "node": "^18"
+    "node": "^16.13 || ^18.12"
   },
   "scripts": {
     "docs:dev": "NODE_OPTIONS=--openssl-legacy-provider vuepress dev main",


### PR DESCRIPTION
The docs repo must not be more strict than the SDK, otherwise the agoric-sdk "test-documentation" CI workflow fails.

Reverts/replaces one piece of 2835b382dfc3b73e3568627ebed78fe1a2cbc67d