### PR TITLE
feat: Improve the jump-to-fragment fixup for non-heading targets

### DIFF
--- a/main/.vuepress/styles/index.styl
+++ b/main/.vuepress/styles/index.styl
@@ -70,6 +70,10 @@
   }
 }
 
+:root.scrollingToTarget {
+  scroll-padding-top: $navbarHeight;
+}
+
 .ag-btn
   background-color $accentColor
   color $white


### PR DESCRIPTION
Router logic was swallowing history entries and not scrolling far enough for such targets[^1] to clear the fixed header.

[^1]: which do not currently exist but are being added, cf. https://github.com/Agoric/documentation/pull/876#discussion_r1409657230