### PR TITLE
feat: make chain-integration > cosmos-sdk links clickable

### DIFF
--- a/main/guides/integration/chain-integration.md
+++ b/main/guides/integration/chain-integration.md
@@ -36,15 +36,15 @@ agd version --long
 # FAQ
 
 - How are transactions encoded?
-https://docs.cosmos.network/v0.45/core/encoding.html
+[Cosmos SDK v0.45 Docs - Encoding](https://docs.cosmos.network/v0.45/core/encoding.html)
 - What data is needed to create a transaction (last block hash, nonce, sender public key, etc.)?
-https://docs.cosmos.network/v0.45/core/transactions.html#transaction-generation
+[Cosmos SDK v0.45 Docs - Transaction Generation](https://docs.cosmos.network/v0.45/core/transactions.html#transaction-generation)
 - What data is signed and how is that data obtained (for example truncated SHA256 of transaction data)?
-https://docs.cosmos.network/v0.45/core/transactions.html#transaction-generation
+[Cosmos SDK v0.45 Docs - Transaction Generation](https://docs.cosmos.network/v0.45/core/transactions.html#transaction-generation)
 - Do transactions expire?
-Transaction do not expire unless you specify --timeout-height: https://docs.cosmos.network/v0.45/core/transactions.html#transaction-generation
+Transaction do not expire unless you specify --timeout-height: [Cosmos SDK v0.45 Docs - Transaction Generation](https://docs.cosmos.network/v0.45/core/transactions.html#transaction-generation)
 However they do have a sequence number and may be invalidated if another transaction with the same sequence number is processed by the chain
 - How are addresses generated?
-https://docs.cosmos.network/v0.45/basics/accounts.html
+[Cosmos SDK v0.45 Docs - Accounts](https://docs.cosmos.network/v0.45/basics/accounts.html)
 - How is the blockchain queried?
-JSON-RPC, gRPC, REST  https://docs.cosmos.network/v0.45/run-node/interact-node.html
+JSON-RPC, gRPC, REST  [Cosmos SDK v0.45 Docs - Interact with Node](https://docs.cosmos.network/v0.45/run-node/interact-node.html)


### PR DESCRIPTION
- (sort of) closes #864, which claims these links do not work

## Before
<img width="1282" alt="image" src="https://github.com/Agoric/documentation/assets/11021913/367ae8a4-4439-4456-8253-d35153c16b7a">


## After 
<img width="1191" alt="image" src="https://github.com/Agoric/documentation/assets/11021913/9ce730ad-cffa-46c3-af3d-ac038470e1f5">
