### PR TITLE
test(snippets): permit Date "secure mode" exceptions

### DIFF
--- a/main/guides/js-programming/hardened-js.md
+++ b/main/guides/js-programming/hardened-js.md
@@ -254,11 +254,13 @@ calls for limiting globals to immutable data and deterministic functions
 (eliminating "ambient authority" in the diagram above).
 
 Hardened JavaScript includes a `Compartment` API for enforcing OCap discipline.
-Only the [standard, built-in objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects)
-such as `Object`, `Array`, and `Promise` are globally available by default
-(with an option for carefully controlled exceptions such as `console.log`).
-With the default `Compartment` options, the non-deterministic `Math.random`
-is not available and `Date.now()` always returns `NaN`.
+Only the [standard, built-in
+objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects)
+such as `Object`, `Array`, and `Promise` are globally available by default (with
+an option for carefully controlled exceptions such as `console.log`).  With the
+default `Compartment` options, the non-deterministic `Math.random` and
+`Date.now()` are not available.  (Earlier versions of Hardened JavaScript
+provided `Compartment` with a `Date.now()` that always returned `NaN`.)
 
 Almost all existing JS code was written to run under Node.js or inside a browser,
 so it's easy to conflate the environment features with JavaScript itself. For

--- a/snippets/test-hardened-js.js
+++ b/snippets/test-hardened-js.js
@@ -57,9 +57,15 @@ test('assign to frozen property fails', t => {
   );
 });
 
-test('Date.now() always returns NaN', t => {
+test('Date.now() is not available or returns NaN', t => {
   const c1 = new Compartment();
-  t.is(c1.evaluate(`Date.now()`), NaN);
+  try {
+    t.is(c1.evaluate(`Date.now()`), NaN, 'legacy Date.now() is NaN');
+  } catch (e) {
+    // New API: throws instead of NaN.
+    t.throws(() => c1.evaluate(`Date.now()`), { message: /^secure mode\b/ });
+    t.throws(() => c1.evaluate(`new Date()`), { message: /^secure mode\b/ });
+  }
 });
 
 test('Math.random is not available', t => {


### PR DESCRIPTION
Newer SES `Date.now()` and `new Date()` throw exceptions starting with `secure mode`.

This updates the snippets tests to tolerate both the new behaviour, and for compatibility, the old behaviour of `Date.now()` returning `NaN`.
