### PR TITLE
docs(getting-started): note major steps in `start:contract`

### DIFF
--- a/main/guides/getting-started/README.md
+++ b/main/guides/getting-started/README.md
@@ -222,6 +222,18 @@ Use control-C to exit the logs, then start the smart contract. Starting the cont
 yarn start:contract
 ```
 
+This `start:contract` script will do a number of things that we will cover in more detail later <small>(_[transaction commands](../agoric-cli/agd-query-tx.md#transaction-commands), [permissioned deployment](../coreeval/)_)</small>:
+
+1. Bundle the contract with `agoric run ...`
+2. Collect some ATOM with `agd tx bank send ...`.
+3. Use the ATOM to open a vault to mint enough IST to pay to install the bundles on chain with `agops vaults open ...`.
+4. Install the bundles on chain with `agd tx swingset install-bundle ...`.
+5. Collect enough BLD to pay for a governance deposit with `agd tx bank send ...`
+6. Make a governance proposal to start the contract with `agd tx gov submit-proposal swingset-core-eval ...`.
+7. Vote for the proposal; wait for it to pass.
+
+While it's doing all that...
+
 ## Installing Keplr Wallet
 Next, you'll install the Keplr wallet plug-in. Open up your browser and navigate to [https://www.keplr.app/download](https://www.keplr.app/download). Select the version appropriate to your browser. 
 


### PR DESCRIPTION
@kbennett2000 does this seem more useful or distracting?

 - [rendered](https://dc-start-contract-steps.documentation-7tp.pages.dev/guides/getting-started/#starting-the-dapp-smart-contract)

Not urgent / important. But it's a blurb I wrote at one point and I'd like you to take a look before I discard it.