### PR TITLE
Added missing `cd` command

### DIFF
--- a/main/guides/getting-started/syncing-up.md
+++ b/main/guides/getting-started/syncing-up.md
@@ -93,8 +93,7 @@ produced a handful of blocks with the `agoric-upgrade-8` upgrade.
 
 The `agoric-upgrade-9` release requires Go version 1.18 or higher.
 
-1. `git clone https://github.com/agoric/agoric-sdk.git; agoric-sdk && git checkout tags/agoric-upgrade-9`
-1. `cd agoric-sdk`
+1. `git clone https://github.com/agoric/agoric-sdk.git; cd agoric-sdk && git checkout tags/agoric-upgrade-9`
 1. `yarn install && yarn build`
 1. `(cd packages/cosmic-swingset && make)`
 1. `agd start`

--- a/main/guides/getting-started/syncing-up.md
+++ b/main/guides/getting-started/syncing-up.md
@@ -94,6 +94,7 @@ produced a handful of blocks with the `agoric-upgrade-8` upgrade.
 The `agoric-upgrade-9` release requires Go version 1.18 or higher.
 
 1. `git clone https://github.com/agoric/agoric-sdk.git; agoric-sdk && git checkout tags/agoric-upgrade-9`
+1. `cd agoric-sdk`
 1. `yarn install && yarn build`
 1. `(cd packages/cosmic-swingset && make)`
 1. `agd start`


### PR DESCRIPTION
In agoric-upgrade-9 section:
Added:
`cd agoric-sdk`
After: 
`git clone https://github.com/agoric/agoric-sdk.git; agoric-sdk && git checkout tags/agoric-upgrade-9`