### PR TITLE
fix README -> getting started link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ and the Interchain Foundation](https://cosmos.network/ibc)
 
 
 * Want to run the full Agoric vm? You can [get started
-here](https://agoric.com/documentation/getting-started/#overview)
+right away](https://docs.agoric.com/guides/getting-started/)


### PR DESCRIPTION
and [avoid _here_ link](https://www.w3.org/QA/Tips/noClickHere)

fixes #849