### PR TITLE
Redirect getting-started to new URL

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -31,3 +31,4 @@
 /zoe/api/ /reference/zoe-api/ 
 /zoe/api/zoe.html /reference/zoe-api/zoe.html 
 /getting-started/beta.html /guides/getting-started/ 
+/getting-started/ /guides/getting-started/


### PR DESCRIPTION
I found the old URL being used at random places on the internet. Redirecting to new location.
Ref: https://v1.cosmos.network/tools