### PR TITLE
fix: counter example heading/description

### DIFF
--- a/main/guides/js-programming/far.md
+++ b/main/guides/js-programming/far.md
@@ -1,7 +1,7 @@
 
 # Far(), Remotable, and Marshaling
 
-To export objects such as from the [Example Secure JavaScript Code](./hardened-js.md#example-secure-javascript-code)
+To export objects such as from the [Example Secure JavaScript Code](./hardened-js.md#example-hardened-javascript-code)
 to make them available to other vats, mark them as _remotable_ using [Far](#far-api):
 
 <<< @/snippets/test-distributed-programming.js#importFar

--- a/main/guides/js-programming/hardened-js.md
+++ b/main/guides/js-programming/hardened-js.md
@@ -9,9 +9,9 @@ The last 10 minutes are Q&A._
 :::
 
 
-## Example Secure JavaScript Code
+## Example Hardened JavaScript Code
 
-Below is an example of a reliable, secure smart contract written in JavaScript.
+The example below demonstrates several features of Hardened JavaScript.
 
 <<< @/snippets/test-hardened-js.js#makeCounter
 


### PR DESCRIPTION
The counter example is not a smart contract. A smart contract in our framework is a module that exports a `start` or `prepare` function.

And "x is secure" is a claim that we typically don't make. Security is rarely an absolute property but more often a matter of degree.