### PR TITLE
install from npm; smart-wallet / local chain only

### DIFF
--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -128,7 +128,10 @@ module.exports = {
           title: 'Agoric CLI',
           path: '/guides/agoric-cli/',
           collapsible: false,
-          children: ['/guides/agoric-cli/'],
+          children: [
+            '/guides/agoric-cli/',
+            '/guides/agoric-cli/agd-query-tx.html',
+          ],
         },
         {
           title: 'JavaScript Framework',

--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -122,7 +122,6 @@ module.exports = {
             '/guides/getting-started/start-a-project.html',
             '/guides/getting-started/contract-rpc.html',
             '/guides/getting-started/deploying.html',
-            '/guides/getting-started/syncing-up.html',
           ],
         },
         {

--- a/main/.vuepress/config.js
+++ b/main/.vuepress/config.js
@@ -119,7 +119,6 @@ module.exports = {
           collapsible: false,
           children: [
             '/guides/getting-started/',
-            '/guides/getting-started/start-a-project.html',
             '/guides/getting-started/contract-rpc.html',
             '/guides/getting-started/deploying.html',
           ],

--- a/main/guides/agoric-cli/README.md
+++ b/main/guides/agoric-cli/README.md
@@ -1,36 +1,72 @@
-# Agoric CLI Commands
+# Agoric CLI Reference
 
-In general, you'll want to issue the Agoric CLI (Command Line Interface) commands in this order:
+## agoric help
 
-1. `agoric init $projectDir`
-2. `cd $projectDir`
-3. `agoric install`
-4. `agoric start` (Usually with `--reset`)
-5. `agoric deploy`
-6. `agoric open`
+Displays the Agoric CLI commands and arguments with brief descriptions.
 
+**Usage**:
 
-## agoric init
+```sh
+agoric [command]
+```
+
+By default, lists all commands:
+
+```
+  cosmos <command...>                            client for an Agoric Cosmos chain
+  ibc-setup <command...>                         set up Inter Blockchain Communication
+  open [options]                                 launch the Agoric UI
+  init [options] <project>                       create a new Dapp directory named <project>
+  set-defaults [options] <program> <config-dir>  update the configuration files for <program> in <config-dir>
+  ibc-relayer                                    run an Inter Blockchain Communications relayer
+  install [force-sdk-version]                    install Dapp dependencies
+  follow [options] <path-spec...>                follow an Agoric Casting leader
+  run <script> [script-args...]                  run a script with all your user privileges and some Agoric endowments
+  deploy [options] [script...]                   run multiple scripts with all your user privileges against the local Agoric
+                                                 VM
+  publish [options] [bundle...]                  publish a bundle to a Cosmos chain
+  wallet [options]                               wallet commands
+  start [options] [profile] [args...]            start an Agoric VM
+  help [command]                                 display help for command
+```
+
+## agoric run
+
+Run a script with all your user privileges and some Agoric endowments.
+
+**Usage**:
+
+```sh
+agoric run [options] <script> [script-args...]
+```
+
+See also:
+
+- [`agoric run` supports bundling proposal modules with writeCoreProposal](https://github.com/Agoric/agoric-sdk/discussions/8087#discussioncomment-6534378) discussion [#8087](https://github.com/Agoric/agoric-sdk/discussions/8087) 2023-07
+
+## ~~agoric init~~
+
+_Deprecated in favor of [yarn create @agoric/dapp](../getting-started/#create-a-project-with-the-basic-starter-kit)_
 
 Creates a new dapp directory named `<project>` with contents copied from the `dapp-template` argument template.
 
-**Syntax**:
+**Usage**:
 
 ```
-agoric init <optional arguments> <projectName>
+agoric init [options] <project>
 ```
-* **projectName**: Name of the new project to initialize.
+
+- **projectName**: Name of the new project to initialize.
 
 **Optional arguments**:
 
-* **--dapp-template &lt;name>**: Use the template specified by `<name>`. If this argument isn't passed, then the default dapp `dapp-fungible-faucet` is used.
-* **--dapp-base &lt;base-url>**: The location where the dapp template can be found. If this argument isn't passed, then the default value of `git://github.com/Agoric/` is used.
-* **-V**, **--version**: Outputs the version number.
-* **--docker-tag &lt;tag>**: Uses the specified tag of any started Docker containers. Defaults to `latest`.
-* **--sdk**: Uses the Agoric SDK containing this program.
-* **-v**, **--verbose**: Causes the command to be run in verbose mode.
-* **-h**, **--help**: Displays help for the command.
-
+- **--dapp-template &lt;name>**: Use the template specified by `<name>`. If this argument isn't passed, then the default dapp `dapp-fungible-faucet` is used.
+- **--dapp-base &lt;base-url>**: The location where the dapp template can be found. If this argument isn't passed, then the default value of `git://github.com/Agoric/` is used.
+- **-V**, **--version**: Outputs the version number.
+- **--docker-tag &lt;tag>**: Uses the specified tag of any started Docker containers. Defaults to `latest`.
+- **--sdk**: Uses the Agoric SDK containing this program.
+- **-v**, **--verbose**: Causes the command to be run in verbose mode.
+- **-h**, **--help**: Displays help for the command.
 
 **Examples**:
 
@@ -38,22 +74,23 @@ agoric init <optional arguments> <projectName>
 agoric init demo
 ```
 
-Creates a directory named "demo" with contents copied from the default dapp-template *dapp-fungible-faucet*.
-
+Creates a directory named "demo" with contents copied from the default dapp-template _dapp-fungible-faucet_.
 
 ```
 agoric init my-first-contract --dapp-template dapp-simple-exchange
 ```
 
-Creates a directory named *my-first-contract* with contents copied from the dapp-template *dapp-simple-exchange*.
+Creates a directory named _my-first-contract_ with contents copied from the dapp-template _dapp-simple-exchange_.
 
 ```
 agoric init my-contract --dapp-template dapp-skeleton --dapp-base file:///home/contracts
 ```
 
-Creates a directory named *my-contract* with contents copied from a dapp-template named *dapp-skeleton* located under the URL *file:///home/contracts*.
+Creates a directory named _my-contract_ with contents copied from a dapp-template named _dapp-skeleton_ located under the URL _file:///home/contracts_.
 
-## agoric install
+## ~~agoric install~~
+
+_Deprecated_
 
 Installs dapp JavaScript dependencies. This may take a while. You use this instead of established npm install tools. The reason is that there is both an SDK (`--sdk`) and NPM mode. Currently we only support SDK mode, which allows you to link your dapp against the SDK dependencies. This allows you to modify any package in the SDK against the SDK dependencies (and see the changes) without having to register those packages with Yarn or NPM.
 
@@ -65,13 +102,30 @@ agoric install <optional arguments>
 
 **Optional arguments**:
 
-* **-V**, **--version**: Outputs the version number.
-* **--docker-tag &lt;tag>**: Uses the specified tag of any started Docker containers. Defaults to `latest`.
-* **--sdk**: Uses the Agoric SDK containing this program.
-* **-v**, **--verbose**: Causes the command to be run in verbose mode.
-* **-h**, **--help**: Displays help for the command.
+- **-V**, **--version**: Outputs the version number.
+- **--docker-tag &lt;tag>**: Uses the specified tag of any started Docker containers. Defaults to `latest`.
+- **--sdk**: Uses the Agoric SDK containing this program.
+- **-v**, **--verbose**: Causes the command to be run in verbose mode.
+- **-h**, **--help**: Displays help for the command.
 
-## agoric start
+## agoric start local-chain
+
+**Usage**:
+
+```
+agoric start local-chain [portNum] -- [initArgs] - local chain
+
+Options:
+  --reset                      clear all VM state before starting
+  --no-restart                 do not actually start the VM
+  --pull                       for Docker-based VM, pull the image before running
+  --rebuild                    rebuild VM dependencies before running
+  -h, --help                   display help for command
+```
+
+## ~~agoric start~~
+
+_Deprecated: Beta Feature_
 
 Runs an Agoric VM on which contracts can run.
 
@@ -83,17 +137,17 @@ agoric start <optional arguments>
 
 **Optional arguments**:
 
-* **profile**: Specifies the environment for the VM. Setting this argument to `testnet` connects the VM to our current testnet. If this argument isn't passed, then the default value of `dev` (representing the development mode) is used.
-* **--reset**: Clears all VM state before starting.
-* **--pull**: For Docker-based VMs, pulls the images before running.
-* **--delay [seconds]**: Accounts for processing time in the simulated chain by delaying each round-trip to it by the specified number of seconds. The default value is `1`, which lets you easily count the number of trips in your head. If this argument isn't passed, then the seconds of delay will be set from the numeric value of the FAKE_CHAIN_DELAY environment variable (or zero if there is no such variable).
-* **--inspect [host[:port]]**: Activates inspector on host:port. The default value is "127.0.0.1:9229".
-* **--inspect-brk [host[:port]]**: Activates inspector on host:port and breaks at start of script. The default value is "127.0.0.1:9229".
-* **-V**, **--version**: Outputs the version number.
-* **--docker-tag &lt;tag>**: Uses the specified tag of any started Docker containers. Defaults to `latest`.
-* **--sdk**: Uses the Agoric SDK containing this program.
-* **-v**, **--verbose**: Causes the command to be run in verbose mode.
-* **-h**, **--help**: Displays help for the command.
+- **profile**: Specifies the environment for the VM. Setting this argument to `testnet` connects the VM to our current testnet. If this argument isn't passed, then the default value of `dev` (representing the development mode) is used.
+- **--reset**: Clears all VM state before starting.
+- **--pull**: For Docker-based VMs, pulls the images before running.
+- **--delay [seconds]**: Accounts for processing time in the simulated chain by delaying each round-trip to it by the specified number of seconds. The default value is `1`, which lets you easily count the number of trips in your head. If this argument isn't passed, then the seconds of delay will be set from the numeric value of the FAKE_CHAIN_DELAY environment variable (or zero if there is no such variable).
+- **--inspect [host[:port]]**: Activates inspector on host:port. The default value is "127.0.0.1:9229".
+- **--inspect-brk [host[:port]]**: Activates inspector on host:port and breaks at start of script. The default value is "127.0.0.1:9229".
+- **-V**, **--version**: Outputs the version number.
+- **--docker-tag &lt;tag>**: Uses the specified tag of any started Docker containers. Defaults to `latest`.
+- **--sdk**: Uses the Agoric SDK containing this program.
+- **-v**, **--verbose**: Causes the command to be run in verbose mode.
+- **-h**, **--help**: Displays help for the command.
 
 **Examples**:
 
@@ -102,7 +156,6 @@ agoric start --reset
 ```
 
 Restarts the Agoric VM, clearing all existing state before doing so.
-
 
 ```
 agoric start --pull
@@ -116,10 +169,11 @@ agoric start --delay 5
 
 Configures a 5 second processing time for each round-trip to the simulated chain.
 
-## agoric deploy
+## ~~agoric deploy~~
+
+_Deprecated: Beta Feature_
 
 Runs one or more deployment scripts against the local Agoric VM. You may optionally specify which host and port to connect to the VM on.
-
 
 **Syntax**:
 
@@ -129,9 +183,8 @@ agoric deploy <optional arguments>
 
 **Optional arguments**:
 
-
 - **Positional Arguments**:
-  - `<script...>`: Deployment script(s) to run against the local Agoric instance. You must specify at least one, and may specify more than one. 
+  - `<script...>`: Deployment script(s) to run against the local Agoric instance. You must specify at least one, and may specify more than one.
 - **Options**:
   - `--hostport <HOST:PORT>`: Host and port on which to connect to the VM.
   - `-h`, `--help`: Display help for `deploy` command
@@ -142,20 +195,20 @@ agoric deploy <optional arguments>
 agoric init demo
 ```
 
-Creates a directory named "demo" with contents copied from the default dapp-template *dapp-fungible-faucet*.
-
+Creates a directory named "demo" with contents copied from the default dapp-template _dapp-fungible-faucet_.
 
 ```
 agoric init my-first-contract --dapp-template dapp-simple-exchange
 ```
 
-Creates a directory named *my-first-contract* with contents copied from the dapp-template *dapp-simple-exchange*.
+Creates a directory named _my-first-contract_ with contents copied from the dapp-template _dapp-simple-exchange_.
 
 ```
 agoric init my-contract --dapp-template dapp-skeleton --dapp-base file:///home/contracts
 ```
 
-Creates a directory named *my-contract* with contents copied from a dapp-template named *dapp-skeleton* located under the URL *file:///home/contracts*.
+Creates a directory named _my-contract_ with contents copied from a dapp-template named _dapp-skeleton_ located under the URL _file:///home/contracts_.
+
 - **Examples**:
   - Run the specified `deploy.js` scripts against the local Agoric VM.
     - `agoric deploy ./contract/deploy.js ./api/deploy.js`
@@ -163,7 +216,9 @@ Creates a directory named *my-contract* with contents copied from a dapp-templat
     port 99.
     - `agoric deploy --hostport 128.7.3.139:99 ./contract/deploy.js`
 
-## agoric open
+## ~~agoric open~~
+
+_Deprecated: Beta Feature_
 
 Launches the Agoric UI. By default, only the UI is shown, not the REPL (Read-Eval-Print-Loop). To show both the UI and REPL, or only the REPL, see the `--repl` optional argument below.
 
@@ -180,7 +235,7 @@ agoric open <optional arguments>
 - **Options**
   - `--hostport <host:port>`: Host and port on which to connect to the VM (default: "127.0.0.1:8000").
   - `--no-browser`: Display the UI's URL, but don't open a browser.
-  - `--repl [yes | only | no]`:  Whether to show the Read-Eval-Print loop. Defaults to `yes` if specified (see
+  - `--repl [yes | only | no]`: Whether to show the Read-Eval-Print loop. Defaults to `yes` if specified (see
     Examples below)
   - `-h`, `--help`: Display help for `open` command.
 
@@ -190,20 +245,20 @@ agoric open <optional arguments>
 agoric init demo
 ```
 
-Creates a directory named "demo" with contents copied from the default dapp-template *dapp-fungible-faucet*.
-
+Creates a directory named "demo" with contents copied from the default dapp-template _dapp-fungible-faucet_.
 
 ```
 agoric init my-first-contract --dapp-template dapp-simple-exchange
 ```
 
-Creates a directory named *my-first-contract* with contents copied from the dapp-template *dapp-simple-exchange*.
+Creates a directory named _my-first-contract_ with contents copied from the dapp-template _dapp-simple-exchange_.
 
 ```
 agoric init my-contract --dapp-template dapp-skeleton --dapp-base file:///home/contracts
 ```
 
-Creates a directory named *my-contract* with contents copied from a dapp-template named *dapp-skeleton* located under the URL *file:///home/contracts*.
+Creates a directory named _my-contract_ with contents copied from a dapp-template named _dapp-skeleton_ located under the URL _file:///home/contracts_.
+
 - **Examples**
   - Launch only the Agoric UI in a browser
     - `agoric open`
@@ -213,23 +268,3 @@ Creates a directory named *my-contract* with contents copied from a dapp-templat
     - `agoric open --repl only`
   - Display both the Agoric UI and the REPL in a browser (`--repl` defaults to `yes`).
     - `agoric open --repl`
-
-## agoric help
-
-Displays the Agoric CLI commands and arguments with brief descriptions.
-
-**Syntax**:
-
-```
-agoric help <optional arguments>
-```
-
-**Optional arguments**:
-
-* **-V**, **--version**: Outputs the version number.
-* **--docker-tag &lt;tag>**: Uses the specified tag of any started Docker containers. Defaults to `latest`.
-* **--sdk**: Uses the Agoric SDK containing this program.
-* **-v**, **--verbose**: Causes the command to be run in verbose mode.
-* **-h**, **--help**: Displays help for the command.
-
-

--- a/main/guides/agoric-cli/agd-query-tx.md
+++ b/main/guides/agoric-cli/agd-query-tx.md
@@ -1,0 +1,167 @@
+# Using `agd` to make queries and transactions
+
+`agd` is the Agoric Cosmos App, analagous to `simd` in the [Cosmos SDK](https://docs.cosmos.network/) simapp or `gaiad` in
+the Cosmos hub. Most of the `simd` [query commands](https://docs.cosmos.network/v0.46/core/cli.html#query-commands) and [transaction commands](https://docs.cosmos.network/v0.46/core/cli.html#transaction-commands) work similarly in `agd`.
+
+::: tip agd for Building Dapps
+
+This section focusses on commands relevant to developing and deploying smart contracts and dapps. See also:
+
+- [Validators topics \- Agoric Community Forum](https://community.agoric.com/c/validators/9)
+- [Governance topics \- Agoric Community Forum](https://community.agoric.com/c/governance/6)
+- [Delegator Guide \(CLI\) \| Cosmos Hub](https://hub.cosmos.network/main/delegators/delegator-guide-cli.html)
+
+:::
+
+::: tip Installing agd
+
+Options include:
+
+- Use the [basic dapp local chain](../getting-started/#start-a-local-agoric-blockchain) docker container: to run `agd status`, enter `yarn docker:bash` followed by `agd status`; or use `docker-compose exec agd agd status`.
+- Install from an [agoric-sdk release](https://github.com/Agoric/agoric-sdk/releases).
+
+:::
+
+If we invoke `agd` without arguments, it prints a list of available commands including:
+
+```
+Available Commands:
+
+  help                Help about any command
+  keys                Manage your application's keys
+  query               Querying subcommands
+  status              Query remote node for status
+  tx                  Transactions subcommands
+  version             Print the application binary version information
+
+Flags:
+  -h, --help                help for agd
+      --home string         directory for config and data (default $HOME)
+```
+
+## Query Commands
+
+In most cases, `agd query ...` is followed by a module name such as `bank`. An exception is `agd status`:
+
+### agd status
+
+Query remote node for status
+
+Example:
+
+```console
+$ agd status
+{"NodeInfo":{"protocol_version":{"p2p":"8","block":"11" ... }}}
+```
+
+The query goes to a local node at `tcp://localhost:26657` by default. To use another node:
+
+```console
+$ agd status --node https://devnet.rpc.agoric.net:443
+{"NodeInfo":{"protocol_version":{"p2p":"8","block":"11" ... }}}
+```
+
+::: tip Port is required
+
+Typically, `:443` can be left implicit in `https` URLs.
+But not here. Without it, we get:
+
+```
+Error: post failed: Post "https://devnet.rpc.agoric.net": dial tcp: address devnet.rpc.agoric.net: missing port in address
+```
+
+:::
+
+### agd query bank balances
+
+Query for account balances by address
+
+Example:
+
+```
+$ addr=agoric14pfrxg63jn6ha0cp6wxkm4nlvswtscrh2pymwm
+$ agd query bank balances $addr
+balances:
+- amount: "331000000"
+  denom: ubld
+- amount: "4854000000"
+  denom: uist
+```
+
+To get **JSON output** rather than YAML:
+
+```console
+$ agd query bank balances $addr -o json
+{"balances":[{"denom":"ubld","amount":"331000000"},{"denom":"uist","amount":"4854000000"}],...}
+```
+
+### agd query gov proposals
+
+Query for a all paginated proposals that match optional filters:
+
+Example:
+
+```
+$ agd query gov proposals --output json | \
+  jq -c '.proposals[] | [.proposal_id,.voting_end_time,.status]'
+["1","2023-11-14T17:32:16.665791640Z","PROPOSAL_STATUS_PASSED"]
+["2","2023-11-14T17:40:16.450879296Z","PROPOSAL_STATUS_PASSED"]
+["3","2023-11-14T17:44:37.432643476Z","PROPOSAL_STATUS_PASSED"]
+```
+
+## Transaction Commands
+
+Making transactions requires setting up an **account** with a private key for signing. The [basic dapp local chain](../getting-started/#start-a-local-agoric-blockchain) container has a number of keys set up for use with `--keyring-backend=test`. Use `agd keys list --keyring-backend=test` to see them.
+
+For accounts that control real negotiable assets, using
+a consumer grade wallet such as Keplr is more straightforward.
+_Consider a hardware wallet such as a Ledger as well._
+
+### agd tx bank send
+
+Send funds from one account to another.
+
+```
+$ src=agoric14pfrxg63jn6ha0cp6wxkm4nlvswtscrh2pymwm
+$ dest=agoric1a3zu5aqw255q0tuxzy9aftvgheekw2wedz3xwq
+$ amt=12000000ubld
+$ agd tx bank send $src $dest $amt \
+  --keyring-backend=test --chain-id=agoriclocal \
+		--gas=auto --gas-adjustment=1.2 \
+		--yes -b block
+```
+
+As usual, use `agd tx bank send --help` for documentation on
+flags such as `--yes`, `-b`, etc.
+
+### agd tx swingset install-bundle
+
+```
+agd tx swingset install-bundle --compress "@bundle1.json" \
+  --from user1 --keyring-backend=test --gas=auto \
+  --chain-id=agoriclocal -bblock --yes -o json
+```
+
+See also the [Agoric Gov Proposal Builder](https://cosgov.org/) web interface, especially for understanding storage fees.
+
+### agd tx gov submit-proposal swingset-core-eval
+
+Usage:
+
+```sh
+  agd tx gov submit-proposal swingset-core-eval [[permit.json] [code.js]]... [flags]
+```
+
+Example:
+
+```
+$ SCRIPT=start-game1.js
+$ PERMIT=start-game1-permit.json
+agd tx gov submit-proposal swingset-core-eval "$PERMIT" "$SCRIPT" \
+  --title="Start Game Place Contract" --description="Evaluate $SCRIPT" \
+  --deposit=10000000ubld --gas=auto --gas-adjustment=1.2 \
+  --from user1 --chain-id agoriclocal --keyring-backend=test \
+  --yes -b block
+```
+
+The [Agoric Gov Proposal Builder](https://cosgov.org/) web interface provides a nice interface for this as well.

--- a/main/guides/getting-started/README.md
+++ b/main/guides/getting-started/README.md
@@ -109,7 +109,7 @@ yarn install  # may take several minutes
 If you run into errors during install or build, make sure you have the relevant developer tools installed. For example, on Debian or Ubuntu Linux, you can run `sudo apt get install build-essential` to install these tools.
 
 Also, check that you are on a
-[supported platform](#platform-linux-shell-or-equivalent) and
+[supported platform](#platform-requirements) and
 not native Windows.
 :::
 
@@ -163,7 +163,7 @@ Let's deploy the contract:
 yarn start:contract
 ```
 
-This `start:contract` script will do a number of things that we will cover in more detail later:
+This `start:contract` script will do a number of things that we will cover in more detail later <small>(_[transaction commands](../agoric-cli/agd-query-tx.md#transaction-commands), [permissioned deployment](../coreeval/)_)</small>:
 
 1. Bundle the contract with `agoric run ...`
 2. Collect some ATOM with `agd tx bank send ...`.

--- a/main/guides/getting-started/README.md
+++ b/main/guides/getting-started/README.md
@@ -1,8 +1,20 @@
 # Starting a Basic Dapp
 
-Welcome! We'll start with a basic _dapp_; that is: a JavaScript contract and UI.
+Welcome! We'll start with a basic _dapp_; that is: a JavaScript contract and associated UI.
 
-But first, note that help is not far away:
+<img alt="Vite + React + Agoric page with Connect Wallet button"
+style="border: 1px solid" width="300"
+src="https://github.com/Agoric/documentation/assets/150986/36a87384-0148-4f9e-8606-e176bd7880b3" />
+
+```js
+/** @param {ZCF<{joinPrice: Amount}>} zcf */
+export const start = async zcf => {
+  const { joinPrice } = zcf.getTerms();
+...
+}
+```
+
+As we begin, note that help is not far away:
 
 ## Getting Support
 
@@ -11,6 +23,13 @@ But first, note that help is not far away:
 - Search and post [Q & A](https://github.com/Agoric/agoric-sdk/discussions/categories/q-a) in [agoric-sdk discussions](https://github.com/Agoric/agoric-sdk/discussions)
 
 ## Platform Requirements
+
+The Agoric SDK is supported on <a href="https://en.wikipedia.org/wiki/Linux">Linux</a>, <a href="https://www.apple.com/macos/">MacOS</a>, and <a href="https://docs.microsoft.com/en-us/windows/wsl/">Windows Subsystem for Linux (WSL)</a>.
+
+::: tip Mac Dev Tools
+On a Mac, be sure to install
+[Xcode](https://apps.apple.com/us/app/xcode/id497799835).
+:::
 
 We support any long-term support (LTS) versions of Node.js.
 Download and install from [Node.js](https://nodejs.org/) if you don't
@@ -27,16 +46,10 @@ corepack enable
 yarn --version # 1.x
 ```
 
-The Agoric SDK is supported on <a href="https://en.wikipedia.org/wiki/Linux">Linux</a>, <a href="https://www.apple.com/macos/">MacOS</a>, and <a href="https://docs.microsoft.com/en-us/windows/wsl/">Windows Subsystem for Linux (WSL)</a>.
+For this getting started exercise, you will need:
 
-::: tip Mac Dev Tools
-On a Mac, you must first install
-[Xcode](https://apps.apple.com/us/app/xcode/id497799835)
-:::
-
-We support running a local Agoric blockchain with [docker-compose](https://docs.docker.com/compose/).
-
-Our user interfaces integrate with the [keplr](https://www.keplr.app/) wallet.
+- [docker compose](https://docs.docker.com/compose/)
+- [Keplr wallet](https://www.keplr.app/) wallet.
 
 ## Create a project with the basic starter kit
 
@@ -77,9 +90,8 @@ Disregard these contents, for now:
 
 - **\_agstate**
 - **api**
-  :::
 
-      node_modules
+:::
 
 ## Install dependencies
 
@@ -116,84 +128,137 @@ The fist time you pull it may take several minutes.
 
 :::
 
-Look at the logs from the blockchain until it is steadily making blocks:
+Look at the logs from the blockchain:
 
 ```sh
 yarn docker:logs
 ```
 
-## Deploy the Contract and Start the UI
+After an initial flurry, when it is steadily making blocks, you should see:
 
-Let's start it up:
-
-```sh
-yarn start
+```
+agd_1  | 2023-12-05T20:52:42.933Z block-manager: block 956 begin
+agd_1  | 2023-12-05T20:52:42.936Z block-manager: block 956 commit
+agd_1  | 2023-12-05T20:52:43.944Z block-manager: block 957 begin
+agd_1  | 2023-12-05T20:52:43.946Z block-manager: block 957 commit
 ```
 
-::: tip TODO: integrated `yarn start` script
+Use control-C to stop viewing the logs and return to a shell prompt.
 
-For now, use the [Agoric Gov Proposal Builder](https://cosgov.org/)
-for deployment:
+::: tip Note: logs include benign error messages
 
-1. Make the contract and proposal bundles.
+You can disregard messages such as:
 
-```sh
-(cd contract; yarn build:proposal)
-```
+- `v5: TypeError: target has no method "getDisplayInfo"`
 
-Note the long `b1-xxx.json` bundle filenames
-as well as `start-game1-permit.json`
-and `start-game1.js`.
-
-2. Use the [Install Bundle](https://cosgov.org/?msgType=installBundle&network=local) tab to install the 2 bundles.
-   It will likely say **insufficient balance**.
-   To get enough IST:
-
-```sh
-yarn docker:make mint4k
-```
-
-2. Get ready to vote. To query the status of proposals, use
-
-```sh
-yarn docker:make gov-q
-```
-
-Then, don't execute this command, but get it ready:
-
-```sh
-yarn docker:make vote PROPOSAL=N
-```
-
-3. Use the [CoreEval Proposal](https://cosgov.org/?msgType=coreEvalProposal&network=local) tab to make a proposal to
-   start the contract using the permit and script.
-   Note the **10 second voting period**,
-   When you **Sign & Submit** the proposal, you can replace `N`
-   above with the proposal number that pops up.
-
-   To verify that the proposal executed correctly:
-
-```sh
-docker-compose logs | less -R
-```
-
-The logs should include some `console.log` output with no errors.
-
-**TODO: what console output exactly?**
-
-4. Start the UI
-
-```sh
-(cd ui; yarn dev)
-```
+These are artifacts of replaying historical events.
 
 :::
 
-Use `yarn docker:bash` to print account info, including `user1`.
-Add that account to keplr using its mnemonic.
+## Deploy the Contract
 
-Then hit **Connect Wallet**. The UI should show your address.
+Let's deploy the contract:
 
-Then **Make Offer**. Keplr should show an offer to **give** 0.25 IST
-and **want** a few places. Sign and broadcast the offer.
+```sh
+yarn start:contract
+```
+
+This `start:contract` script will do a number of things that we will cover in more detail later:
+
+1. Bundle the contract with `agoric run ...`
+2. Collect some ATOM with `agd tx bank send ...`.
+3. Use the ATOM to open a vault to mint enough IST to pay to install the bundles on chain with `agops vaults open ...`.
+4. Install the bundles on chain with `agd tx swingset install-bundle ...`.
+5. Collect enough BLD to pay for a governance deposit with `agd tx bank send ...`
+6. Make a governance proposal to start the contract with `agd tx gov submit-proposal swingset-core-eval ...`.
+7. Vote for the proposal; wait for it to pass.
+8. Print key material for an account you can use.
+
+## Set up Keplr wallet and import account
+
+Install the [Keplr Wallet](https://www.keplr.app/) if you have not done so already. Then copy the _mnemonic phrase_ printed at the end of the previous step; for example copy `congress` thru `switch` in the following:
+
+```
+Import the following mnemonic into Keplr:
+congress goose visual acid shine view pair fruit chaos boost cigar upgrade certain warrior color omit perfect clutch little bulb divorce split fashion switch
+
+The resulting address should be: agoric1a3zu5aqw255q0tuxzy9aftvgheekw2wedz3xwq
+```
+
+::: warning Keep your own mnemonic confidential!
+
+For any mnemonic phrase you use to secure your own assets, **take care to keep it strictly confidential!** The mnemonic here is only for testing.
+Using a **separate browser profile** is a good way to avoid accidentally
+using the wrong account when testing vs. with real assets.
+
+:::
+
+Import it into Keplr:
+
+1. Inside your Keplr wallet browser extension, press the ‘Accounts’ icon on the top right corner and then click the ‘Add Wallet button.
+
+<img width="800" src="https://assets-global.website-files.com/634f88fecbcc16e1f71b7e3c/635b7493ae1431bd476ce90e_Adding%20Accs.png" />
+
+2. Choose **Import an existing wallet**.
+
+3. Choose **Use recover phrase or private key**.
+
+4. Paste the mnemonic. Hit **Import**.
+
+<img width="800" src="https://assets-global.website-files.com/634f88fecbcc16e1f71b7e3c/6363571c7c3d77a25e1d9bbf_accs7.webp" />
+
+5. Enter a **Wallet Name** such as `user1`. Hit **Next**.
+
+6. On the **Select Chains** page, hit **Save** (_choice of chain does not matter at this point._)
+
+::: tip See also Keplr docs
+
+The figures above are from...
+
+- [Connect Additional Keplr Accounts](https://help.keplr.app/articles/how-to-connect-additional-keplr-accounts)
+- [Four Ways to Create a Keplr Account](https://help.keplr.app/articles/four-ways-to-create-a-keplr-account#:~:text=Import%20an%20Existing%20Account%20via%20Mnemonic%20Phrase)
+
+:::
+
+## Start the Dapp UI
+
+To start the Dapp UI:
+
+```sh
+yarn start:ui
+```
+
+The result includes a link:
+
+```
+  VITE v4.5.0  ready in 132 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+  ➜  press h to show help
+```
+
+Follow that link to get the Dapp UI:
+
+<img alt="Vite + React + Agoric page with Connect Wallet button"
+style="border: 1px solid"
+src="https://github.com/Agoric/documentation/assets/150986/36a87384-0148-4f9e-8606-e176bd7880b3" />
+
+Then hit **Connect Wallet**. The UI should show your address and your IST balance, after you approve an **Add Agoric local to Keplr** dialog.
+
+## Make an Offer
+
+Then hit **Make Offer**. Keplr should show an offer to **give** 0.25 IST
+and **want** a few places. Approve the offer to sign and broadcast it to the (local) blockchain.
+
+<img alt="Confirm Transaction with Give / Want offer details"
+style="border: 1px solid"
+src="https://github.com/Agoric/documentation/assets/150986/fd724782-9480-4acf-8e10-e0da5c780248" />
+
 After a few seconds, the UI should show the places.
+
+<img alt="Purses display updated with wanted Places"
+style="border: 1px solid"
+src="https://github.com/Agoric/documentation/assets/150986/64c0fe24-8238-4839-add8-5c1007722756" />
+
+Congratulations! You are on your way to building dapps on Agoric.

--- a/main/guides/getting-started/README.md
+++ b/main/guides/getting-started/README.md
@@ -26,11 +26,6 @@ As we begin, note that help is not far away:
 
 The Agoric SDK is supported on <a href="https://en.wikipedia.org/wiki/Linux">Linux</a>, <a href="https://www.apple.com/macos/">MacOS</a>, and <a href="https://docs.microsoft.com/en-us/windows/wsl/">Windows Subsystem for Linux (WSL)</a>.
 
-::: tip Mac Dev Tools
-On a Mac, be sure to install
-[Xcode](https://apps.apple.com/us/app/xcode/id497799835).
-:::
-
 We support any long-term support (LTS) versions of Node.js.
 Download and install from [Node.js](https://nodejs.org/) if you don't
 already have `node`. Check to make sure:
@@ -38,6 +33,26 @@ already have `node`. Check to make sure:
 ```shell
 node --version # LTS version such as 18.16.0
 ```
+
+::: details Troubleshooting Symbol.dispose error from node v18.19.0
+
+Node v18.19.0 has a breadking change that results in...
+
+```
+Removing intrinsics.Symbol.dispose
+failed to delete intrinsics.Symbol.dispose (TypeError#1)
+TypeError#1: Cannot delete property 'dispose' of function Symbol() { [native code] }
+```
+
+This is a known issue, but updating this app with the fix may take some
+time. Meanwhile, please downgrade node to an earlier version.
+
+For reference:
+
+- [Node 18\.19 breaks release\-mainnet1B branch · agoric\-sdk \#8599](https://github.com/Agoric/agoric-sdk/issues/8599)
+- [feat\(ses\): tame Symbol so whitelist works by erights · endojs \#1579](https://github.com/endojs/endo/pull/1579)
+
+:::
 
 We use the `yarn` package manager. [Installing with corepack](https://yarnpkg.com/corepack) is what the `yarn` maintainers recommend:
 
@@ -49,7 +64,7 @@ yarn --version # 1.x
 For this getting started exercise, you will need:
 
 - [docker compose](https://docs.docker.com/compose/)
-- [Keplr wallet](https://www.keplr.app/) wallet.
+- [Keplr wallet](https://www.keplr.app/)
 
 ## Create a project with the basic starter kit
 
@@ -84,7 +99,7 @@ The `demo` directory now has:
 - **ui/** - web UI
 - **docker-compose.yml** - for running a local Agoric blockchain
 
-::: tip TODO: prune api, agstate
+::: details TODO: prune api, agstate
 
 Disregard these contents, for now:
 
@@ -104,18 +119,21 @@ cd demo
 yarn install  # may take several minutes
 ```
 
-::: tip Troubleshooting `yarn install`
+::: details Troubleshooting yarn install
 
-If you run into errors during install or build, make sure you have the relevant developer tools installed. For example, on Debian or Ubuntu Linux, you can run `sudo apt get install build-essential` to install these tools.
-
-Also, check that you are on a
-[supported platform](#platform-requirements) and
+If you run into errors during `yarn install`,
+check that you are on a [supported platform](#platform-requirements) and
 not native Windows.
+
+Then make sure you have the relevant developer tools installed. For example, on Debian or Ubuntu Linux, run `sudo apt get install build-essential`.
+On MacOS, be install
+[Xcode](https://apps.apple.com/us/app/xcode/id497799835).
+
 :::
 
 ## Start a local Agoric blockchain
 
-To run a local Agoric blockchain with [docker-compose](https://docs.docker.com/compose/):
+To run a local Agoric blockchain with [docker compose](https://docs.docker.com/compose/):
 
 ```sh
 yarn start:docker
@@ -145,7 +163,7 @@ agd_1  | 2023-12-05T20:52:43.946Z block-manager: block 957 commit
 
 Use control-C to stop viewing the logs and return to a shell prompt.
 
-::: tip Note: logs include benign error messages
+::: details Note: logs include benign error messages
 
 You can disregard messages such as:
 
@@ -176,7 +194,16 @@ This `start:contract` script will do a number of things that we will cover in mo
 
 ## Set up Keplr wallet and import account
 
-Install the [Keplr Wallet](https://www.keplr.app/) if you have not done so already. Then copy the _mnemonic phrase_ printed at the end of the previous step; for example copy `congress` thru `switch` in the following:
+::: warning Keep your own mnemonic seed phrase confidential!
+
+For any mnemonic phrase you use to secure your own assets, **take care to keep it strictly confidential!** The mnemonic here is only for testing.
+Using a **separate browser profile** is a good way to avoid accidentally
+using the wrong account when testing vs. with real assets.
+
+:::
+
+Install the [Keplr Wallet](https://www.keplr.app/) if you have not done so already. Then copy the _mnemonic phrase_ printed at the end of the previous step
+and use it to add an account. For example copy `congress` thru `switch` in the following:
 
 ```
 Import the following mnemonic into Keplr:
@@ -185,15 +212,7 @@ congress goose visual acid shine view pair fruit chaos boost cigar upgrade certa
 The resulting address should be: agoric1a3zu5aqw255q0tuxzy9aftvgheekw2wedz3xwq
 ```
 
-::: warning Keep your own mnemonic confidential!
-
-For any mnemonic phrase you use to secure your own assets, **take care to keep it strictly confidential!** The mnemonic here is only for testing.
-Using a **separate browser profile** is a good way to avoid accidentally
-using the wrong account when testing vs. with real assets.
-
-:::
-
-Import it into Keplr:
+::: details How to import mnemonic to add a Keplr wallet
 
 1. Inside your Keplr wallet browser extension, press the ‘Accounts’ icon on the top right corner and then click the ‘Add Wallet button.
 
@@ -211,9 +230,7 @@ Import it into Keplr:
 
 6. On the **Select Chains** page, hit **Save** (_choice of chain does not matter at this point._)
 
-::: tip See also Keplr docs
-
-The figures above are from...
+See also:
 
 - [Connect Additional Keplr Accounts](https://help.keplr.app/articles/how-to-connect-additional-keplr-accounts)
 - [Four Ways to Create a Keplr Account](https://help.keplr.app/articles/four-ways-to-create-a-keplr-account#:~:text=Import%20an%20Existing%20Account%20via%20Mnemonic%20Phrase)
@@ -253,12 +270,12 @@ and **want** a few places. Approve the offer to sign and broadcast it to the (lo
 
 <img alt="Confirm Transaction with Give / Want offer details"
 style="border: 1px solid"
-src="https://github.com/Agoric/documentation/assets/150986/fd724782-9480-4acf-8e10-e0da5c780248" />
+src="https://github.com/Agoric/documentation/assets/150986/fa2cec17-2ed4-465b-9394-f7c115b1cefe" />
 
 After a few seconds, the UI should show the places.
 
 <img alt="Purses display updated with wanted Places"
 style="border: 1px solid"
-src="https://github.com/Agoric/documentation/assets/150986/64c0fe24-8238-4839-add8-5c1007722756" />
+src="https://github.com/Agoric/documentation/assets/150986/11dbc9a7-253a-4b8f-8ca5-2c3a1efed123" />
 
 Congratulations! You are on your way to building dapps on Agoric.

--- a/main/guides/getting-started/README.md
+++ b/main/guides/getting-started/README.md
@@ -1,9 +1,8 @@
-# Installing the Agoric SDK
+# Starting a Basic Dapp
 
-To write JavaScript smart contracts using the Agoric Zoe framework, first install the Agoric Software
-Development Kit (SDK).
+Welcome! We'll start with a basic _dapp_; that is: a JavaScript contract and UI.
 
-After installing the Agoric SDK, you can proceed to [starting a project](./start-a-project.md).
+But first, note that help is not far away:
 
 ## Getting Support
 
@@ -11,153 +10,190 @@ After installing the Agoric SDK, you can proceed to [starting a project](./start
 - Join weekly [Office Hours](https://github.com/Agoric/agoric-sdk/wiki/Office-Hours)
 - Search and post [Q & A](https://github.com/Agoric/agoric-sdk/discussions/categories/q-a) in [agoric-sdk discussions](https://github.com/Agoric/agoric-sdk/discussions)
 
-## Quick Start
+## Platform Requirements
 
-If you're on a [supported platform](#platform-linux-shell-or-equivalent) (MacOS, Linux, or WSL) and you're familar with JavaScript development tools such as `node`, `yarn`, and `git`:
+We support any long-term support (LTS) versions of Node.js.
+Download and install from [Node.js](https://nodejs.org/) if you don't
+already have `node`. Check to make sure:
 
 ```shell
-go version # Version 1.20.3 or higher
 node --version # LTS version such as 18.16.0
-npm install --global yarn # Install yarn for package management
-git clone --branch community-dev https://github.com/Agoric/agoric-sdk # Clone the "community-dev" branch
-cd agoric-sdk
-yarn install # Asks yarn to install all the dependant node packages
-yarn build # Builds the agoric-sdk packages
-(cd packages/cosmic-swingset && make) # Builds the cosmic-swingset package
-yarn link-cli ~/bin/agoric # Creates an executable script
-agoric --version # Prints the version number of the SDK
 ```
 
-Now you are ready proceed to [starting a project](./start-a-project.md).
+We use the `yarn` package manager. [Installing with corepack](https://yarnpkg.com/corepack) is what the `yarn` maintainers recommend:
 
-_If you get "command not found", see [troubleshooting below](#install-agoric-cli)._
-
-::: tip Watch: Prepare Your Agoric Environment (November 2020)
-This presentation is a good overview of the Agoric SDK setup process,
-though a few details are out of date:
-
-- node version: 12.x is too old; use the LTS version 18.16.0 or a later LTS version
-- skip `git checkout hackathon-2020-11`; use the `community-dev` branch
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/w0By22jYhJA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-**Note:** Video omits adding the Agoric SDK to your PATH.
-:::
-
-## Platform: Linux Shell or Equivalent
+```sh
+corepack enable
+yarn --version # 1.x
+```
 
 The Agoric SDK is supported on <a href="https://en.wikipedia.org/wiki/Linux">Linux</a>, <a href="https://www.apple.com/macos/">MacOS</a>, and <a href="https://docs.microsoft.com/en-us/windows/wsl/">Windows Subsystem for Linux (WSL)</a>.
-
-- To open a terminal on MacOS, see **Applications>Utilities>terminal** in the **Finder**.
-- To launch a terminal on Linux, use the **Terminal** application.
-- To access WSL from Windows, visit the [WSL documentation](https://docs.microsoft.com/en-us/windows/wsl/).
 
 ::: tip Mac Dev Tools
 On a Mac, you must first install
 [Xcode](https://apps.apple.com/us/app/xcode/id497799835)
 :::
 
-## Install Go
+We support running a local Agoric blockchain with [docker-compose](https://docs.docker.com/compose/).
 
-Download Go from [go.dev/doc/install](https://go.dev/doc/install) and follow the instructions for your platform.
+Our user interfaces integrate with the [keplr](https://www.keplr.app/) wallet.
 
-```shell
-go version # Version 1.20.3 or higher
+## Create a project with the basic starter kit
+
+Choose a name such as `demo` and then:
+
+```sh
+yarn create @agoric/dapp demo
 ```
 
-## Install Node.js
+::: tip TODO: make dapp-game-places the default
 
-Download Node.js from [Node.js](https://nodejs.org/) and follow the instructions for your platform.
-We recommend installing the LTS version of node 18.
+Until `dapp-game-places` is the default, use `--dapp-base` etc.
+to refer to it:
 
-```shell
-node --version # LTS version such as 18.16.0
+```sh
+yarn create @agoric/dapp \
+  --dapp-base https://github.com/agoric-labs/ \
+  --dapp-template dapp-game-places \
+  demo
+
 ```
 
-**Note:** Agoric will support all long-term support (LTS) versions of Node.js. 
+:::
 
-## Install the Yarn Package Manager
+### Project structure
 
-Follow [Yarn Installation](https://classic.yarnpkg.com/en/docs/install)
-instructions. For example:
+The `demo` directory now has:
 
-```shell
-npm install --global yarn
-yarn --version # 1.22.10 or higher
-```
+- **README.md**
+- **package.json** as usual for a JavaScript project, along with **yarn.lock**
+- **contract/** - smart contract source code, tests, etc.
+- **ui/** - web UI
+- **docker-compose.yml** - for running a local Agoric blockchain
 
-## Install Git
+::: tip TODO: prune api, agstate
 
-Follow [Git installation instructions](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) or use your platform's package manager.
+Disregard these contents, for now:
 
-```shell
-npm install --global git
-git --version # 2.25.0 or higher
-```
-
-## Clone the Agoric SDK
-
-```shell
-git clone --branch community-dev https://github.com/Agoric/agoric-sdk
-cd agoric-sdk
-```
-
-Cloning and installing the Agoric SDK can take a while. Please be patient.
-
-## Install NPM Dependencies
-
-```shell
-yarn install
-```
-
-**Note:** If you run into errors during install or build, make sure you have the relevant developer tools installed. For example, on Debian or Ubuntu Linux, you can run `sudo apt get install build-essential` to install these tools.
-
-## Build Packages
-
-```shell
-yarn build
-```
-
-**Note:** If this `yarn build` step fails, check that you are on a
-[supported platform](#platform-linux-shell-or-equivalent) and
-not native Windows.
-
-## Build the Cosmic Swingset Package
-
-```shell
-(cd packages/cosmic-swingset && make)
-```
-
-## Install Agoric CLI
-
-Use `yarn link-cli` to install the Agoric CLI (Command Line Interface) in a convenient place of your choosing such as:
-
-```shell
-yarn link-cli ~/bin/agoric
-```
-
-or:
-
-```shell
-sudo yarn link-cli /usr/local/bin/agoric
-```
-
-**Note:** Run `echo $PATH` to see directories in your current path, separated by colons. These are good candidates for where to have `yarn link-cli` place the executable.
-
-::: tip Troubleshooting "command not found"
-Watch:
-
-- [Linux add to \$PATH: Fix "command not found" error (Linux & Mac)](https://www.youtube.com/watch?v=gkqsLRDnqlA) 6:19 Mar 2018.
+- **\_agstate**
+- **api**
   :::
 
-## Check the Agoric Version
+      node_modules
 
-To check that it's installed correctly:
+## Install dependencies
 
-```shell
-agoric --version # v0.18.2 "community-dev" branch
+The UI depends on the React framework, and the contract depends on
+the Agoric framework. The packages in this project also have
+development dependencies for testing, code formatting, and static analysis.
+
+```sh
+cd demo
+yarn install  # may take several minutes
 ```
 
-If the install was successful, you are ready to proceed to [starting a project](./start-a-project.md).
+::: tip Troubleshooting `yarn install`
 
+If you run into errors during install or build, make sure you have the relevant developer tools installed. For example, on Debian or Ubuntu Linux, you can run `sudo apt get install build-essential` to install these tools.
 
+Also, check that you are on a
+[supported platform](#platform-linux-shell-or-equivalent) and
+not native Windows.
+:::
+
+## Start a local Agoric blockchain
+
+To run a local Agoric blockchain with [docker-compose](https://docs.docker.com/compose/):
+
+```sh
+yarn start:docker
+```
+
+::: tip Note: large docker image
+
+The docker image used here is several gigabytes.
+The fist time you pull it may take several minutes.
+
+:::
+
+Look at the logs from the blockchain until it is steadily making blocks:
+
+```sh
+yarn docker:logs
+```
+
+## Deploy the Contract and Start the UI
+
+Let's start it up:
+
+```sh
+yarn start
+```
+
+::: tip TODO: integrated `yarn start` script
+
+For now, use the [Agoric Gov Proposal Builder](https://cosgov.org/)
+for deployment:
+
+1. Make the contract and proposal bundles.
+
+```sh
+(cd contract; yarn build:proposal)
+```
+
+Note the long `b1-xxx.json` bundle filenames
+as well as `start-game1-permit.json`
+and `start-game1.js`.
+
+2. Use the [Install Bundle](https://cosgov.org/?msgType=installBundle&network=local) tab to install the 2 bundles.
+   It will likely say **insufficient balance**.
+   To get enough IST:
+
+```sh
+yarn docker:make mint4k
+```
+
+2. Get ready to vote. To query the status of proposals, use
+
+```sh
+yarn docker:make gov-q
+```
+
+Then, don't execute this command, but get it ready:
+
+```sh
+yarn docker:make vote PROPOSAL=N
+```
+
+3. Use the [CoreEval Proposal](https://cosgov.org/?msgType=coreEvalProposal&network=local) tab to make a proposal to
+   start the contract using the permit and script.
+   Note the **10 second voting period**,
+   When you **Sign & Submit** the proposal, you can replace `N`
+   above with the proposal number that pops up.
+
+   To verify that the proposal executed correctly:
+
+```sh
+docker-compose logs | less -R
+```
+
+The logs should include some `console.log` output with no errors.
+
+**TODO: what console output exactly?**
+
+4. Start the UI
+
+```sh
+(cd ui; yarn dev)
+```
+
+:::
+
+Use `yarn docker:bash` to print account info, including `user1`.
+Add that account to keplr using its mnemonic.
+
+Then hit **Connect Wallet**. The UI should show your address.
+
+Then **Make Offer**. Keplr should show an offer to **give** 0.25 IST
+and **want** a few places. Sign and broadcast the offer.
+After a few seconds, the UI should show the places.

--- a/snippets/zoe/contracts/test-zoe-hello.js
+++ b/snippets/zoe/contracts/test-zoe-hello.js
@@ -1,0 +1,32 @@
+// TODO: convince prettier that harden() is a global
+/* global harden */
+
+import '@endo/init';
+import { E } from '@endo/far';
+import test from 'ava';
+import { start as startHello } from '../src/01-hello.js';
+import { start as startState } from '../src/02-state.js';
+import { start as startAccess } from '../src/03-access.js';
+
+const mockZcf = harden({});
+
+test('contract greet greets by name', async t => {
+  const { publicFacet } = startHello(mockZcf);
+  const actual = await E(publicFacet).greet('Bob');
+  t.is(actual, 'Hello, Bob!');
+});
+
+test('state', async t => {
+  const { publicFacet } = startState(mockZcf);
+  t.is(await E(publicFacet).get(), 'Hello, World!');
+  await E(publicFacet).set(2);
+  t.is(await E(publicFacet).get(), 2);
+});
+
+test('access', async t => {
+  const { publicFacet, creatorFacet } = startAccess(mockZcf);
+  t.is(await E(publicFacet).get(), 'Hello, World!');
+  await t.throwsAsync(E(publicFacet).set(2), { message: /no method/ });
+  await E(creatorFacet).set(2);
+  t.is(await E(publicFacet).get(), 2);
+});

--- a/snippets/zoe/src/01-hello.js
+++ b/snippets/zoe/src/01-hello.js
@@ -1,0 +1,16 @@
+import { Far } from '@endo/far';
+
+// A Zoe contract is a module that exports a start function
+// that defines the contract's API.
+export const start = _z => {
+  // publicFacet provides public API methods
+  // Mark it Far() to allow callers from outside the contract
+  // and give it a suggestive interface name for debugging.
+  const publicFacet = Far('Hello', {
+    greet: who => {
+      return `Hello, ${who}!`;
+    },
+  });
+
+  return { publicFacet };
+};

--- a/snippets/zoe/src/02-state.js
+++ b/snippets/zoe/src/02-state.js
@@ -1,0 +1,16 @@
+import { Far } from '@endo/far';
+
+export const start = _z => {
+  // Contracts can use ordinary variables for state
+  // that lasts between transactions.
+  let value = 'Hello, World!';
+  const publicFacet = Far('ValueCell', {
+    get: () => value,
+    set: v => (value = v),
+  });
+
+  return { publicFacet };
+};
+
+// p.s. Fits in a tweet!
+// https://twitter.com/DeanTribble/status/1433268983977820161

--- a/snippets/zoe/src/03-access.js
+++ b/snippets/zoe/src/03-access.js
@@ -1,0 +1,20 @@
+import { Far } from '@endo/far';
+
+export const start = _z => {
+  let value = 'Hello, World!';
+
+  // We can limit the public API to read-only
+  // by omitting the set() method
+  const publicFacet = Far('ValueView', {
+    get: () => value,
+  });
+
+  // The creatorFacet is provided only to the
+  // caller of E(zoe).startInstance()
+  const creatorFacet = Far('ValueCell', {
+    get: () => value,
+    set: v => (value = v),
+  });
+
+  return { publicFacet, creatorFacet };
+};


### PR DESCRIPTION
 - consolidates the whole page of details on installing the SDK from a `git clone` to one `yarn create @agoric/dapp demo` to install from npm packages
 - replaces `ag-solo` style initial dapp (card store) with smart-wallet style game piece dapp running on a local chain in a docker container

refs #894, #726

rendered:

 - [x] [getting started](https://dc-npm-only.documentation-7tp.pages.dev/guides/getting-started/)

builds on:

 - https://github.com/Agoric/agoric-sdk/pull/8530
    - https://github.com/Agoric/agoric-sdk/issues/3857
    - https://github.com/Agoric/agoric-sdk/issues/8380
 - https://github.com/Agoric/agoric-3-proposals/issues/6
 - https://github.com/agoric-labs/dapp-game-places/issues/5

related follow-on work:

 - #893 
 - https://github.com/Agoric/agoric-sdk/pull/8537
 - #889