### PR TITLE
Deprecatedzoe

### DIFF
--- a/main/reference/ertp-api/amount-math.md
+++ b/main/reference/ertp-api/amount-math.md
@@ -18,8 +18,8 @@ not equal, an error is thrown and no changes are made.
 
 
 ## AmountMath.make(brand, allegedValue)
-- **brand** **[Brand](./brand.md)**
-- **allegedValue** **[Value](./ertp-data-types.md#value)**
+- **brand**: **[Brand](./brand.md)**
+- **allegedValue**: **[Value](./ertp-data-types.md#value)**
 - Returns: **[Amount](./ertp-data-types.md#amount)**
 
 Creates an **Amount** from a given **Value** and a **Brand**.
@@ -30,8 +30,8 @@ const amount837 = AmountMath.make(quatloosBrand, 837n);
 ```
 
 ## AmountMath.coerce(brand, allegedAmount)
-- **brand** **[Brand](./brand.md)**
-- **allegedAmount** **[Amount](./ertp-data-types.md#amount)**
+- **brand**: **[Brand](./brand.md)**
+- **allegedAmount**: **[Amount](./ertp-data-types.md#amount)**
 - Returns: **Amount**
 
 Makes sure an **Amount** is for the specified *brand* and if so, returns it.
@@ -44,8 +44,8 @@ const verifiedAmount = AmountMath.coerce(quatloosBrand, allegedAmount);
 ```
 
 ## AmountMath.getValue(brand, amount)
-- **brand** **[Brand](./brand.md)**
-- **amount** **[Amount](./ertp-data-types.md#amount)**
+- **brand**: **[Brand](./brand.md)**
+- **amount**: **[Amount](./ertp-data-types.md#amount)**
 - Returns: **[Value](./ertp-data-types.md#amount)**
 
 Returns the **Value** from the given **Amount**.
@@ -57,8 +57,8 @@ const quatloos123 = AmountMath.make(quatloosBrand, 123n);
 const myValue = AmountMath.getValue(quatloosBrand, quatloos123);
 ```
 ## AmountMath.makeEmpty(brand, assetKind)
-- **brand** **[Brand](./brand.md)**
-- **assetKind** **[AssetKind](./ertp-data-types.md#assetkind)**
+- **brand**: **[Brand](./brand.md)**
+- **assetKind**: **[AssetKind](./ertp-data-types.md#assetkind)**
 - Returns: **[Amount](./ertp-data-types.md#amount)**
 
 Returns the **Amount** representing an empty **Amount** for the *brand* parameter's 
@@ -74,7 +74,7 @@ const empty = AmountMath.makeEmpty(quatloosBrand, AssetKind.NAT);
 ```
 
 ## AmountMath.makeEmptyFromAmount(amount)
-- **amount** **[Amount](./ertp-data-types.md#amount)**
+- **amount**: **[Amount](./ertp-data-types.md#amount)**
 - Returns: **Amount**
 
 Returns the **Amount** representing an empty **Amount**, using another
@@ -88,8 +88,8 @@ const quatloosAmount0 = AmountMath.makeEmptyFromAmount(quatloosAmount837);
 ```
 
 ## AmountMath.isEmpty(amount, brand?)
-- **amount** **[Amount](./ertp-data-types.md#amount)**
-- **brand** **[Brand](./brand.md)** - Optional, defaults to **undefined**.
+- **amount**: **[Amount](./ertp-data-types.md#amount)**
+- **brand**: **[Brand](./brand.md)** - Optional, defaults to **undefined**.
 - Returns: **Boolean**
 
 Returns **true** if the **Amount** is empty. Otherwise returns **false**.
@@ -108,9 +108,9 @@ const result = AmountMath.isEmpty(quatloos1);
 ```
 
 ## AmountMath.isGTE(leftAmount, rightAmount, brand?)
-- **leftAmount** **[Amount](./ertp-data-types.md#amount)**
-- **rightAmount** **Amount**
-- **brand** **[Brand](./brand.md)** - Optional, defaults to **undefined**.
+- **leftAmount**: **[Amount](./ertp-data-types.md#amount)**
+- **rightAmount**: **Amount**
+- **brand**: **[Brand](./brand.md)** - Optional, defaults to **undefined**.
 - Returns: **Boolean**
 
 Returns **true** if the **[Value](./ertp-data-types.md#value)** of *leftAmount* is greater than or equal to
@@ -142,9 +142,9 @@ AmountMath.isGTE(quatloos5, quatloos5);
 ```
 
 ## AmountMath.isEqual(leftAmount, rightAmount, brand?)
-- **leftAmount** **[Amount](./ertp-data-types.md#amount)**
-- **rightAmount** **Amount**
-- **brand** **[Brand](./brand.md)** - Optional, defaults to **undefined**.
+- **leftAmount**: **[Amount](./ertp-data-types.md#amount)**
+- **rightAmount**: **Amount**
+- **brand**: **[Brand](./brand.md)** - Optional, defaults to **undefined**.
 - Returns: **Boolean**
 
 Returns **true** if the **[Value](./ertp-data-types.md#value)** of *leftAmount* is equal to
@@ -178,9 +178,9 @@ AmountMath.isEqual(empty, quatloos10);
 ```
 
 ## AmountMath.add(leftAmount, rightAmount, brand?)
-- **leftAmount** **[Amount](./ertp-data-types.md#amount)**
-- **rightAmount** **Amount**
-- **brand** **[Brand](./brand.md)** - Optional, defaults to **undefined**.
+- **leftAmount**: **[Amount](./ertp-data-types.md#amount)**
+- **rightAmount**: **Amount**
+- **brand**: **[Brand](./brand.md)** - Optional, defaults to **undefined**.
 - Returns: **Amount**
 
 Returns a new **Amount** that is the union of *leftAmount* and *rightAmount*. Both
@@ -206,9 +206,9 @@ const combinedList = AmountMath.add(listAmountA, listAmountB);
 ```
 
 ## AmountMath.subtract(leftAmount, rightAmount, brand?)
-- **leftAmount** **[Amount](./ertp-data-types.md#amount)**
-- **rightAmount** **Amount**
-- **brand** **[Brand](./brand.md)** - Optional, defaults to **undefined**.
+- **leftAmount**: **[Amount](./ertp-data-types.md#amount)**
+- **rightAmount**: **Amount**
+- **brand**: **[Brand](./brand.md)** - Optional, defaults to **undefined**.
 - Returns: **Amount**
 
 Returns a new **Amount** that is the *leftAmount* minus the *rightAmount* (i.e., 
@@ -239,9 +239,9 @@ const badList = AmountMath.subtract(listAmountA, listAmountB)
 ```
 
 ## AmountMath.min(x, y, brand?)
-- **x** **[Amount](./ertp-data-types.md#amount)**
-- **y** **Amount**
-- **brand** **[Brand](./brand.md)** - Optional, defaults to **undefined**.
+- **x**: **[Amount](./ertp-data-types.md#amount)**
+- **y**: **Amount**
+- **brand**: **[Brand](./brand.md)** - Optional, defaults to **undefined**.
 - Returns: **Amount**
 
 Returns the minimum value between *x* and *y*.
@@ -259,9 +259,9 @@ const comparisonResult = AmountMath.min(smallerAmount, largerAmount);
 ```
 
 ## AmountMath.max(x, y, brand?)
-- **x** **[Amount](./ertp-data-types.md#amount)**
-- **y** **Amount**
-- **brand** **[Brand](./brand.md)** - Optional, defaults to **undefined**.
+- **x**: **[Amount](./ertp-data-types.md#amount)**
+- **y**: **Amount**
+- **brand**: **[Brand](./brand.md)** - Optional, defaults to **undefined**.
 - Returns: **Amount**
 
 Returns the maximum value between *x* and *y*.

--- a/main/reference/ertp-api/brand.md
+++ b/main/reference/ertp-api/brand.md
@@ -16,7 +16,7 @@ will always be associated with
 the *Quatloos* **Mint** and *Quatloos* **Issuer**.
 
 ## aBrand.isMyIssuer(allegedIssuer)
-- **allegedIssuer** **[Issuer](./issuer.md)**
+- **allegedIssuer**: **[Issuer](./issuer.md)**
 - Returns: **Boolean**
 
 Returns **true** if *allegedIssuer* is the **Brand**'s **Issuer**. Returns **false** if it's not.

--- a/main/reference/ertp-api/issuer.md
+++ b/main/reference/ertp-api/issuer.md
@@ -16,15 +16,15 @@ validate an untrusted **Payment** of that **Brand**.
 are ephemeral, so any object created there dies as soon as the script ends.
 
 ## makeIssuerKit(allegedName, assetKind?, displayInfo?, optShutdownWithFailure?, elementShape?)
-- **allegedName** **String** 
-- **assetKind** **[AssetKind](./ertp-data-types.md#assetkind)** - Optional, defaults to **AssetKind.NAT**.
-- **displayInfo** **[DisplayInfo](./ertp-data-types.md#displayinfo)** - Optional, defaults to **undefined**.
+- **allegedName**: **String** 
+- **assetKind**: **[AssetKind](./ertp-data-types.md#assetkind)** - Optional, defaults to **AssetKind.NAT**.
+- **displayInfo**: **[DisplayInfo](./ertp-data-types.md#displayinfo)** - Optional, defaults to **undefined**.
 - **optShutdownWithFailure** - Optional, defaults to **undefined**.
 - **elementShape** - Optional, defaults to **undefined**.
 - Returns **IssuerKit**. This is an object with three properties:
-	- **issuer** **Issuer**
-	- **mint** **[Mint](./mint.md)**
- 	- **brand** **[Brand](./brand.md)**
+	- **issuer**: **Issuer**
+	- **mint**: **[Mint](./mint.md)**
+ 	- **brand**: **[Brand](./brand.md)**
 
 Creates and returns a new **Issuer** and its associated **Mint** and **Brand**.
 All three are in unchangeable one-to-one relationships with each other. 
@@ -111,7 +111,7 @@ moolaIssuer.getAssetKind(); // Returns 'copy_set', also known as 'AssetKind.COPY
 ```
 
 ## anIssuer.getAmountOf(payment)
-- **payment** **[Payment](./payment.md)**
+- **payment**: **[Payment](./payment.md)**
 - Returns: **[Amount](./ertp-data-types.md#amount)**
 
 Describes the **Payment**'s balance as an **Amount**. Because a **Payment** from an untrusted
@@ -148,9 +148,11 @@ const { issuer: quatloosIssuer } = makeIssuerKit('quatloos');
 const quatloosPurse = quatloosIssuer.makeEmptyPurse();
 ```
 
-## anIssuer.burn(payment, optAmount?)
-- **payment** **[Payment](./payment.md)**
-- **optAmount** **[Amount](./ertp-data-types.md#amount)** - Optional.
+
+## **anIssuer.burn(payment, optAmount?)**
+- **payment**: **[Payment](./payment.md)**
+- **optAmount**: **[Amount](./ertp-data-types.md#amount)** - Optional.
+
 - Returns: **Amount**
 
 Destroys all of the digital assets in the **Payment**,
@@ -175,8 +177,8 @@ const burntAmount = quatloosIssuer.burn(paymentToBurn, amountToBurn);
 ```
 
 ## anIssuer.claim(payment, optAmount?)
-- **payment** **[Payment](./payment.md)**
-- **optAmount** **[Amount](./ertp-data-types.md#amount)** - Optional.
+- **payment**: **[Payment](./payment.md)**
+- **optAmount**: **[Amount](./ertp-data-types.md#amount)** - Optional.
 - Returns: **Payment** 
 
 Transfers all digital assets from *payment* to a new **Payment** and consumes the
@@ -198,8 +200,8 @@ const newPayment = quatloosIssuer.claim(originalPayment, amountToTransfer);
 ```
 
 ## anIssuer.combine(paymentsArray, optTotalAmount?)
-- **paymentsArray** **Array&lt;[Payment](./payment.md)>**
-- **optTotalAmount** **[Amount](./ertp-data-types.md#amount)** - Optional.
+- **paymentsArray**: **Array&lt;[Payment](./payment.md)>**
+- **optTotalAmount**: **[Amount](./ertp-data-types.md#amount)** - Optional.
 - Returns: **Payment**
 
 Combines multiple **Payments** into one new **Payment**. If any item in *paymentsArray* is
@@ -226,8 +228,8 @@ const combinedPayment = quatloosIssuer.combine(payments);
 ```
 
 ## anIssuer.split(payment, paymentAmountA)
-- **payment** **[Payment](./payment.md)**
-- **paymentAmountA** **[Amount](./ertp-data-types.md#amount)**
+- **payment**: **[Payment](./payment.md)**
+- **paymentAmountA**: **[Amount](./ertp-data-types.md#amount)**
 - Returns: **Array&lt;Payment>**
 
 Splits a single **Payment** into two new **Payments**, A and B, according to *paymentAmountA*.
@@ -248,8 +250,8 @@ const [paymentA, paymentB] = quatloosIssuer.split(oldPayment, AmountMath.make(qu
 ```
 
 ## anIssuer.splitMany(payment, amountArray)
-- **payment** **[Payment](./payment.md)**
-- **amountArray** **Array&lt;[Amount](./ertp-data-types.md#amount)>**
+- **payment**: **[Payment](./payment.md)**
+- **amountArray**: **Array&lt;[Amount](./ertp-data-types.md#amount)>**
 - Returns: **Array&lt;Payment>**
 
 Splits a single **Payment** into multiple **Payments**.
@@ -281,7 +283,7 @@ quatloosIssuer.splitMany(payment, badAmounts);
 ```
 
 ## anIssuer.isLive(payment)
-- **payment** **[Payment](./payment.md)**
+- **payment**: **[Payment](./payment.md)**
 - Returns: **Boolean**
 
 Returns **true** if the *payment* was created by the **Issuer** and is available for use 

--- a/main/reference/ertp-api/mint.md
+++ b/main/reference/ertp-api/mint.md
@@ -23,7 +23,7 @@ issuer === quatloosMintIssuer;
 ```
 
 ## aMint.mintPayment(newAmount)
-- **newAmount** **[Amount](./ertp-data-types.md#amount)**
+- **newAmount**: **[Amount](./ertp-data-types.md#amount)**
 - Returns: **[Payment](./payment.md)**
 
 Creates and returns new digital assets of the **Mint**'s associated **[Brand](./brand.md)**.

--- a/main/reference/ertp-api/payment.md
+++ b/main/reference/ertp-api/payment.md
@@ -17,7 +17,7 @@ take out, say, only 3 *Quatloos* from it.
 However, you can split a **Payment** into multiple **Payments**. For example, you could split a 
 10 *Quatloos* **Payment** into two new **Payments** of 3 *Quatloos* and 7 *Quatloos* by calling the
 **[anIssuer.split()](./issuer.md#anissuer-split-payment-paymentamounta)** method which consumes the 
-original 10 *Quatloos* **Payment** and creates two new smaller **Payments.
+original 10 *Quatloos* **Payment** and creates two new smaller **Payments**.
 
 **Payments** are often received from other actors. Since they are not self-verifying,
 you cannot trust **Payments**. To get the verified balance of a **Payment**, call the **[anIssuer.getAmountOf()](./issuer.md#anissuer-getamountof-payment)** method.

--- a/main/reference/ertp-api/purse.md
+++ b/main/reference/ertp-api/purse.md
@@ -66,8 +66,8 @@ const checkNotifier = async () => {
 ```
 
 ## aPurse.deposit(payment, optAmount?)
-- **payment** **[Payment](./payment.md)**
-- **optAmount** **[Amount](./ertp-data-types.md#amount)** - Optional. 
+- **payment**: **[Payment](./payment.md)**
+- **optAmount**: **[Amount](./ertp-data-types.md#amount)** - Optional. 
 - Returns: **Amount**
 
 Deposit all the contents of *payment* into the **Purse**, returning an **Amount** describing the
@@ -102,7 +102,7 @@ const depositAmountB = quatloosPurse.deposit(secondPayment, quatloos123);
 
 ## aPurse.withdraw(amount)
 
-- **amount** **[Amount](./ertp-data-types.md#amount)**
+- **amount**: **[Amount](./ertp-data-types.md#amount)**
 - Returns: **[Payment](./payment.md)**
 
 Withdraws the specified **Amount** of digital assets from the **Purse** into a new **Payment** object.
@@ -168,8 +168,8 @@ To add assets to a **Purse** directly, you use **aPurse.deposit()**. To add asse
 to a **Purse** via its **DepositFacet**, you use **aDepositFacet.receive()**.
 
 ## aDepositFacet.receive(payment, optAmount?)
-- **payment** **[Payment](./payment.md)**
-- **optAmount** **[Amount](./ertp-data-types.md#amount)** - Optional.
+- **payment**: **[Payment](./payment.md)**
+- **optAmount**: **[Amount](./ertp-data-types.md#amount)** - Optional.
 - Returns **Amount**
 
 The **DepositFacet** takes the **Payment** and adds it to the balance of the **DepositFacet**'s associated **Purse**. 

--- a/main/reference/zoe-api/README.md
+++ b/main/reference/zoe-api/README.md
@@ -3,7 +3,10 @@
 <Zoe-Version/>
 
 
-The Zoe framework provides a way to write smart contracts without having to worry about [offer safety](/guides/zoe/offer-safety.md). To use Zoe, we put things in terms of "offers". An offer proposal is a statement about what you want and what you're willing to offer. It turns out, many smart contracts (apart from gifts and one-way payments) involve an exchange of digital assets that can be put in terms of offer proposals.
+The Zoe framework provides a way to write smart contracts without having to worry about [offer safety](/guides/zoe/offer-safety.md). 
+To use Zoe, we put things in terms of "offers". An offer proposal is a statement about what you want and
+what you're willing to offer. It turns out, many smart contracts (apart from gifts and one-way payments)
+involve an exchange of digital assets that can be put in terms of offer proposals.
 
 Start creating your own contract or build on any of our existing contracts.
 Explore our pre-built contracts [here](/guides/zoe/contracts/README.md).
@@ -36,13 +39,14 @@ The Zoe API introduces and uses the following data types:
 | [AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord) | A record in which the property names are **Keywords** and the values are **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)**. |
 | [Handle](./zoe-data-types.md#handle) | A **Far** object without any methods whose only useful property is its unique identity. |
 | [Instance](./zoe-data-types.md#instance) | A handle to an opaque object that represents a contract instance. |
-| [Invitation](./zoe-data-types.md#invitation) | TBD |
+| [Invitation](./zoe-data-types.md#invitation) | A non-fungible eright that can be held in **[Payment](/reference/ertp-api/payment.md)** or **[Purses](/reference/ertp-api/purse.md)**, just like any other eright. |
 | [InvitationIssuer](./zoe-data-types.md#invitationissuer) | An **[Issuer](/reference/ertp-api/issuer.md)** for **[Invitations](./zoe-data-types.md#invitation)**, which grant the right to participate in a contract. |
 | [Keyword](./zoe-data-types.md#keyword) | An ASCII identifier string that must begin with an upper case letter. |
 | [MutableQuote](./zoe-data-types.md#mutablequote) | Statement from a **[PriceAuthority](./price-authority.md)** as to the current price level at a particular time when multiple calls, replacing the trigger value, are expected. |
 | [ParsableNumber](./zoe-data-types.md#parsablenumber) | Defined as a **bigint**, **number**, or **string**. |
 | [PriceQuote](./zoe-data-types.md#pricequote) | Statement from a **[PriceAuthority](./price-authority.md)** as to the current price level at a particular time when only a single calls is expected. |
 | [Ratio](./zoe-data-types.md#ratio) | Pass-by-value record that consists of a *numerator* **[Amount](/reference/ertp-api/ertp-data-types.md#amount)** and a *denominator* **Amount**. |
+| [TransferPart](./zoe-data-types.md#transferpart) | One or two **[Allocation](./zoe-data-types.md#allocation)** changes among existing **[ZCFSeats](./zcfseat.md)**. **TransferParts** are the individual elements of the *transfer* array passed into the **[atomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** function. |
 
 
 

--- a/main/reference/zoe-api/README.md
+++ b/main/reference/zoe-api/README.md
@@ -39,7 +39,7 @@ The Zoe API introduces and uses the following data types:
 | [AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord) | A record in which the property names are **Keywords** and the values are **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)**. |
 | [Handle](./zoe-data-types.md#handle) | A **Far** object without any methods whose only useful property is its unique identity. |
 | [Instance](./zoe-data-types.md#instance) | A handle to an opaque object that represents a contract instance. |
-| [Invitation](./zoe-data-types.md#invitation) | A non-fungible eright that can be held in **[Payment](/reference/ertp-api/payment.md)** or **[Purses](/reference/ertp-api/purse.md)**, just like any other eright. |
+| [Invitation](./zoe-data-types.md#invitation) | A non-fungible eright that can be held in **[Payments](/reference/ertp-api/payment.md)** or **[Purses](/reference/ertp-api/purse.md)**, just like any other eright. |
 | [InvitationIssuer](./zoe-data-types.md#invitationissuer) | An **[Issuer](/reference/ertp-api/issuer.md)** for **[Invitations](./zoe-data-types.md#invitation)**, which grant the right to participate in a contract. |
 | [Keyword](./zoe-data-types.md#keyword) | An ASCII identifier string that must begin with an upper case letter. |
 | [MutableQuote](./zoe-data-types.md#mutablequote) | Statement from a **[PriceAuthority](./price-authority.md)** as to the current price level at a particular time when multiple calls, replacing the trigger value, are expected. |

--- a/main/reference/zoe-api/README.md
+++ b/main/reference/zoe-api/README.md
@@ -46,9 +46,6 @@ The Zoe API introduces and uses the following data types:
 | [ParsableNumber](./zoe-data-types.md#parsablenumber) | Defined as a **bigint**, **number**, or **string**. |
 | [PriceQuote](./zoe-data-types.md#pricequote) | Statement from a **[PriceAuthority](./price-authority.md)** as to the current price level at a particular time when only a single calls is expected. |
 | [Ratio](./zoe-data-types.md#ratio) | Pass-by-value record that consists of a *numerator* **[Amount](/reference/ertp-api/ertp-data-types.md#amount)** and a *denominator* **Amount**. |
-| [TransferPart](./zoe-data-types.md#transferpart) | One or two **[Allocation](./zoe-data-types.md#allocation)** changes among existing **[ZCFSeats](./zcfseat.md)**. **TransferParts** are the individual elements of the *transfer* array passed into the **[atomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** function. |
-
-
-
+| [TransferPart](./zoe-data-types.md#transferpart) |  **[Allocation](./zoe-data-types.md#allocation)** changes for one or two existing **[ZCFSeats](./zcfseat.md)**. **TransferParts** are the individual elements of the *transfer* array passed into the **[atomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** function. |
 
 

--- a/main/reference/zoe-api/README.md
+++ b/main/reference/zoe-api/README.md
@@ -12,7 +12,7 @@ The Zoe API supports the following objects:
 
 | Object | Description |
 | --- | --- |
-| [Zoe Service](./zoe.md) | Deploy and work with smart contracts. |
+| [Zoe Service](./zoe.md) | Deploys and works with smart contracts. |
 | [UserSeat](./user-seat.md) | Used outside contracts to access or manipulate offers. |
 | [Zoe Contract Facet](./zoe-contract-facet.md) | Accesses a running contract instance. |
 | [ZCFSeat](./zcfseat.md) | Used within contracts to access or manipulate offers. |
@@ -33,8 +33,8 @@ The Zoe API introduces and uses the following data types:
 | Data Type | Description |
 | --- | --- |
 | [Allocation](./zoe-data-types.md#allocation) | The **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)** to be paid out to each seat upon exiting an **Offer**. |
-| [AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord) | Records in which the property names are **Keywords** and the values are **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)**. |
-| [Handle](./zoe-data-types.md#handle) | TBD  |
+| [AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord) | A record in which the property names are **Keywords** and the values are **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)**. |
+| [Handle](./zoe-data-types.md#handle) | A **Far** object without any methods whose only useful property is its unique identity. |
 | [Instance](./zoe-data-types.md#instance) | A handle to an opaque object that represents a contract instance. |
 | [Invitation](./zoe-data-types.md#invitation) | TBD |
 | [InvitationIssuer](./zoe-data-types.md#invitationissuer) | An **[Issuer](/reference/ertp-api/issuer.md)** for **[Invitations](./zoe-data-types.md#invitation)**, which grant the right to participate in a contract. |

--- a/main/reference/zoe-api/price-authority.md
+++ b/main/reference/zoe-api/price-authority.md
@@ -11,8 +11,8 @@ price feed that updates with every price change.
 
 
 ## E(PriceAuthority).getQuoteIssuer(brandIn, brandOut)
-- **brandIn** **[Brand](/reference/ertp-api/brand.md)**
-- **brandOut** **Brand**
+- **brandIn**: **[Brand](/reference/ertp-api/brand.md)**
+- **brandOut**: **Brand**
 - Returns: **[Issuer](/reference/ertp-api/issuer.md) | Promise&lt;Issuer>**
 
 Gets the ERTP **Issuer** of **[PriceQuotes](./zoe-data-types.md#pricequote)** for a 
@@ -26,8 +26,8 @@ const quoteIssuer = await E(PriceAuthority).getQuoteIssuer(
 ```
 
 ## E(PriceAuthority).getTimerService(brandIn, brandOut)
-- **brandIn** **[Brand](/reference/ertp-api/brand.md)**
-- **brandOut** **Brand**
+- **brandIn**: **[Brand](/reference/ertp-api/brand.md)**
+- **brandOut**: **Brand**
 - Returns: **TimerService | Promise&lt;TimerService>**
 
 Gets the timer used in **[PriceQuotes](./zoe-data-types.md#pricequote)** for a 
@@ -38,8 +38,8 @@ const myTimer = E(PriceAuthority).getTimerService(collateral.brand, loanKit.bran
 ```
 
 ## E(PriceAuthority).makeQuoteNotifier(amountIn, brandOut)
-- **amountIn** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **brandOut** **[Brand](/reference/ertp-api/brand.md)**
+- **amountIn**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **brandOut**: **[Brand](/reference/ertp-api/brand.md)**
 - Returns: **ERef&lt;Notifier&lt;[PriceQuote](./zoe-data-types.md#pricequote)>>**
 
 Be notified of the latest **PriceQuotes** for a given *amountIn*. The issuing
@@ -50,8 +50,8 @@ const myNotifier = E(PriceAuthority).makeQuoteNotifier(quatloos100, usdBrand);
 ```
 
 ## E(PriceAuthority).quoteGiven(amountIn, brandOut)
-- **amountIn** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **brandOut** **[Brand](/reference/ertp-api/brand.md)**
+- **amountIn**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **brandOut**: **[Brand](/reference/ertp-api/brand.md)**
 - Returns: **Promise&lt;[PriceQuote](./zoe-data-types.md#pricequote)>**
 
 Gets a quote on-demand corresponding to *amountIn*.
@@ -61,8 +61,8 @@ const quote = await E(PriceAuthority).quoteGiven(moola500, quatloosBrand);
 ```
 
 ## E(PriceAuthority).quoteWanted(brandIn, amountOut)
-- **brandIn** **[Brand](/reference/ertp-api/brand.md)**
-- **amountOut** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **brandIn**: **[Brand](/reference/ertp-api/brand.md)**
+- **amountOut**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
 - Returns: **Promise&lt;[PriceQuote](./zoe-data-types.md#pricequote)>**
 
 Gets a quote on-demand corresponding to *amountOut*.
@@ -72,9 +72,9 @@ const quote = await E(PriceAuthority).quoteWanted(quatloosBrand, moola500);
 ```
 
 ## E(PriceAuthority).quoteAtTime(deadline, amountIn, brandOut)
-- **deadline** **Timestamp**
-- **amountIn** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **brandOut** **[Brand](/reference/ertp-api/brand.md)**
+- **deadline**: **Timestamp**
+- **amountIn**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **brandOut**: **[Brand](/reference/ertp-api/brand.md)**
 - Returns: **Promise&lt;[PriceQuote](./zoe-data-types.md#pricequote)>**
 
 Resolves after *deadline* passes on the **PriceAuthority**’s **timerService** with the
@@ -85,11 +85,11 @@ const priceQuoteOnThisAtTime = E(PriceAuthority).quoteAtTime(7n, quatloosAmount3
 ```
 
 ## E(PriceAuthority).quoteWhenGT(amountIn, amountOutLimit)
-- **amountIn** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **amountOutLimit** **Amount**
+- **amountIn**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **amountOutLimit**: **Amount**
 - Returns: **Promise&lt;[PriceQuote](./zoe-data-types.md#pricequote)>**
 
-Resolves when a price quote of *amountIn* exceeds *amountOutLimit*.
+Resolves when a **PriceQuote** of *amountIn* exceeds *amountOutLimit*.
 
 ```js
 const quote = E(PriceAuthority).quoteWhenGT(
@@ -99,8 +99,8 @@ const quote = E(PriceAuthority).quoteWhenGT(
 ```
 
 ## E(PriceAuthority).quoteWhenGTE(amountIn, amountOutLimit)
-- **amountIn** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **amountOutLimit** **Amount**
+- **amountIn**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **amountOutLimit**: **Amount**
 - Returns: **Promise&lt;[PriceQuote](./zoe-data-types.md#pricequote)>**
 
 Resolves when a **PriceQuote** of *amountIn* reaches or exceeds *amountOutLimit*.
@@ -127,8 +127,8 @@ const quote = E(PriceAuthority).quoteWhenLT(
 ```
 
 ## E(PriceAuthority).quoteWhenLTE(amountIn, amountOutLimit)
-- **amountIn** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **amountOutLimit** **Amount**
+- **amountIn**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **amountOutLimit**: **Amount**
 - Returns: **Promise&lt;[PriceQuote](./zoe-data-types.md#pricequote)>**
 
 Resolves when a **PriceQuote** of *amountIn* reaches or drops below *amountOutLimit*.
@@ -141,8 +141,8 @@ const quote = E(PriceAuthority).quoteWhenLTE(
 ```
 
 ## E(PriceAuthority).mutableQuoteWhenGT(amountIn, amountOutLimit)
-- **amountIn** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **amountOutLimit** **Amount**
+- **amountIn**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **amountOutLimit**: **Amount**
 - Returns: **Promise&lt;[MutableQuote](./zoe-data-types.md#mutablequote)>**
 
 Resolves when a **PriceQuote** of *amountIn* exceeds *amountOutLimit*.
@@ -155,8 +155,8 @@ const quote = E(PriceAuthority).mutableQuoteWhenGT(
 ```
 
 ## E(PriceAuthority).mutableQuoteWhenGTE(amountIn, amountOutLimit)
-- **amountIn** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **amountOutLimit** **Amount**
+- **amountIn**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **amountOutLimit**: **Amount**
 - Returns: **Promise&lt;[MutableQuote](./zoe-data-types.md#mutablequote)>**
 
 Resolves when a **PriceQuote** of *amountIn* reaches or exceeds
@@ -170,8 +170,8 @@ const quote = E(PriceAuthority).mutableQuoteWhenGTE(
 ```
 
 ## E(PriceAuthority).mutableQuoteWhenLT(amountIn, amountOutLimit)
-- **amountIn** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **amountOutLimit** **Amount**
+- **amountIn**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **amountOutLimit**: **Amount**
 - Returns: **Promise&lt;[MutableQuote](./zoe-data-types.md#mutablequote)>**
 
 Resolves when a **PriceQuote** of *amountIn* drops below
@@ -185,8 +185,8 @@ const quote = E(PriceAuthority).mutableQuoteWhenLT(
 ```
 
 ## E(PriceAuthority).mutableQuoteWhenLTE(amountIn, amountOutLimit)
-- **amountIn** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **amountOutLimit** **Amount**
+- **amountIn**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **amountOutLimit**: **Amount**
 - Returns: **Promise&lt;[MutableQuote](./zoe-data-types.md#mutablequote)>**
 
 Resolves when a **PriceQuote** of *amountIn* reaches or drops below

--- a/main/reference/zoe-api/ratio-math.md
+++ b/main/reference/zoe-api/ratio-math.md
@@ -6,7 +6,7 @@ dividing an amount by a ratio of two natural numbers.
 The Ratio Math functions have to be imported.
 
 ## assertIsRatio(ratio)
-- **ratio** **[Ratio](./zoe-data-types.md#ratio)**
+- **ratio**: **[Ratio](./zoe-data-types.md#ratio)**
 - Returns: None.
 
 Throws an error if the argument is not a valid **Ratio**.
@@ -20,10 +20,10 @@ assertIsRatio(aRatio);
 ```
 
 ## makeRatio(numerator, numeratorBrand, denominator?, denominatorBrand?)
-- **numerator** **BigInt**
-- **numeratorBrand** **[Brand](/reference/ertp-api/brand.md)**
-- **denominator** **BigInt** - Optional, defaults to 100n.
-- **denominatorBrand)** **Brand** - Optional, defaults to the *numeratorBrand* value.
+- **numerator**: **BigInt**
+- **numeratorBrand**: **[Brand](/reference/ertp-api/brand.md)**
+- **denominator**: **BigInt** - Optional, defaults to 100n.
+- **denominatorBrand)**: **Brand** - Optional, defaults to the *numeratorBrand* value.
 - Returns: **[Ratio](./zoe-data-types.md#ratio)**
 
 Returns a **Ratio** based on the arguments passed into the function.
@@ -38,8 +38,8 @@ const ratio = makeRatio(75n, quatloosBrand, 4n, moolasBrand);
 ```
 
 ## makeRatioFromAmounts(numeratorAmount, denominatorAmount)
-- **numeratorAmount** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **denominatorAmount** **Amount**
+- **numeratorAmount**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **denominatorAmount**: **Amount**
 - Returns: **[Ratio](./zoe-data-types.md#ratio)**
 
 Returns a **Ratio**, representing a fraction and consisting of an immutable pair 
@@ -53,8 +53,8 @@ const halfADollar = makeRatioFromAmounts(fiftyCents, dollar);
 ```
 
 ## floorMultiplyBy(amount, ratio)
-- **amount** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **ratio** **[Ratio](./zoe-data-types.md#ratio)**
+- **amount**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **ratio**: **[Ratio](./zoe-data-types.md#ratio)**
 - Returns: **Amount**
 
 Returns an immutable **Amount**. Its **[Brand](/reference/ertp-api/brand.md)** is the *ratio*'s
@@ -86,8 +86,8 @@ const exchange = floorMultiplyBy(dollars47, exchangeRatio);
 ```
 
 ## ceilMultiplyBy(amount, ratio)
-- **amount** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **ratio** **[Ratio](./zoe-data-types.md#ratio)**
+- **amount**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **ratio**: **[Ratio](./zoe-data-types.md#ratio)**
 - Returns: **Amount**
 
 Returns an immutable **Amount**. Its **[Brand](/reference/ertp-api/brand.md)** is the *ratio*'s
@@ -119,8 +119,8 @@ const exchange = ceilMultiplyBy(dollars47, exchangeRatio);
 ```
 
 ## multiplyBy(amount, ratio)
-- **amount** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **ratio** **[Ratio](./zoe-data-types.md#ratio)**
+- **amount**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **ratio**: **[Ratio](./zoe-data-types.md#ratio)**
 - Returns: **Amount**
 
 Returns an immutable **Amount**. Its **[Brand](/reference/ertp-api/brand.md)** is the *ratio*'s
@@ -151,8 +151,8 @@ const exchange = multiplyBy(dollars47, exchangeRatio);
 ```
 
 ## floorDivideBy(amount, ratio)
-- **amount** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **ratio** **[Ratio](./zoe-data-types.md#ratio)**
+- **amount**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **ratio**: **[Ratio](./zoe-data-types.md#ratio)**
 - Returns: **Amount**
 
 Returns an immutable **Amount**. Its **[Brand](/reference/ertp-api/brand.md)** is the *ratio*'s denominator's **Brand**.
@@ -182,8 +182,8 @@ const exchange = floorDivideBy(dollars47, exchangeRatio);
 ```
 
 ## ceilDivideBy(amount, ratio)
-- **amount** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **ratio** **[Ratio](./zoe-data-types.md#ratio)**
+- **amount**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **ratio**: **[Ratio](./zoe-data-types.md#ratio)**
 - Returns: **Amount**
 
 Returns an immutable **Amount**. Its **[Brand](/reference/ertp-api/brand.md)** is the *ratio*'s denominator's **Brand**.
@@ -213,8 +213,8 @@ const exchange = ceilDivideBy(dollars47, exchangeRatio);
 ```
 
 ## divideBy(amount, ratio)
-- **amount** **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
-- **ratio** **[Ratio](./zoe-data-types.md#ratio)**
+- **amount**: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
+- **ratio**: **[Ratio](./zoe-data-types.md#ratio)**
 - Returns: **Amount**
 
 Returns an immutable **Amount**. Its **[Brand](/reference/ertp-api/brand.md)** is the *ratio*'s denominator's **Brand**.
@@ -244,7 +244,7 @@ const exchange = divideBy(dollars47, exchangeRatio);
 ```
 
 ## invertRatio(ratio)
-- **ratio** **[Ratio](./zoe-data-types.md#ratio)**
+- **ratio**: **[Ratio](./zoe-data-types.md#ratio)**
 - Returns: **Ratio**
 
 Returns a **Ratio** such that the *ratio* argument's numerator is the returned value's
@@ -257,8 +257,8 @@ const invertedRatio = invertRatio(exchangeRatio);
 ```
 
 ## addRatios(left, right)
-- **left** **[Ratio](./zoe-data-types.md#ratio)**
-- **right** **Ratio**
+- **left**: **[Ratio](./zoe-data-types.md#ratio)**
+- **right**: **Ratio**
 - Returns: **Ratio**
 
 Returns a **Ratio** that's the sum of the *left* and *right* parameters.
@@ -282,8 +282,8 @@ This **Ratio** would then be returned.
 
 
 ## subtractRatios(left, right)
-- **left** **[Ratio](./zoe-data-types.md#ratio)**
-- **right** **Ratio**
+- **left**: **[Ratio](./zoe-data-types.md#ratio)**
+- **right**: **Ratio**
 - Returns: **Ratio**
 
 Returns a **Ratio** that's the result when the *right* parameter is subtracted from the *left* one.
@@ -306,8 +306,8 @@ For example:
 This **Ratio** would then be returned.
 
 ## multiplyRatios(left, right)
-- **left** **[Ratio](./zoe-data-types.md#ratio)**
-- **right** **Ratio**
+- **left**: **[Ratio](./zoe-data-types.md#ratio)**
+- **right**: **Ratio**
 - Returns: **Ratio**
 
 Returns a **Ratio** that's the product of the *left* and *right* parameters.
@@ -318,7 +318,7 @@ identical. similarly, the **Brands** of the *denominators* of *left* and
 and an error is thrown instead.
 
 ## oneMinus(ratio)
-- **ratio** **[Ratio](./zoe-data-types.md#ratio)**
+- **ratio**: **[Ratio](./zoe-data-types.md#ratio)**
 - Returns: **Ratio**
 
 Subtracts the *ratio* argument from 1 and returns the resultant **Ratio**.
@@ -326,8 +326,8 @@ Subtracts the *ratio* argument from 1 and returns the resultant **Ratio**.
 This function requires the *ratio* argument to be between 0 and 1. It also requires the numerator and denominator **[Brands](/reference/ertp-api/brand.md)** to be the same. If either of these conditions aren't met, an error is thrown and no **Ratio** is returned.
 
 ## ratioGTE(left, right)
-- **left** **[Ratio](./zoe-data-types.md#ratio)**
-- **right** **Ratio**
+- **left**: **[Ratio](./zoe-data-types.md#ratio)**
+- **right**: **Ratio**
 - Returns: **Boolean**
 
 Returns **true** if *left* is larger than or equal to *right*, **false** otherwise.
@@ -336,8 +336,8 @@ An error is returned if the **[Brands](/reference/ertp-api/brand.md)** of *left*
 aren't identical.
 
 ## ratiosSame(left, right)
-- **left** **[Ratio](./zoe-data-types.md#ratio)**
-- **right** **Ratio**
+- **left**: **[Ratio](./zoe-data-types.md#ratio)**
+- **right**: **Ratio**
 - Returns: **Boolean**
 
 Returns **true** if the *left* and *right* **Ratios** are the same, **false** otherwise. Note that for
@@ -348,22 +348,22 @@ of both the *numerator* and *denominator* of one **Ratio** must be identical to 
 
 
 ## quantize(ratio, newDen)
-- **ratio** **[Ratio](./zoe-data-types.md#ratio)**
-- **newDen** **BigInt**
+- **ratio**: **[Ratio](./zoe-data-types.md#ratio)**
+- **newDen**: **BigInt**
 - Returns: **Ratio**
 
 Creates and returns a new **Ratio** that's equivalent to the *ratio* argument, but with a new denominator specified by the *newDen* argument.
 
 ## parseRatio(numeric, numeratorBrand, denominatorBrand?)
-- **numeric** **[ParsableNumber](./zoe-data-types.md#parsablenumber)**
-- **numeratorBrand** **[Brand](/reference/ertp-api/brand.md)**
-- **denominatorBrand** **Brand** - Optional, defaults to *numeratorBrand*.
+- **numeric**: **[ParsableNumber](./zoe-data-types.md#parsablenumber)**
+- **numeratorBrand**: **[Brand](/reference/ertp-api/brand.md)**
+- **denominatorBrand**: **Brand** - Optional, defaults to *numeratorBrand*.
 - Returns: **[Ratio](./zoe-data-types.md#ratio)**
 
 Creates a **Ratio** from the *numeric* argument, and returns that **Ratio**.
 
 ## assertParsableNumber(specimen)
-- **specimen** **Object**
+- **specimen**: **Object**
 - Returns: None.
 
 Throws an error if the argument is not a **[ParsableNumber](./zoe-data-types.md#parsablenumber)**.

--- a/main/reference/zoe-api/user-seat.md
+++ b/main/reference/zoe-api/user-seat.md
@@ -54,9 +54,8 @@ const paymentKeywordRecord = {
 };
 ```
 
-
 ## E(UserSeat).getPayout(keyword)
-- **keyword** **[Keyword](./zoe-data-types.md#keyword)**
+- **keyword**: **[Keyword](./zoe-data-types.md#keyword)**
 - Returns: **Promise&lt;[Payment](/reference/ertp-api/payment.md)>**
 
 A **Payout** is a **Payment** that goes to a party in a successful transaction, redirecting

--- a/main/reference/zoe-api/zcfmint.md
+++ b/main/reference/zoe-api/zcfmint.md
@@ -13,8 +13,8 @@ Returns an **IssuerRecord** containing the **[Issuer](/reference/ertp-api/issuer
 **[Brand](/reference/ertp-api/brand.md)** associated with the **zcfMint**.
 
 ## aZCFMint.mintGains(gains, zcfSeat?)
-  - **gains** **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
-  - **zcfSeat** **[ZCFSeat](./zcfseat.md)** - Optional.
+  - **gains**: **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
+  - **zcfSeat**: **[ZCFSeat](./zcfseat.md)** - Optional.
   - Returns: **ZCFSeat**
 
 All **amounts** in *gains* must be of this **ZCFMint**'s **[Brand](/reference/ertp-api/brand.md)**.
@@ -24,9 +24,9 @@ that **seat**'s **[Allocation](./zoe-data-types.md#allocation)**. If a **seat** 
 it is returned. Otherwise a new **seat** is returned.
 
 ## aZCFMint.burnLosses(losses, zcfSeat?)
-  - **losses** **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
-  - **zcfSeat** **[ZCFSeat](./zcfseat.md)** - Optional.
-  - Returns: None.
+  - **losses**: **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
+  - **zcfSeat**: **[ZCFSeat](./zcfseat.md)** - Optional.
+  - Returns: None
 
 All **amounts** in *losses* must be of this **ZCFMint**'s **[Brand](/reference/ertp-api/brand.md)**.
 The *losses*' **[Keywords](./zoe-data-types.md#keyword)** are in that **seat**'s namespace.

--- a/main/reference/zoe-api/zcfseat.md
+++ b/main/reference/zoe-api/zcfseat.md
@@ -137,7 +137,7 @@ It checks whether **newAllocation** fully satisfies
 Gets and returns the **stagedAllocation**, which is the **Allocation** committed if the seat is
 reallocated over, if offer safety holds, and rights are conserved.
 
-**Note**: This method has been deprecated. Use **[AtomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
+**Note**: This method has been deprecated. Use **[atomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
 :::
 
 ::: warning DEPRECATED
@@ -148,7 +148,7 @@ Returns **true** if there is a staged allocation, i.e., whether **ZCFSeat.increm
 **ZCFSeat.decrementBy()** has been called and **ZCFSeat.clear()**
 and **reallocate()** have not. Otherwise returns **false**.
 
-**Note**: This method has been deprecated. Use **[AtomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
+**Note**: This method has been deprecated. Use **[atomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
 :::
 
 ::: warning DEPRECATED
@@ -177,7 +177,7 @@ t.deepEqual(zcfSeat1.getStagedAllocation(), { IST: empty  });
 While this incremented the allocation by an empty amount, any amount would have been added to the 
 allocation in the same way.
 
-**Note**: This method has been deprecated. Use **[AtomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
+**Note**: This method has been deprecated. Use **[atomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
 :::
 
 ::: warning DEPRECATED
@@ -225,7 +225,16 @@ It throws an error because you cannot subtract something from nothing. So trying
 allocation by a non-empty amount is an error, while decrementing an empty allocation by an empty amount
 is effectively a null operation with no effects.
 
-**Note**: This method has been deprecated. Use **[AtomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
+**Note**: This method has been deprecated. Use **[atomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
+:::
+
+::: warning DEPRECATED
+## aZCFSeat.clear()
+  - Returns: None.
+
+Deletes the **ZCFSeat**'s current staged allocation, if any,
+
+**Note**: This method has been deprecated. Use **[atomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
 :::
 
 

--- a/main/reference/zoe-api/zcfseat.md
+++ b/main/reference/zoe-api/zcfseat.md
@@ -7,17 +7,8 @@ represent offers outside the contract. The two facets provide access to the same
 and changes made from either side affect both.
 
 A **ZCFSeat** includes synchronous queries for the current state of the
-associated offer, such as the amounts of assets that are currently# ZCFSeat Object
-
-Zoe uses **seats** to access or manipulate offers. Seats represent active offers and let
-contracts and users interact with them. Two kinds of seats represent a single
-position. **ZCFSeats** are used within contracts and with **zcf** methods.  **UserSeats**
-represent offers outside the contract. The two facets provide access to the same allocation,
-and changes made from either side affect both.
-
-A **ZCFSeat** includes synchronous queries for the current state of the
 associated offer, such as the amounts of assets that are currently
-allocated to the offer. It also includes synchronous operations
+assigned to the **ZCFSeat** Object. It also includes synchronous operations
 to manipulate the offer. The queries and operations are as follows:
 
 ## aZCFSeat.getSubscriber()

--- a/main/reference/zoe-api/zcfseat.md
+++ b/main/reference/zoe-api/zcfseat.md
@@ -7,10 +7,18 @@ represent offers outside the contract. The two facets provide access to the same
 and changes made from either side affect both.
 
 A **ZCFSeat** includes synchronous queries for the current state of the
+associated offer, such as the amounts of assets that are currently# ZCFSeat Object
+
+Zoe uses **seats** to access or manipulate offers. Seats represent active offers and let
+contracts and users interact with them. Two kinds of seats represent a single
+position. **ZCFSeats** are used within contracts and with **zcf** methods.  **UserSeats**
+represent offers outside the contract. The two facets provide access to the same allocation,
+and changes made from either side affect both.
+
+A **ZCFSeat** includes synchronous queries for the current state of the
 associated offer, such as the amounts of assets that are currently
 allocated to the offer. It also includes synchronous operations
 to manipulate the offer. The queries and operations are as follows:
-
 
 ## aZCFSeat.getSubscriber()
 - Returns: **Subscriber**
@@ -34,7 +42,7 @@ const { want, give, exit } = sellerSeat.getProposal();
 ```
 
 ## aZCFSeat.exit(completion)
-   - **completion** **Object**
+   - **completion**: **Object**
    - Returns: None.
 
 Causes the **seat** to exit, preventing further changes to its allocation. All **payouts**,
@@ -47,7 +55,7 @@ seats or outstanding promises and the contract instance continue.
 **Note**: You should not use **aZCFSeat.exit()** when exiting with an error. Use the method **[aZCFSeat.fail()](#azcfseat-fail-msg)** instead. 
 
 ## aZCFSeat.fail(msg)
-   - **msg** **String**
+   - **msg**: **String**
    - Returns: None.
 
 The **seat** exits, displaying the optional **msg** string, if there is one, on the console.
@@ -68,8 +76,8 @@ throw seat.fail(Error('you did it wrong'));
 Returns **true** if the **ZCFSeat** has exited, **false** if it is still active.
 
 ## aZCFSeat.getAmountAllocated(keyword, brand)
-  - **keyword** **[Keyword](./zoe-data-types.md#keyword)**
-  - **brand** **[Brand](/reference/ertp-api/brand.md)**
+  - **keyword**: **[Keyword](./zoe-data-types.md#keyword)**
+  - **brand**: **[Brand](/reference/ertp-api/brand.md)**
   - Returns: **[Amount](/reference/ertp-api/ertp-data-types.md#amount)**
 
 Returns the **Amount** from the part of the **[Allocation](./zoe-data-types.md#allocation)** that matches the
@@ -110,14 +118,8 @@ An **Allocation** example:
 }
 ```
 
-## aZCFSeat.getStagedAllocation()
-  - Returns: **[Allocation](./zoe-data-types.md#allocation)**
-
-Gets and returns the **stagedAllocation**, which is the **Allocation** committed if the seat is
-reallocated over, if offer safety holds, and rights are conserved.
-
 ## aZCFSeat.isOfferSafe(newAllocation)
-   - **newAllocation** **[Allocation](./zoe-data-types.md#allocation)**
+   - **newAllocation**: **[Allocation](./zoe-data-types.md#allocation)**
    - Returns **Boolean**
 
 Takes an **allocation** as an argument and returns **true** if that **allocation**
@@ -128,8 +130,30 @@ It checks whether **newAllocation** fully satisfies
 **proposal.want**. Both can be fully satisfied. See the ZoeHelper
 [**satisfies()**](./zoe-helpers.md#satisfies-zcf-seat-update) method for more details.
 
+::: warning DEPRECATED
+## aZCFSeat.getStagedAllocation()
+  - Returns: **[Allocation](./zoe-data-types.md#allocation)**
+
+Gets and returns the **stagedAllocation**, which is the **Allocation** committed if the seat is
+reallocated over, if offer safety holds, and rights are conserved.
+
+**Note**: This method has been deprecated. Use **[AtomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
+:::
+
+::: warning DEPRECATED
+## aZCFSeat.hasStagedAllocation()
+  - Returns: **Boolean**
+
+Returns **true** if there is a staged allocation, i.e., whether **ZCFSeat.incrementBy()** or
+**ZCFSeat.decrementBy()** has been called and **ZCFSeat.clear()**
+and **reallocate()** have not. Otherwise returns **false**.
+
+**Note**: This method has been deprecated. Use **[AtomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
+:::
+
+::: warning DEPRECATED
 ## aZCFSeat.incrementBy(amountKeywordRecord)
-  - **amountKeywordRecord** **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
+  - **amountKeywordRecord**: **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
   - Returns: **AmountKeyRecord**
 
 Adds the **amountKeywordRecord** argument to the **ZCFseat**'s staged allocation and returns the 
@@ -151,11 +175,14 @@ zcfSeat1.incrementBy({ IST: empty });
 t.deepEqual(zcfSeat1.getStagedAllocation(), { IST: empty  });
 ```
 While this incremented the allocation by an empty amount, any amount would have been added to the 
-allocation in the same way. 
+allocation in the same way.
 
+**Note**: This method has been deprecated. Use **[AtomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
+:::
 
+::: warning DEPRECATED
 ## aZCFSeat.decrementBy(amountKeywordRecord)
-  - **amountKeywordRecord** **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
+  - **amountKeywordRecord**: **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
   - Returns: **AmountKeywordRecord**
 
 Subtracts the **amountKeywordRecord** argument from the **ZCFseat**'s staged allocation and returns the
@@ -198,18 +225,10 @@ It throws an error because you cannot subtract something from nothing. So trying
 allocation by a non-empty amount is an error, while decrementing an empty allocation by an empty amount
 is effectively a null operation with no effects.
 
-## aZCFSeat.clear()
-  - Returns: None.
-
-Deletes the **ZCFSeat**'s current staged allocation, if any.
+**Note**: This method has been deprecated. Use **[AtomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
+:::
 
 
-## aZCFSeat.hasStagedAllocation()
-  - Returns: **Boolean**
-
-Returns **true** if there is a staged allocation, i.e., whether **ZCFSeat.incrementBy()** or
-**ZCFSeat.decrementBy()** has been called and **ZCFSeat.clear()**
-and **reallocate()** have not. Otherwise returns **false**.
 
 
 

--- a/main/reference/zoe-api/zoe-contract-facet.md
+++ b/main/reference/zoe-api/zoe-contract-facet.md
@@ -11,9 +11,9 @@ the **zcf** object during that launch (see [Contract Requirements](/guides/zoe/c
 In the operations below, **instance** is the handle for the running contract instance.
 
 ## zcf.makeZCFMint(keyword, assetKind?, displayInfo?)
-- **keyword** **[Keyword](./zoe-data-types.md#keyword)**
-- **assetKind** **[AssetKind](/reference/ertp-api/ertp-data-types.md#assetkind)** - Optional, defaults to **AssetKind.NAT**.
-- **displayInfo** **[DisplayInfo](/reference/ertp-api/ertp-data-types.md#displayinfo)** - Optional, defaults to **undefined**.
+- **keyword**: **[Keyword](./zoe-data-types.md#keyword)**
+- **assetKind**: **[AssetKind](/reference/ertp-api/ertp-data-types.md#assetkind)** - Optional, defaults to **AssetKind.NAT**.
+- **displayInfo**: **[DisplayInfo](/reference/ertp-api/ertp-data-types.md#displayinfo)** - Optional, defaults to **undefined**.
 - Returns: **Promise&lt;[ZCFMint](./zcfmint.md)>**
 
 Creates a synchronous Zoe mint, allowing users to mint and reallocate digital assets synchronously
@@ -50,8 +50,8 @@ const invitationIssuer = await zcf.getInvitationIssuer();
 ```
 
 ## zcf.saveIssuer(issuer, keyword)
-- **issuer** **[Issuer](/reference/ertp-api/issuer.md)**
-- **keyword** **[Keyword](./zoe-data-types.md#keyword)**
+- **issuer**: **[Issuer](/reference/ertp-api/issuer.md)**
+- **keyword**: **[Keyword](./zoe-data-types.md#keyword)**
 - Returns: **Promise&lt;IssuerRecord>**
 
 Informs Zoe about an **Issuer** and returns a promise for acknowledging
@@ -71,13 +71,13 @@ await zcf.saveIssuer(secondaryIssuer, keyword);
 ```
 
 ## zcf.makeInvitation(offerHandler, description, customProperties?, proposalShape?)
-- **offerHandler** **ZCFSeat => Object**
-- **description** **String**
-- **customProperties** **Object** - Optional.
-- **proposalShape** **Pattern** - Optional.
+- **offerHandler**: **ZCFSeat => Object**
+- **description**: **String**
+- **customProperties**: **Object** - Optional.
+- **proposalShape**: **Pattern** - Optional.
 - Returns: **Promise&lt;[Invitation](./zoe-data-types.md#invitation)>**
 
-Make a credible Zoe **Invitation** for a smart contract. Note that **Invitations** are a special case
+Makes a credible Zoe **Invitation** for a smart contract. Note that **Invitations** are a special case
 of an ERTP **payment**. They are associated with the **invitationIssuer** and its **mint**, which 
 validate and mint **Invitations**. **zcf.makeInvitation()** serves as an interface to
 the **invitation** **mint**.
@@ -115,19 +115,19 @@ const { zcfSeat: mySeat } = zcf.makeEmptySeatKit();
 The contract code can request its own current instance, so it can be sent elsewhere.
 
 ## zcf.getBrandForIssuer(issuer)
-- **issuer** **[Issuer](/reference/ertp-api/issuer.md)**
+- **issuer**: **[Issuer](/reference/ertp-api/issuer.md)**
 - Returns: **[Brand](/reference/ertp-api/brand.md)**
 
 Returns the **Brand** associated with the *issuer*.
 
 ## zcf.getIssuerForBrand(brand)
-- **brand** **[Brand](/reference/ertp-api/brand.md)**
+- **brand**: **[Brand](/reference/ertp-api/brand.md)**
 - Returns: **[Issuer](/reference/ertp-api/issuer.md)**
 
 Returns the **Issuer** of the *brand* argument.
 
 ## zcf.getAssetKind(brand)
-- **brand** **[Brand](/reference/ertp-api/brand.md)**
+- **brand**: **[Brand](/reference/ertp-api/brand.md)**
 - Returns: **[AssetKind](/reference/ertp-api/ertp-data-types.md#assetkind)**
 
 Returns the **AssetKind** associated with the *brand* argument.
@@ -142,7 +142,7 @@ The contract requests Zoe to not accept offers for this contract instance.
 It can't be called from outside the contract unless the contract explicitly makes it accessible.
 
 ## zcf.shutdown(completion)
-- **completion** **Usually (but not always) a String**
+- **completion**: **Usually (but not always) a String**
 - Returns: None.
 
 Shuts down the entire vat and contract instance and gives payouts.
@@ -164,7 +164,7 @@ zcf.shutdown();
 ```
 
 ## zcf.shutdownWithFailure(reason)
-- **reason** **Error**
+- **reason**: **Error**
 - Returns: None.
 
 Shuts down the entire vat and contract instance due to an error.
@@ -220,7 +220,7 @@ E(zoeService).offer(creatorInvitation, proposal, paymentKeywordRecord);
 ```
 
 ## zcf.assertUniqueKeyword(keyword)
-- **keyword** **[Keyword](./zoe-data-types.md#keyword)**
+- **keyword**: **[Keyword](./zoe-data-types.md#keyword)**
 - Returns: **Undefined**
 
 Checks if a **Keyword** is valid and not already used as a **Brand** in this **Instance** (i.e., unique)
@@ -229,8 +229,10 @@ a valid **Keyword**, or is not unique.
 ```js
 zcf.assertUniqueKeyword(keyword);
 ```
+
+::: warning DEPRECATED
 ## zcf.reallocate(seats)
-- **seats** **[ZCFSeats](./zcfseat.md)[]** (at least two)
+- **seats**: **[ZCFSeats](./zcfseat.md)[]** (at least two)
 - Returns: None.
 
 **zcf.reallocate()** commits the staged allocations for each of its seat arguments,
@@ -273,8 +275,11 @@ buyerSeat.incrementBy(sellerSeat.decrementBy({ Items: wantedItems }));
 zcf.reallocate(buyerSeat, sellerSeat);
 ```
 
+**Note**: This method has been deprecated. Use **[AtomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
+:::
+
 ## zcf.setOfferFilter(strings)
-- **strings** **Array&lt;String>**
+- **strings**: **Array&lt;String>**
 - Returns: None.
 
 Prohibit invocation of invitatations whose description include any of the strings.

--- a/main/reference/zoe-api/zoe-contract-facet.md
+++ b/main/reference/zoe-api/zoe-contract-facet.md
@@ -41,7 +41,7 @@ mySynchronousMint.mintGains({ myKeyword: amount }, seat);
 ```
 
 ## zcf.getInvitationIssuer()
-- Returns: **[InvitationIssuer](./zoe-data-types.md#invitationissuer)**
+- Returns: **Promise&lt;[InvitationIssuer](./zoe-data-types.md#invitationissuer)>**
 
 Returns the **InvitationIssuer** for the Zoe instance.
 
@@ -230,6 +230,31 @@ a valid **Keyword**, or is not unique.
 zcf.assertUniqueKeyword(keyword);
 ```
 
+## zcf.setOfferFilter(strings)
+- **strings**: **Array&lt;String>**
+- Returns: None.
+
+Prohibit invocation of invitatations whose description include any of the strings.
+Any of the strings that end with a colon (:) will be treated as a prefix,
+and invitations whose description string begins with the string (including the colon)
+will be burned and not processed if passed to **E(Zoe).offer()**.
+
+It is expected that most contracts will never invoke this function directly. It is
+intended to be used by **governance** in a legible way, so that the contract's
+governance process can take emergency action in order to stop processing when necessary.
+
+Note that blocked strings can be re-enabled by calling this method again and simply not
+including that string in the *strings* argument.
+
+## zcf.getOfferFilter()
+- Returns: **Array&lt;String>**
+
+Returns all the strings that have been disabled for use in invitations, if any.
+A contract's invitations may be disabled using the
+**[zcf.setOfferFilter()](#zcf-setofferfilter-strings)** method when governance determines
+that they provide a vulnerability.
+
+
 ::: warning DEPRECATED
 ## zcf.reallocate(seats)
 - **seats**: **[ZCFSeats](./zcfseat.md)[]** (at least two)
@@ -275,29 +300,7 @@ buyerSeat.incrementBy(sellerSeat.decrementBy({ Items: wantedItems }));
 zcf.reallocate(buyerSeat, sellerSeat);
 ```
 
-**Note**: This method has been deprecated. Use **[AtomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
+**Note**: This method has been deprecated. Use **[atomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** instead.
 :::
 
-## zcf.setOfferFilter(strings)
-- **strings**: **Array&lt;String>**
-- Returns: None.
 
-Prohibit invocation of invitatations whose description include any of the strings.
-Any of the strings that end with a colon (:) will be treated as a prefix,
-and invitations whose description string begins with the string (including the colon)
-will be burned and not processed if passed to **E(Zoe).offer()**.
-
-It is expected that most contracts will never invoke this function directly. It is
-intended to be used by **governance** in a legible way, so that the contract's
-governance process can take emergency action in order to stop processing when necessary.
-
-Note that blocked strings can be re-enabled by calling this method again and simply not
-including that string in the *strings* argument.
-
-## zcf.getOfferFilter()
-- Returns: **Array&lt;String>**
-
-Returns all the strings that have been disabled for use in invitations, if any.
-A contract's invitations may be disabled using the
-**[zcf.setOfferFilter()](#zcf-setofferfilter-strings)** method when governance determines
-that they provide a vulnerability.

--- a/main/reference/zoe-api/zoe-data-types.md
+++ b/main/reference/zoe-api/zoe-data-types.md
@@ -4,7 +4,8 @@ Zoe introduces and uses several data types.
 
 ## Allocation
 
-**Allocations** represent the **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)** to be paid out to each seat upon exiting a **Proposal**.
+**Allocations** represent the **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)** to be paid
+out to each seat upon exiting a **Proposal**.
 
 For example, if a seat expected to be paid 5 *Quatloos* and 3 *Widgets* after successfully exiting a **Proposal**, the **Allocation** would look like:
 
@@ -45,11 +46,15 @@ const myAmountKeywordRecord =
 ```
 ## Handle
 
-**Handles** within Zoe have a slightly different definition than in regular JavaScript. They are **Far** objects without any methods whose only useful property are their unique identities. They're often created in order to designate some other object, where the **Handles** can be passed around as reliable designators without giving access to the designated objects.
+**Handles** within Zoe have a slightly different definition than in regular JavaScript. They are **Far**
+objects without any methods whose only useful property are their unique identities. They're often
+created in order to designate some other object, where the **Handles** can be passed around as reliable
+designators without giving access to the designated objects.
 
 ## Instance
 
-**Instances** are handles to opaque objects that represent contract instances. You can get information about them via these methods:
+**Instances** are handles to opaque objects that represent contract instances. You can get information
+about them via these methods:
 
 - **[E(Zoe).getBrands()](./zoe.md#e-zoe-getbrands-instance)**
 - **[E(Zoe).getIssuers()](./zoe.md#e-zoe-getissuers-instance)**
@@ -62,7 +67,7 @@ An **Invitation** is a kind of **[Payment](/reference/ertp-api/payment.md)**. It
 that can be held in **Payments** or **[Purses](/reference/ertp-api/purse.md)**, just like any other
 eright. An **Invitation** **Payment** would be a **Payment** holding an **Invitation**. Because we
 almost always just use a **Payment** holding a single **Invitation** in order to pass around
-**Invitations**, we normally elide the difference.
+**Invitations**, the difference is normally elided.
 
 ## InvitationIssuer
 
@@ -134,3 +139,24 @@ and produces results of the same **Brand**.
 **Ratios** can also have two different **Brands**, essentially typing them such as miles per
 hour or US dollars for Swiss francs (i.e., an exchange rate ratio).
 
+## TransferPart
+
+**TransferParts** are the individual elements of the *transfer* array passed into the 
+**[atomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** function. Each **TransferPart**
+represents one or two **[Allocation](#allocation)** changes among existing 
+**[ZCFSeats](./zcfseat.md)**. Each **TransferPart** consists of 4 fields, none of which are mandatory:
+
+* **fromSeat**?: **ZCFSeat** - The seat from which an **[Amount](/reference/ertp-api/ertp-data-types.md#amount)** is being taken.
+* **toSeat**?: **ZCFSeat** - The seat to which an **[Amount](/reference/ertp-api/ertp-data-types.md#amount)** is being given.
+* **fromAmounts**?: **[AmountKeywordRecord](#amountkeywordrecord)** - The **AmountKeywordRecord** which will be taken from the *fromSeat*.
+* **toAmounts**?: **AmountKeywordRecord** - The **AmountKeywordRecord** which will be given to the *toSeat*.
+
+If a *fromSeat* is specified, then a *fromAmounts* is required. This does *not* hold true for *toSeat*;
+you can specify a *toSeat* without specifying a *toAmounts*.
+
+**TransferParts** can be automatically created by using the helper functions 
+**[fromOnly()](./zoe-helpers.md#fromonly-fromseat-fromamounts)** or 
+**[toOnly()](./zoe-helpers.md#toonly-toseat-toamounts)**. 
+Of course, as with any JavaScript datatype, you can also manually create **TransferParts**. 
+Note that if you manually create a **TransferPart**, you'll need to set any fields that you 
+don't include to **undefined**.

--- a/main/reference/zoe-api/zoe-data-types.md
+++ b/main/reference/zoe-api/zoe-data-types.md
@@ -53,8 +53,8 @@ designators without giving access to the designated objects.
 
 ## Instance
 
-**Instances** are handles to opaque objects that represent contract instances. You can get information
-about them via these methods:
+An **Instance** is a handle that represents an instance of a contract.
+You can get information about the contract instance via these methods:
 
 - **[E(Zoe).getBrands()](./zoe.md#e-zoe-getbrands-instance)**
 - **[E(Zoe).getIssuers()](./zoe.md#e-zoe-getissuers-instance)**
@@ -120,8 +120,8 @@ const { quoteAmount, quotePayment } = priceQuote;
 
 **PriceQuotes** are returned in two forms: 
 - **PriceDescription**
-  - Always includes **amountIn**, **amountOut**, the quote's **TimeStamp**,
-    and the **TimerService** the **TimeStamp** is relative to.
+  - Always includes **amountIn**, **amountOut**, the quote's **Timestamp**,
+    and the **TimerService** the **Timestamp** is relative to.
 - **PriceDescription** wrapped as a **QuoteAuthority** issued payment. 
   - This lets quotes be shared in a format letting others verify the time and values. 
 
@@ -151,12 +151,12 @@ represents one or two **[Allocation](#allocation)** changes among existing
 * **fromAmounts**?: **[AmountKeywordRecord](#amountkeywordrecord)** - The **AmountKeywordRecord** which will be taken from the *fromSeat*.
 * **toAmounts**?: **AmountKeywordRecord** - The **AmountKeywordRecord** which will be given to the *toSeat*.
 
-If a *fromSeat* is specified, then a *fromAmounts* is required. This does *not* hold true for *toSeat*;
-you can specify a *toSeat* without specifying a *toAmounts*.
+If a *fromSeat* is specified, then a *fromAmounts* is required. When you specify a *toSeat* without specifying a *toAmounts*, it means that the *fromAmount* will be taken from *fromSeat* and given to *toSeat*.
 
-**TransferParts** can be automatically created by using the helper functions 
-**[fromOnly()](./zoe-helpers.md#fromonly-fromseat-fromamounts)** or 
-**[toOnly()](./zoe-helpers.md#toonly-toseat-toamounts)**. 
-Of course, as with any JavaScript datatype, you can also manually create **TransferParts**. 
-Note that if you manually create a **TransferPart**, you'll need to set any fields that you 
+**TransferParts** that represent one side of a transfer
+can be created using the helper functions
+**[fromOnly()](./zoe-helpers.md#fromonly-fromseat-fromamounts)** or
+**[toOnly()](./zoe-helpers.md#toonly-toseat-toamounts)**.
+Of course, as with any JavaScript datatype, you can also manually create **TransferParts**.
+Note that if you manually create a **TransferPart**, you'll need to set any fields that you
 don't include to **undefined**.

--- a/main/reference/zoe-api/zoe-data-types.md
+++ b/main/reference/zoe-api/zoe-data-types.md
@@ -162,4 +162,4 @@ can be created using the helper functions
 Of course, as with any JavaScript datatype, you can also manually create **TransferParts**.
 If you manually create a **TransferPart** and don't include the *fromSeat*, *toSeat*, and/or
 *fromAmounts* fields, you'll need to set the missing fields to **undefined**. (Note that if you don't
-include the *toAmounts* field, there's no need to set it to **udefined**; you can simply omit it.)
+include the *toAmounts* field, there's no need to set it to **undefined**; you can simply omit it.)

--- a/main/reference/zoe-api/zoe-data-types.md
+++ b/main/reference/zoe-api/zoe-data-types.md
@@ -46,10 +46,10 @@ const myAmountKeywordRecord =
 ```
 ## Handle
 
-**Handles** within Zoe have a slightly different definition than in regular JavaScript. They are **Far**
-objects without any methods whose only useful property are their unique identities. They're often
-created in order to designate some other object, where the **Handles** can be passed around as reliable
-designators without giving access to the designated objects.
+**Handles** are **Far** objects without any methods whose only useful property are their
+unique identities. They're often created in order to designate some other object, where the
+**Handles** can be passed around as reliable designators without giving access to the
+designated objects.
 
 ## Instance
 
@@ -75,7 +75,7 @@ almost always just use a **Payment** holding a single **Invitation** in order to
 instance has a single **InvitationIssuer** for the entirety of its lifetime. All **Invitations** come
 from the **[Mint](/reference/ertp-api/mint.md)** associated with the Zoe instance's **InvitationIssuer**.
 
-**InvitationIssuers** have all the methods of regular **Issuers**, but the two methods that qre most
+**InvitationIssuers** have all the methods of regular **Issuers**, but the two methods that are most
 often used are **[anIssuer.claim()](/reference/ertp-api/issuer.md#anissuer-claim-payment-optamount)**
 and **[anIssuer.getAmountOf()](/reference/ertp-api/issuer.md#anissuer-getamountof-payment)**.
 
@@ -144,7 +144,7 @@ hour or US dollars for Swiss francs (i.e., an exchange rate ratio).
 **TransferParts** are the individual elements of the *transfer* array passed into the 
 **[atomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** function. Each **TransferPart**
 represents one or two **[Allocation](#allocation)** changes among existing 
-**[ZCFSeats](./zcfseat.md)**. Each **TransferPart** consists of 4 fields, none of which are mandatory:
+**[ZCFSeats](./zcfseat.md)**. Each **TransferPart** consists of 4 elements, none of which are mandatory:
 
 * **fromSeat**?: **ZCFSeat** - The seat from which an **[Amount](/reference/ertp-api/ertp-data-types.md#amount)** is being taken.
 * **toSeat**?: **ZCFSeat** - The seat to which an **[Amount](/reference/ertp-api/ertp-data-types.md#amount)** is being given.

--- a/main/reference/zoe-api/zoe-data-types.md
+++ b/main/reference/zoe-api/zoe-data-types.md
@@ -151,12 +151,15 @@ represents one or two **[Allocation](#allocation)** changes among existing
 * **fromAmounts**?: **[AmountKeywordRecord](#amountkeywordrecord)** - The **AmountKeywordRecord** which will be taken from the *fromSeat*.
 * **toAmounts**?: **AmountKeywordRecord** - The **AmountKeywordRecord** which will be given to the *toSeat*.
 
-If a *fromSeat* is specified, then a *fromAmounts* is required. When you specify a *toSeat* without specifying a *toAmounts*, it means that the *fromAmount* will be taken from *fromSeat* and given to *toSeat*.
+If a *fromSeat* is specified, then a *fromAmounts* is required. When you specify a *toSeat* without
+specifying a *toAmounts*, it means that the *fromAmount* will be taken from *fromSeat* and given to
+*toSeat*.
 
 **TransferParts** that represent one side of a transfer
 can be created using the helper functions
 **[fromOnly()](./zoe-helpers.md#fromonly-fromseat-fromamounts)** or
 **[toOnly()](./zoe-helpers.md#toonly-toseat-toamounts)**.
 Of course, as with any JavaScript datatype, you can also manually create **TransferParts**.
-Note that if you manually create a **TransferPart**, you'll need to set any fields that you
-don't include to **undefined**.
+If you manually create a **TransferPart** and don't include the *fromSeat*, *toSeat*, and/or
+*fromAmounts* fields, you'll need to set the missing fields to **undefined**. (Note that if you don't
+include the *toAmounts* field, there's no need to set it to **udefined**; you can simply omit it.)

--- a/main/reference/zoe-api/zoe-data-types.md
+++ b/main/reference/zoe-api/zoe-data-types.md
@@ -17,8 +17,9 @@ For example, if a seat expected to be paid 5 *Quatloos* and 3 *Widgets* after su
 
 ## AmountKeywordRecord
 
-**AmountKeywordRecord** is a record in which the property names are **[Keywords](#keyword)**, and
-the values are **amounts**. **Keywords** are unique identifiers per contract
+**AmountKeywordRecords** are records in which the property names are **[Keywords](#keyword)**, and
+the values are **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)**. **Keywords** are 
+unique identifiers per contract
 that tie together the **proposal**, **payments** to be escrowed, and **payouts**
 to the user. In the below example, **Asset** and **Price** are **Keywords**.
 
@@ -44,7 +45,7 @@ const myAmountKeywordRecord =
 ```
 ## Handle
 
-**Handles&** within Zoe have a slightly different definition than in regular JavaScript. They are **Far** objects without any methods whose only useful property are their unique unforgeable identities. They're often created in order to designate some other object, where the **Handles** can be passed around as reliable designators without giving access to the designated ojects.
+**Handles** within Zoe have a slightly different definition than in regular JavaScript. They are **Far** objects without any methods whose only useful property are their unique identities. They're often created in order to designate some other object, where the **Handles** can be passed around as reliable designators without giving access to the designated objects.
 
 ## Instance
 
@@ -57,13 +58,11 @@ const myAmountKeywordRecord =
 
 ## Invitation
 
-TBD
-
-For most purposes, a good enough approximation is that an Invitation is indeed a kind of Payment.
-
-Technically, an Invitation is a non-fungible eright that can be held in payments or purses, just like any other eright. An Invitation payment would be a Payment holding an Invitation. An Invitation payment is a kind of Payment.
-
-But we almost always just use a Payment holding a single Invitation in order to pass around Invitations, so we normally elide the difference.
+An **Invitation** is a kind of **[Payment](/reference/ertp-api/payment.md)**. It's a non-fungible eright
+that can be held in **Payments** or **[Purses](/reference/ertp-api/purse.md)**, just like any other
+eright. An **Invitation** **Payment** would be a **Payment** holding an **Invitation**. Because we
+almost always just use a **Payment** holding a single **Invitation** in order to pass around
+**Invitations**, we normally elide the difference.
 
 ## InvitationIssuer
 
@@ -71,7 +70,9 @@ But we almost always just use a Payment holding a single Invitation in order to 
 instance has a single **InvitationIssuer** for the entirety of its lifetime. All **Invitations** come
 from the **[Mint](/reference/ertp-api/mint.md)** associated with the Zoe instance's **InvitationIssuer**.
 
-**InvitationIssuers** have all the methods of regular **Issuers**, but the two methods that qre most often used are **[anIssuer.claim()](/reference/ertp-api/issuer.md#anissuer-claim-payment-optamount)** and **[anIssuer.getAmountOf()](/reference/ertp-api/issuer.md#anissuer-getamountof-payment)**.
+**InvitationIssuers** have all the methods of regular **Issuers**, but the two methods that qre most
+often used are **[anIssuer.claim()](/reference/ertp-api/issuer.md#anissuer-claim-payment-optamount)**
+and **[anIssuer.getAmountOf()](/reference/ertp-api/issuer.md#anissuer-getamountof-payment)**.
 
 A successful call of **anInvitationIssuer.claim()** means you are assured the **Invitation** passed into
 the method is recognized as valid by the **InvitationIssuer**. You are also assured the **Invitation**
@@ -114,7 +115,7 @@ const { quoteAmount, quotePayment } = priceQuote;
 
 **PriceQuotes** are returned in two forms: 
 - **PriceDescription**
-  - Always includes **amountIn**, **amountOut**, the quote's **Timestamp**,
+  - Always includes **amountIn**, **amountOut**, the quote's **TimeStamp**,
     and the **TimerService** the **TimeStamp** is relative to.
 - **PriceDescription** wrapped as a **QuoteAuthority** issued payment. 
   - This lets quotes be shared in a format letting others verify the time and values. 
@@ -127,11 +128,9 @@ const { quoteAmount, quotePayment } = priceQuote;
 just like **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)**.
 A **Ratio** cannot have a denominator value of 0.
 
-The ratio functions have to be imported.
-
 The most common kind of **Ratio** is applied to an **Amount** of a particular **Brand**
 and produces results of the same **Brand**.
 
 **Ratios** can also have two different **Brands**, essentially typing them such as miles per
-hour or US dollars for Swiss francs (an exchange rate ratio).
+hour or US dollars for Swiss francs (i.e., an exchange rate ratio).
 

--- a/main/reference/zoe-api/zoe-data-types.md
+++ b/main/reference/zoe-api/zoe-data-types.md
@@ -65,17 +65,15 @@ You can get information about the contract instance via these methods:
 
 An **Invitation** is a kind of **[Payment](/reference/ertp-api/payment.md)**. It's a non-fungible eright
 that can be held in **Payments** or **[Purses](/reference/ertp-api/purse.md)**, just like any other
-eright. An **Invitation** **Payment** would be a **Payment** holding an **Invitation**. Because we
-almost always just use a **Payment** holding a single **Invitation** in order to pass around
-**Invitations**, the difference is normally elided.
+eright. An **Invitation** **Payment** is a **Payment** holding an **Invitation**.
 
 ## InvitationIssuer
 
-**InvitationIssuers** are special types of **[Issuers](/reference/ertp-api/issuer.md)**. Every Zoe
-instance has a single **InvitationIssuer** for the entirety of its lifetime. All **Invitations** come
-from the **[Mint](/reference/ertp-api/mint.md)** associated with the Zoe instance's **InvitationIssuer**.
+The **InvitationIssuer** is a special type of **[Issuer](/reference/ertp-api/issuer.md)**. The single Zoe
+instance has an **InvitationIssuer** for the entirety of its lifetime. All **Invitations** come from the
+**[Mint](/reference/ertp-api/mint.md)** associated with the Zoe instance's **InvitationIssuer**.
 
-**InvitationIssuers** have all the methods of regular **Issuers**, but the two methods that are most
+**InvitationIssuer** has all the methods of regular **Issuers**, but the two methods that are most
 often used are **[anIssuer.claim()](/reference/ertp-api/issuer.md#anissuer-claim-payment-optamount)**
 and **[anIssuer.getAmountOf()](/reference/ertp-api/issuer.md#anissuer-getamountof-payment)**.
 
@@ -141,10 +139,11 @@ hour or US dollars for Swiss francs (i.e., an exchange rate ratio).
 
 ## TransferPart
 
-**TransferParts** are the individual elements of the *transfer* array passed into the 
+**TransferParts** are the individual elements of the *transfer* array passed into the
 **[atomicRearrange()](./zoe-helpers.md#atomicrearrange-zcf-transfers)** function. Each **TransferPart**
-represents one or two **[Allocation](#allocation)** changes among existing 
-**[ZCFSeats](./zcfseat.md)**. Each **TransferPart** consists of 4 elements, none of which are mandatory:
+represents one or two **[Allocation](#allocation)** changes among existing
+**[ZCFSeats](./zcfseat.md)**. Each **TransferPart** consists of 4 elements, each of which can be elided
+in some cases:
 
 * **fromSeat**?: **ZCFSeat** - The seat from which an **[Amount](/reference/ertp-api/ertp-data-types.md#amount)** is being taken.
 * **toSeat**?: **ZCFSeat** - The seat to which an **[Amount](/reference/ertp-api/ertp-data-types.md#amount)** is being given.

--- a/main/reference/zoe-api/zoe-helpers.md
+++ b/main/reference/zoe-api/zoe-helpers.md
@@ -19,9 +19,34 @@ ZoeHelper functions are contract helpers, in that they are useful to contract co
 Contracts are started up by Zoe, 
 and **zcf** is passed in as a parameter to **start()**. 
 
+## atomicRearrange(zcf, transfers)
+- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)** 
+- **transfers**: **TransferPart[]**
+- Returns: None.
+
+Asks Zoe to rearrange the [Allocation](./zoe-data-types.md#allocation) among the seats
+mentioned in *transfers*. This is a set of changes to allocations that must satisfy
+ * several constraints. If these constraints are all met, then the
+ * reallocation happens atomically. Otherwise it does not happen
+ * at all.
+ *
+
+* All the mentioned seats are still live -- enforced by ZCF.
+* The overall transfer is expressed as an array of `TransferPart`.
+ *      Each individual `TransferPart` is one of
+ *       - A transfer from a `fromSeat` to a `toSeat`.
+ *         This is not needed for Zoe's safety, as Zoe does
+           its own overall conservation check. Rather, it helps catch
+           and diagnose contract bugs earlier.
+ *       - A taking from a `fromSeat`'s allocation. See the `fromOnly`
+           helper.
+         - A giving into a `toSeat`'s allocation. See the `toOnly`
+           helper.
+
+
 ## assertIssuerKeywords(zcf, expected)
-- **zcf** **[ZoeContractFacet](./zoe-contract-facet.md)** 
-- **expected** **Array&lt;String>**
+- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)** 
+- **expected**: **Array&lt;String>**
 - Returns: None.
 
 Checks that the **[Keywords](./zoe-data-types.md#keyword)** in the *expected* argument match what the contract expects. 
@@ -38,9 +63,9 @@ assertIssuerKeywords(zcf, harden(['Asset', 'Price']));
 ```
 
 ## satisfies(zcf, seat, update)
-- **zcf** **[ZoeContractFacet](./zoe-contract-facet.md)**
-- **seat** **[ZCFSeat](./zcfseat.md)**
-- **update** **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
+- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)**
+- **seat**: **[ZCFSeat](./zcfseat.md)**
+- **update**: **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
 - Returns: **Boolean** 
 
 Returns **true** if an update to a **seat**'s **currentAllocation** satisfies its
@@ -69,9 +94,9 @@ if (satisfiedBy(offer, seat) && satisfiedBy(seat, offer)) {
 ```
 
 ## swap(zcf, leftSeat, rightSeat)
-- **zcf** **[ZoeContractFacet](./zoe-contract-facet.md)**
-- **leftSeat** **[ZCFSeat](./zcfseat.md)**
-- **rightSeat** **ZCFSeat**
+- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)**
+- **leftSeat**: **[ZCFSeat](./zcfseat.md)**
+- **rightSeat**: **ZCFSeat**
 - Returns: **defaultAcceptanceMsg**
 
 For both **seats**, everything a **seat** wants is given to it, having been
@@ -100,9 +125,9 @@ swap(zcf, firstSeat, secondSeat);
 ```
 
 ## swapExact(zcf, leftSeat, rightSeat)
-- **zcf** **[ZoeContractFacet](./zoe-contract-facet.md)**
-- **leftSeat** **[ZCFSeat](./zcfseat.md)**
-- **rightSeat** **ZCFSeat**
+- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)**
+- **leftSeat**: **[ZCFSeat](./zcfseat.md)**
+- **rightSeat**: **ZCFSeat**
 - Returns: **defaultAcceptanceMsg**
 
 For both seats, everything a seat wants is given to it, having been
@@ -134,15 +159,15 @@ const swapMsg = swapExact(zcf, zcfSeatA, zcfSeatB);
 ```
 
 ## fitProposalShape(seat, proposalShape)
-- **seat** **[ZCFSeat](./zcfseat.md)**
-- **proposalShape** **Pattern**
+- **seat**: **[ZCFSeat](./zcfseat.md)**
+- **proposalShape**: **Pattern**
 - Returns: None.
 
 Checks the seat's proposal against the *proposalShape* argument. If the proposal does not match *proposalShape*, the seat will be exited and all **[Payments](/reference/ertp-api/payment.md)** will be refunded.
 
 ## assertProposalShape(seat, expected)
-- **seat** **[ZCFSeat](./zcfseat.md)**
-- **expected** **ExpectedRecord**
+- **seat**: **[ZCFSeat](./zcfseat.md)**
+- **expected**: **ExpectedRecord**
 - Returns: None.
 
 Checks the seat's proposal against an *expected* record that says
@@ -174,8 +199,8 @@ const sell = seat => {
 ```
 
 ## assertNatAssetKind(zcf, brand)
-- **zcf** **[ZoeContractFacet](./zoe-contract-facet.md)**
-- **brand** **[Brand](/reference/ertp-api/brand.md)**
+- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)**
+- **brand**: **[Brand](/reference/ertp-api/brand.md)**
 - Returns: **Boolean**
 
 Asserts that the *brand* is [AssetKind.NAT](/reference/ertp-api/ertp-data-types.md#assetkind).
@@ -192,10 +217,10 @@ assertNatAssetKind(zcf, quatloosBrand);
 ```
 
 ## depositToSeat(zcf, recipientSeat, amounts, payments)
-- **zcf** **[ZoeContractFacet](./zoe-contract-facet.md)**
-- **recipientSeat** **[ZCFSeat](./zcfseat.md)**
-- **amounts** **[AmountKeywordRecord](./zoe-data-types.md#allocation)**
-- **payments** **PaymentKeywordRecord**
+- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)**
+- **recipientSeat**: **[ZCFSeat](./zcfseat.md)**
+- **amounts**: **[AmountKeywordRecord](./zoe-data-types.md#allocation)**
+- **payments**: **PaymentKeywordRecord**
 - Returns: **Promise&lt;String>**
 
 Deposits payments such that their amounts are reallocated to a seat.
@@ -214,9 +239,9 @@ await depositToSeat(zcf, zcfSeat, { Dep: quatloos(2n) }, { Dep: quatloosPayment 
 ```
 
 ## withdrawFromSeat(zcf, seat, amounts)
-- **zcf** **[ZoeContractFacet](./zoe-contract-facet.md)**
-- **seat** **[ZCFSeat](./zcfseat.md)**
-- **amounts** **[AmountKeywordRecord](./zoe-data-types.md#allocation)**
+- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)**
+- **seat**: **[ZCFSeat](./zcfseat.md)**
+- **amounts**: **[AmountKeywordRecord](./zoe-data-types.md#allocation)**
 - Returns: **Promise&lt;PaymentKeywordRecord>**
 
 Withdraws payments from a seat. Note that withdrawing the amounts of
@@ -234,8 +259,8 @@ const paymentKeywordRecord = await withdrawFromSeat(zcf, zcfSeat, { With: quatlo
 ```
 
 ## saveAllIssuers(zcf, issuerKeywordRecord)
-- **zcf** **[ZoeContractFacet](./zoe-contract-facet.md)**
-- **issuerKeywordRecord** **IssuerKeywordRecord**
+- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)**
+- **issuerKeywordRecord**: **IssuerKeywordRecord**
 - Returns: **Promise&lt;PaymentKeywordRecord>**
 
 Saves all of the issuers in an **IssuersKeywordRecord** to ZCF, using
@@ -252,13 +277,13 @@ await saveAllIssuers(zcf, { G: gIssuer, D: dIssuer, P: pIssuer });
 ```
 
 ## offerTo(zcf, invitation, keywordMapping, proposal, fromSeat, toSeat, offerArgs)
-- **zcf** **[ZoeContractFacet](./zoe-contract-facet.md)**
-- **invitation** **ERef&lt;[Invitation](./zoe-data-types.md#invitation)>**
-- **keywordMapping** **KeywordRecord**
-- **proposal** **Proposal**
-- **fromSeat** **[ZCFSeat](./zcfseat.md)**
-- **toSeat** **ZCFSeat**
-- **offerArgs** **Object**
+- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)**
+- **invitation**: **ERef&lt;[Invitation](./zoe-data-types.md#invitation)>**
+- **keywordMapping**: **KeywordRecord**
+- **proposal**: **Proposal**
+- **fromSeat**: **[ZCFSeat](./zcfseat.md)**
+- **toSeat**: **ZCFSeat**
+- **offerArgs**: **Object**
 - Returns: **OfferToReturns**
 
 **offerTo()** makes an offer from your current contract instance (which

--- a/main/reference/zoe-api/zoe-helpers.md
+++ b/main/reference/zoe-api/zoe-helpers.md
@@ -21,28 +21,49 @@ and **zcf** is passed in as a parameter to **start()**.
 
 ## atomicRearrange(zcf, transfers)
 - **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)** 
-- **transfers**: **TransferPart[]**
+- **transfers**: **Array&lt;[TransferPart](./zoe-data-types.md#transferpart)>**
 - Returns: None.
 
-Asks Zoe to rearrange the [Allocation](./zoe-data-types.md#allocation) among the seats
-mentioned in *transfers*. This is a set of changes to allocations that must satisfy
- * several constraints. If these constraints are all met, then the
- * reallocation happens atomically. Otherwise it does not happen
- * at all.
- *
+Asks Zoe to rearrange the **[Allocations](./zoe-data-types.md#allocation)** among the seats
+mentioned in *transfers*. *transfers* are a set of changes to **Allocations** that must satisfy
+several constraints. If these constraints are all met, then the
+reallocation happens atomically. Otherwise an error is thrown and it does not happen
+at all. The constraints are as follows.
 
-* All the mentioned seats are still live -- enforced by ZCF.
-* The overall transfer is expressed as an array of `TransferPart`.
- *      Each individual `TransferPart` is one of
- *       - A transfer from a `fromSeat` to a `toSeat`.
- *         This is not needed for Zoe's safety, as Zoe does
-           its own overall conservation check. Rather, it helps catch
-           and diagnose contract bugs earlier.
- *       - A taking from a `fromSeat`'s allocation. See the `fromOnly`
-           helper.
-         - A giving into a `toSeat`'s allocation. See the `toOnly`
-           helper.
+ * All the mentioned seats are still live.
+ * There aren't any outstanding stagings for any of the mentioned seats.
 
+	Stagings are a reallocation mechanism that has been
+    deprecated in favor of this **atomicRearrange()** function.
+    To prevent confusion, each reallocation can only be
+    expressed in the old way or the new way, but not a mixture.
+ * Overall conservation must be maintained. In other words, the reallocated
+    **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)** must balance out to zero.
+
+Note that you can manually construct the **TransferParts** that make up the *transfers* array manually,
+or you can use the helper functions **[fromOnly()](#fromonly-fromseat-fromamounts)** or 
+**[toOnly()](#toonly-toseat-toamounts)** to create simple **TransferParts** that only contain 
+two of the possible 4 potential fields.
+
+## fromOnly(fromSeat, fromAmounts)
+- **fromSeat**: **[ZCFSeat](./zcfseat.md)**
+- **fromAmounts**: **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
+- Returns: **[TransferPart](./zoe-data-types.md#transferpart)**
+
+Returns a **TransferPart** when a reallocation only involves taking an 
+**[Allocation](./zoe-data-types.md#allocation)** from the **ZCFSeat** specified by *fromSeat*.
+**TransferParts** are used as part of the *transfer* argument of the 
+**[atomicRearrange()](#atomicrearrange-zcf-transfers)** function.
+
+## toOnly(toSeat, toAmounts)
+- **toSeat**: **[ZCFSeat](./zcfseat.md)**
+- **toAmounts**: **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
+- Returns: **[TransferPart](./zoe-data-types.md#transferpart)**
+
+Returns a **TransferPart** when a reallocation only involves giving an 
+**[Allocation](./zoe-data-types.md#allocation)** to the **ZCFSeat** specified by *toSeat*.
+**TransferParts** are used as part of the *transfer* argument of the 
+**[atomicRearrange()](#atomicrearrange-zcf-transfers)** function.
 
 ## assertIssuerKeywords(zcf, expected)
 - **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)** 
@@ -266,7 +287,7 @@ const paymentKeywordRecord = await withdrawFromSeat(zcf, zcfSeat, { With: quatlo
 Saves all of the issuers in an **IssuersKeywordRecord** to ZCF, using
 the method [**zcf.saveIssuer()**](./zoe-contract-facet.md#zcf-saveissuer-issuer-keyword).
 
-This does **not** error if any of the [Keywords](./zoe-data-types.md#keyword) already exist. If the **Keyword** is
+This does **not** error if any of the **[Keywords](./zoe-data-types.md#keyword)** already exist. If the **Keyword** is
 already present, it is ignored.
 
 ```js

--- a/main/reference/zoe-api/zoe-helpers.md
+++ b/main/reference/zoe-api/zoe-helpers.md
@@ -1,12 +1,13 @@
 # ZoeHelper Functions
 
-The ZoeHelper functions extract common contract code and
-patterns into reusable helpers.
+The ZoeHelper functions provide convenient abstractions for accessing Zoe functionality from within
+contracts. In most cases, you pass a reference to zcf or one or more seats.
 
 All of the ZoeHelper functions are described below. To use any of them, import them
 directly from **@agoric/zoe/src/contractSupport/index.js**. For example, the
 following imports the two ZoeHelper functions **[assertIssuerKeywords()](#assertissuerkeywords-zcf-expected)** and
 **[assertProposalShape()](#assertproposalshape-seat-expected)**:
+
 
 ```js
 import {
@@ -15,20 +16,15 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 ```
 
-ZoeHelper functions are contract helpers, in that they are useful to contract code. 
-Contracts are started up by Zoe, 
-and **zcf** is passed in as a parameter to **start()**. 
-
 ## atomicRearrange(zcf, transfers)
 - **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)** 
 - **transfers**: **Array&lt;[TransferPart](./zoe-data-types.md#transferpart)>**
 - Returns: None.
 
-Asks Zoe to rearrange the **[Allocations](./zoe-data-types.md#allocation)** among the seats
-mentioned in *transfers*. *transfers* are a set of changes to **Allocations** that must satisfy
-several constraints. If these constraints are all met, then the
-reallocation happens atomically. Otherwise an error is thrown and it does not happen
-at all. The constraints are as follows.
+Asks Zoe to rearrange the **[Allocations](./zoe-data-types.md#allocation)** among the seats mentioned in
+*transfers*. *transfers* are a set of changes to **Allocations** that must satisfy several
+constraints. If these constraints are all met, then the reallocation happens atomically. Otherwise an
+error is thrown and none of the propossed changes has any effect. The constraints are as follows.
 
  * All the mentioned seats are still live.
  * There aren't any outstanding stagings for any of the mentioned seats.
@@ -38,65 +34,63 @@ at all. The constraints are as follows.
     To prevent confusion, each reallocation can only be
     expressed in the old way or the new way, but not a mixture.
  * Overall conservation must be maintained. In other words, the reallocated
-    **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)** must balance out to zero.
+    **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)** must balance out.
  * Offer Safety is preserved for each seat. That means reallocations can only take assets from a seat
 	 as long as either it gets the assets described in the want section of its proposal, or it retains
-     all of the assets specified in the give section of the proposal. This constraint applies to the
-     entire atomicRearrangement, not to the individual **TransferParts**.
+     all of the assets specified in the give section of the proposal. This constraint applies to each
+     seat across the entire atomicRearrangement, not to the individual **TransferParts**.
 
-Note that you can manually construct the **TransferParts** that make up the *transfers* array manually,
-or you can use the helper functions **[fromOnly()](#fromonly-fromseat-fromamounts)** or 
-**[toOnly()](#toonly-toseat-toamounts)** to create simple **TransferParts** that only contain 
-two of the possible 4 potential fields.
-
-## atomicTransfer(zcf, fromSeat?, toSeat?, fromAmounts?, toAmounts?)
-- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)** 
-- **fromSeat**: **[ZCFSeat](./zcfseat.md)** - Optional, defaults to **undefined**.
-- **toSeat**: **ZCFSeat** - Optional, defaults to **undefined**.
-- **fromAmounts**: **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)** - Optional, defaults to **undefined**.
-- **toAmounts**: **AmountKeywordRecord** - Optional, defaults to **undefined**.
-- Returns: None.
-
-Asks Zoe to rearrange the **[Allocations](./zoe-data-types.md#allocation)** among the seats
-mentioned in *fromSeat* and *toSeat*. The reallocations must satisfy
-several constraints. If these constraints are all met, then the
-reallocation happens atomically. Otherwise an error is thrown and it does not happen
-at all. The constraints are as follows.
-
- * All the mentioned seats are still live.
- * There aren't any outstanding stagings for any of the mentioned seats.
- * Overall conservation must be maintained. In other words, the reallocated
-    **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)** must balance out to zero.
- * Offer Safety is preserved for each seat. That means reallocations can only take assets from a seat
-	 as long as either it gets the assets described in the want section of its proposal, or it retains
-     all of the assets specified in the give section of the proposal.
-
-If a *fromSeat* is specified, then a *fromAmounts* is required. When you specify a *toSeat* without
-specifying a *toAmounts*, it means that the *fromAmount* will be taken from *fromSeat* and given to
-*toSeat*. If you don't include a *fromSeat*, *toSeat*, and/or
-*fromAmounts* argument, you'll need to set the missing arguments to **undefined**.
-(Note that if you don't
-include the *toAmounts* argument, there's no need to set it to **undefined**; you can simply omit it.)
+Note that you can construct the **TransferParts** that make up the *transfers* array manually, or for
+transfers that only include one seat, you can use the helper functions
+**[fromOnly()](#fromonly-fromseat-fromamounts)** and **[toOnly()](#toonly-toseat-toamounts)** to create
+**TransferParts** that only use a subset of the fields.
 
 ## fromOnly(fromSeat, fromAmounts)
 - **fromSeat**: **[ZCFSeat](./zcfseat.md)**
 - **fromAmounts**: **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
 - Returns: **[TransferPart](./zoe-data-types.md#transferpart)**
 
-Returns a **TransferPart** when a reallocation only involves taking an 
-**[Allocation](./zoe-data-types.md#allocation)** from the **ZCFSeat** specified by *fromSeat*.
-**TransferParts** are used as part of the *transfer* argument of the 
-**[atomicRearrange()](#atomicrearrange-zcf-transfers)** function.
+Returns a **TransferPart** which only takes **fromAmounts** from *fromSeat*. **TransferParts** are used
+as part of the *transfer* argument of the **[atomicRearrange()](#atomicrearrange-zcf-transfers)**
+function.
 
 ## toOnly(toSeat, toAmounts)
 - **toSeat**: **[ZCFSeat](./zcfseat.md)**
 - **toAmounts**: **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)**
 - Returns: **[TransferPart](./zoe-data-types.md#transferpart)**
 
-Returns a **TransferPart** when a reallocation only involves giving an 
-**[Allocation](./zoe-data-types.md#allocation)** to the **ZCFSeat** specified by *toSeat*.
-**TransferParts** are used as part of the *transfer* argument of the 
-**[atomicRearrange()](#atomicrearrange-zcf-transfers)** function.
+Returns a **TransferPart** which only gives **toAmount** to *toSeat*. **TransferParts** are used as part
+of the *transfer* argument of the **[atomicRearrange()](#atomicrearrange-zcf-transfers)** function.
+
+## atomicTransfer(zcf, fromSeat, toSeat, fromAmounts, toAmounts?)
+- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)**
+- **fromSeat**: **[ZCFSeat](./zcfseat.md)** - Optional.
+- **toSeat**: **ZCFSeat** - Optional.
+- **fromAmounts**: **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)** - Optional.
+- **toAmounts**: **AmountKeywordRecord** - Optional, defaults to **fromAmounts**.
+- Returns: None.
+
+Asks Zoe to rearrange the **[Allocations](./zoe-data-types.md#allocation)** among the seats mentioned in
+*fromSeat* and *toSeat*. The reallocations must satisfy several constraints. If these constraints are all
+met, then the reallocation happens atomically. Otherwise an error is thrown and none of the proposed
+changes has any effect. The constraints are as follows.
+
+ * All the mentioned seats are still live.
+ * There aren't any outstanding stagings for any of the mentioned seats.
+
+	Stagings are a reallocation mechanism that has been
+    deprecated in favor of this **atomicRearrange()** function.
+    To prevent confusion, each reallocation can only be
+    expressed in the old way or the new way, but not a mixture.
+ * Overall conservation must be maintained. In other words, the reallocated
+    **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)** must balance out.
+ * Offer Safety is preserved for each seat. That means reallocations can only take assets from a seat
+	 as long as either it gets the assets described in the want section of its proposal, or it retains
+     all of the assets specified in the give section of the proposal. This constraint applies to each
+     seat across the entire atomicRearrangement, not to the individual **TransferParts**.
+
+When you don't specify *toAmounts*, it means that the *fromAmount* will be taken from *fromSeat* and
+given to *toSeat*.
 
 ## assertIssuerKeywords(zcf, expected)
 - **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)** 

--- a/main/reference/zoe-api/zoe-helpers.md
+++ b/main/reference/zoe-api/zoe-helpers.md
@@ -39,7 +39,7 @@ at all. The constraints are as follows.
     expressed in the old way or the new way, but not a mixture.
  * Overall conservation must be maintained. In other words, the reallocated
     **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)** must balance out to zero.
- *  Offer Safety is preserved for each seat. That means reallocations can only take assets from a seat
+ * Offer Safety is preserved for each seat. That means reallocations can only take assets from a seat
 	 as long as either it gets the assets described in the want section of its proposal, or it retains
      all of the assets specified in the give section of the proposal. This constraint applies to the
      entire atomicRearrangement, not to the individual **TransferParts**.
@@ -57,15 +57,26 @@ two of the possible 4 potential fields.
 - **toAmounts**: **AmountKeywordRecord** - Optional, defaults to **undefined**.
 - Returns: None.
 
-TBD
+Asks Zoe to rearrange the **[Allocations](./zoe-data-types.md#allocation)** among the seats
+mentioned in *fromSeat* and *toSeat*. The reallocations must satisfy
+several constraints. If these constraints are all met, then the
+reallocation happens atomically. Otherwise an error is thrown and it does not happen
+at all. The constraints are as follows.
 
-port const atomicTransfer = (
-  zcf,
-  fromSeat = undefined,
-  toSeat = undefined,
-  fromAmounts = undefined,
-  toAmounts = undefined,
-) => atomicRearrange(zcf, harden([[fromSeat, toSeat, fromAmounts, toAmounts]]));
+ * All the mentioned seats are still live.
+ * There aren't any outstanding stagings for any of the mentioned seats.
+ * Overall conservation must be maintained. In other words, the reallocated
+    **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)** must balance out to zero.
+ * Offer Safety is preserved for each seat. That means reallocations can only take assets from a seat
+	 as long as either it gets the assets described in the want section of its proposal, or it retains
+     all of the assets specified in the give section of the proposal.
+
+If a *fromSeat* is specified, then a *fromAmounts* is required. When you specify a *toSeat* without
+specifying a *toAmounts*, it means that the *fromAmount* will be taken from *fromSeat* and given to
+*toSeat*. If you don't include a *fromSeat*, *toSeat*, and/or
+*fromAmounts* argument, you'll need to set the missing arguments to **undefined**.
+(Note that if you don't
+include the *toAmounts* argument, there's no need to set it to **undefined**; you can simply omit it.)
 
 ## fromOnly(fromSeat, fromAmounts)
 - **fromSeat**: **[ZCFSeat](./zcfseat.md)**

--- a/main/reference/zoe-api/zoe-helpers.md
+++ b/main/reference/zoe-api/zoe-helpers.md
@@ -39,11 +39,33 @@ at all. The constraints are as follows.
     expressed in the old way or the new way, but not a mixture.
  * Overall conservation must be maintained. In other words, the reallocated
     **[Amounts](/reference/ertp-api/ertp-data-types.md#amount)** must balance out to zero.
+ *  Offer Safety is preserved for each seat. That means reallocations can only take assets from a seat
+	 as long as either it gets the assets described in the want section of its proposal, or it retains
+     all of the assets specified in the give section of the proposal. This constraint applies to the
+     entire atomicRearrangement, not to the individual **TransferParts**.
 
 Note that you can manually construct the **TransferParts** that make up the *transfers* array manually,
 or you can use the helper functions **[fromOnly()](#fromonly-fromseat-fromamounts)** or 
 **[toOnly()](#toonly-toseat-toamounts)** to create simple **TransferParts** that only contain 
 two of the possible 4 potential fields.
+
+## atomicTransfer(zcf, fromSeat?, toSeat?, fromAmounts?, toAmounts?)
+- **zcf**: **[ZoeContractFacet](./zoe-contract-facet.md)** 
+- **fromSeat**: **[ZCFSeat](./zcfseat.md)** - Optional, defaults to **undefined**.
+- **toSeat**: **ZCFSeat** - Optional, defaults to **undefined**.
+- **fromAmounts**: **[AmountKeywordRecord](./zoe-data-types.md#amountkeywordrecord)** - Optional, defaults to **undefined**.
+- **toAmounts**: **AmountKeywordRecord** - Optional, defaults to **undefined**.
+- Returns: None.
+
+TBD
+
+port const atomicTransfer = (
+  zcf,
+  fromSeat = undefined,
+  toSeat = undefined,
+  fromAmounts = undefined,
+  toAmounts = undefined,
+) => atomicRearrange(zcf, harden([[fromSeat, toSeat, fromAmounts, toAmounts]]));
 
 ## fromOnly(fromSeat, fromAmounts)
 - **fromSeat**: **[ZCFSeat](./zcfseat.md)**

--- a/main/reference/zoe-api/zoe.md
+++ b/main/reference/zoe-api/zoe.md
@@ -285,7 +285,7 @@ const { creatorFacet, publicFacet, creatorInvitation } = await E(Zoe).startInsta
 
 
 ## E(Zoe).offer(invitation, proposal?, paymentKeywordRecord?, offerArgs)
-- **invitation**: **[Invitation](./zoe-data-types.md#invitation)|Promise&lt;Invitation>**
+- **invitation**: **[Invitation](./zoe-data-types.md#invitation) | Promise&lt;Invitation>**
 - **proposal**: **Proposal** - Optional.
 - **paymentKeywordRecord**: **PaymentKeywordRecord** - Optional.
 - **offerArgs**: **Object**

--- a/main/reference/zoe-api/zoe.md
+++ b/main/reference/zoe-api/zoe.md
@@ -21,7 +21,7 @@ For more information about using **E**, see the [Agoric's JavaScript Distributed
 :::
 
 ## E(Zoe).getBrands(instance)
-- **instance** **[Instance](./zoe-data-types.md#instance)**
+- **instance**: **[Instance](./zoe-data-types.md#instance)**
 - Returns: **Promise&lt;BrandKeywordRecord>**
 
 Returns a **Promise** for a **BrandKeywordRecord** containing all **[Brands](/reference/ertp-api/brand.md)** defined in the *instance* argument.
@@ -44,7 +44,7 @@ const brandKeywordRecord = await E(Zoe).getBrands(instance);
 ```
 
 ## E(Zoe).getIssuers(instance)
-- **instance** **[Instance](./zoe-data-types.md#instance)**
+- **instance**: **[Instance](./zoe-data-types.md#instance)**
 - Returns: **Promise&lt;IssuerKeywordRecord>**
 
 Returns a **Promise** for an **IssuerKeywordRecord** containing all **[Issuers](/reference/ertp-api/issuer.md)** defined in the *instance* argument.
@@ -66,7 +66,7 @@ const issuerKeywordRecord = await E(Zoe).getIssuers(instance);
 ```
 
 ## E(Zoe).getTerms(instance)
-- **instance** **[Instance](./zoe-data-types.md#instance)**
+- **instance**: **[Instance](./zoe-data-types.md#instance)**
 - Returns: **Promise&lt;Object>**
 
 Returns a **Promise** for the terms of the *instance* argument, including its **[Brands](/reference/ertp-api/brand.md)**, **[Issuers](/reference/ertp-api/issuer.md)**, and any
@@ -88,7 +88,7 @@ const terms = await E(Zoe).getTerms(instance);
 ```
 
 ## E(Zoe).getPublicFacet(instance)
-- **instance** **[Instance](./zoe-data-types.md#instance)**
+- **instance**: **[Instance](./zoe-data-types.md#instance)**
 - Returns: **Promise&lt;PublicFacet>**
 
 Returns a **Promise** for the **PublicFacet** defined for the *instance* argument.
@@ -118,16 +118,16 @@ const { value: invitationValue } =
 ```
 
 ## E(Zoe).getInvitationDetails(invitation)
-- **invitation** **[Invitation](./zoe-data-types.md#invitation)**
+- **invitation**: **[Invitation](./zoe-data-types.md#invitation)**
 - Returns **Promise&lt;Object>**
 
 Takes an **Invitation** as an argument and returns a **Promise** for an object containing the following
 details about the **Invitation**:
 
-- **installation** **Installation**: The contract's Zoe installation.
-- **instance** **[Instance](./zoe-data-types.md#instance)**: The contract instance this invitation is for.
-- **invitationHandle** **[Handle](./zoe-data-types.md#handle)**: A **Handle** used to refer to this **Invitation**.
-- **description** **String**: Describes the purpose of this **Invitation**. Use it
+- **installation**: **Installation**: The contract's Zoe installation.
+- **instance**: **[Instance](./zoe-data-types.md#instance)**: The contract instance this invitation is for.
+- **invitationHandle**: **[Handle](./zoe-data-types.md#handle)**: A **Handle** used to refer to this **Invitation**.
+- **description**: **String**: Describes the purpose of this **Invitation**. Use it
    to match the invitation to the role it plays in the contract.
 
 ```js
@@ -136,7 +136,7 @@ const invitationValue = await E(Zoe).getInvitationDetails(invitation);
 ```
 
 ## E(Zoe).install(bundle)
-- **bundle** **SourceBundle**
+- **bundle**: **SourceBundle**
 - Returns: **Promise&lt;Installation>**
 
 Takes bundled source code for a Zoe contract as an argument and installs the code on Zoe.
@@ -161,13 +161,13 @@ Returns a **Promise** for the configuration settings for the Zoe contract.
 Returns a **Promise** for an **Issuer** whose associated **[Mint](/reference/ertp-api/mint.md)** can mint IST.
 
 ## E(Zoe).getOfferFilter(instance)
-- **instance** **[Instance](./zoe-data-types.md#instance)**
+- **instance**: **[Instance](./zoe-data-types.md#instance)**
 - Returns: **Array&lt;String>**
 
 Returns all the offer **[Keywords](./zoe-data-types.md#keyword)** that have been disabled, if any. Offer **Keywords** may be disabled if they prove problematic in some fashion, or to debug undesired behavior.
 
 ## E(Zoe).getInstance(invitation)
-- **invitation** **[Invitation](./zoe-data-types.md#invitation)**
+- **invitation**: **[Invitation](./zoe-data-types.md#invitation)**
 - Returns: **Promise&lt;[Instance](./zoe-data-types.md#instance)>**
 
 Returns a **Promise** for the contract **instance** the **Invitation** is part of.
@@ -185,13 +185,13 @@ const instance = await E(Zoe).getInstance(invitation);
 ```
 
 ## E(Zoe).getProposalShapeForInvitation(invitation) 
-- **invitation** **[Invitation](./zoe-data-types.md#invitation)**
+- **invitation**: **[Invitation](./zoe-data-types.md#invitation)**
 - Returns: **Promise&lt;Pattern>**
 
 Returns a **Promise** for the **Pattern** that the **Invitation's** **Proposal** adheres to.
 
 ## E(Zoe).getInstallation(invitation)
-- **invitation** **[Invitation](./zoe-data-types.md#invitation)**
+- **invitation**: **[Invitation](./zoe-data-types.md#invitation)**
 - Returns: **Promise&lt;Installation>**
 
 Returns a **Promise** for the contract **installation** the **Invitation**'s contract instance uses.
@@ -201,7 +201,7 @@ const installation = await E(Zoe).getInstallation(invitation);
 ```
 
 ## E(Zoe).getInstallationForInstance(instance)
-- **instance** **[Instance](./zoe-data-types.md#instance)**
+- **instance**: **[Instance](./zoe-data-types.md#instance)**
 - Returns **Promise&lt;Installation>**
 
 Returns a **Promise** for the contract **installation** used by the
@@ -215,10 +215,10 @@ const installation = await E(Zoe).getInstallationForInstance(instance);
 ```
 
 ## E(Zoe).startInstance(installation, issuerKeywordRecord?, terms?, privateArgs?)
-- **installation** **ERef&lt;Installation>**
-- **issuerKeywordRecord** **IssuerKeywordRecord** - Optional.
-- **terms** **Object** - Optional.
-- **privateArgs** **Object** - Optional.
+- **installation**: **ERef&lt;Installation>**
+- **issuerKeywordRecord**: **IssuerKeywordRecord** - Optional.
+- **terms**: **Object** - Optional.
+- **privateArgs**: **Object** - Optional.
 - Returns: **Promise&lt;StartInstanceResult>**
 
 Creates an instance of the installed smart contract specified by
@@ -245,11 +245,11 @@ among multiple contracts, pass in the following as **privateArgs**:
 
 It returns a **Promise** for a **StartInstanceResult** object. The object consists of:
 
-- **adminFacet** **AdminFacet**
-- **creatorFacet** **any**
-- **publicFacet** **any**
-- **instance** **Instance**
-- **creatorInvitation** **Payment | undefined**
+- **adminFacet**: **AdminFacet**
+- **creatorFacet**: **any**
+- **publicFacet**: **any**
+- **instance**: **Instance**
+- **creatorInvitation**: **Payment | undefined**
 
 The **adminFacet** has one method:
 - **getVatShutdownPromise()**    
@@ -285,10 +285,10 @@ const { creatorFacet, publicFacet, creatorInvitation } = await E(Zoe).startInsta
 
 
 ## E(Zoe).offer(invitation, proposal?, paymentKeywordRecord?, offerArgs)
-- **invitation** **[Invitation](./zoe-data-types.md#invitation)|Promise&lt;Invitation>**
-- **proposal** **Proposal** - Optional.
-- **paymentKeywordRecord** **PaymentKeywordRecord** - Optional.
-- **offerArgs** **Object**
+- **invitation**: **[Invitation](./zoe-data-types.md#invitation)|Promise&lt;Invitation>**
+- **proposal**: **Proposal** - Optional.
+- **paymentKeywordRecord**: **PaymentKeywordRecord** - Optional.
+- **offerArgs**: **Object**
 - Returns: **Promise&lt;[UserSeat](./user-seat.md)>**
 
 Used to make an offer to the contract that created the **Invitation** that is
@@ -353,13 +353,13 @@ before being used by the contract code since they are coming directly from the u
 have malicious behavior.
 
 ## E(Zoe).installBundleID(bundleId)
-- bundleId **BundleId**
+- bundleId: **BundleId**
 - Returns: **Promise&lt;Installation>**
 
 Reserved for future use.
 
 ## E(Zoe).getBundleIDFromInstallation(installation) 
-- **installation** **Installation**
+- **installation**: **Installation**
 - Returns: **Promise&lt;BundleId>**
 
 Reserved for future use.


### PR DESCRIPTION
Contains the updates relevant to the atomicRearrange() update of the Zoe API. Also contains formatting changes to the method declarations to make them more legible. (This is why the various ERTP topics were touched.)

Note: i omitted mentioning the atomicTransfer() function entirely, as it seemed superfluous & thus needlessly confusing. If you feel strongly about this omission, bounce the PR back to me & I'll add it.

