### PR TITLE
refine node LTS support wording

### DIFF
--- a/main/guides/getting-started/README.md
+++ b/main/guides/getting-started/README.md
@@ -68,7 +68,7 @@ go version # Version 1.20.3 or higher
 ## Install Node.js
 
 Download Node.js from [Node.js](https://nodejs.org/) and follow the instructions for your platform.
-We support Long Term Support (LTS) versions of node; currently, version 18.
+We support the Long Term Support (LTS) releases of Node, both [Active and Maintenance](https://nodejs.org/en/about/previous-releases). The "Current" release is likely to work but is not officially supported.
 
 ```shell
 node --version # LTS version such as 18.16.0

--- a/main/guides/getting-started/README.md
+++ b/main/guides/getting-started/README.md
@@ -68,7 +68,7 @@ go version # Version 1.20.3 or higher
 ## Install Node.js
 
 Download Node.js from [Node.js](https://nodejs.org/) and follow the instructions for your platform.
-We recommend installing the LTS version of node 18.
+We support Long Term Support (LTS) versions of node; currently, version 18.
 
 ```shell
 node --version # LTS version such as 18.16.0


### PR DESCRIPTION
It currently says "We recommend installing the LTS version of node 18" as if there are non-LTS versions of node 18 and as if we don't recommend v20 once it becomes LTS.

refs: #627