### PR TITLE
chore: demote beta / pre-smart-wallet material

### DIFF
--- a/main/.vitepress/config.mjs
+++ b/main/.vitepress/config.mjs
@@ -125,10 +125,6 @@ export default defineConfig({
               text: 'Smart Wallet Dapp Architecture',
               link: '/guides/getting-started/contract-rpc',
             },
-            {
-              text: 'Deploying Smart Contracts',
-              link: '/guides/getting-started/deploying',
-            },
           ],
         },
         {
@@ -182,15 +178,6 @@ export default defineConfig({
               text: 'Notifiers and Subscriptions',
               link: '/guides/js-programming/notifiers',
             },
-          ],
-        },
-        {
-          text: 'Wallet',
-          link: '/guides/wallet/',
-          collapsed: true,
-          items: [
-            { text: 'Agoric Wallet', link: '/guides/wallet/' },
-            { text: 'Wallet UI', link: '/guides/wallet/ui' },
           ],
         },
         {
@@ -330,38 +317,12 @@ export default defineConfig({
           ],
         },
         {
-          text: 'Agoric Dapps',
-          link: '/guides/dapps/',
-          collapsed: true,
-          items: [
-            { text: 'Agoric Dapps', link: '/guides/dapps/' },
-            {
-              text: 'Dapp Templates',
-              link: '/guides/dapps/dapp-templates',
-            },
-            {
-              text: 'Starting Multiuser Dapps',
-              link: '/guides/dapps/starting-multiuser-dapps',
-            },
-            {
-              text: 'Deploying Smart Contracts',
-              link: '/guides/getting-started/deploying',
-            },
-            {
-              text: 'Smart Wallet Dapp Architecture',
-              link: '/guides/getting-started/contract-rpc',
-            },
-          ],
+          text: 'Smart Wallet Dapp Architecture',
+          link: '/guides/getting-started/contract-rpc',
         },
         {
           text: 'Agoric Platform',
           link: '/guides/platform/',
-          collapsed: true,
-          items: [],
-        },
-        {
-          text: 'Chainlink Integration',
-          link: '/guides/chainlink-integration',
           collapsed: true,
           items: [],
         },

--- a/main/.vitepress/config.mjs
+++ b/main/.vitepress/config.mjs
@@ -335,21 +335,6 @@ export default defineConfig({
       ],
       '/reference/': [
         {
-          text: 'Wallet API',
-          link: '/reference/wallet-api/',
-          collapsed: true,
-          items: [
-            {
-              text: 'Wallet API Commands',
-              link: '/reference/wallet-api/wallet-commands',
-            },
-            {
-              text: 'WalletBridge API Commands',
-              link: '/reference/wallet-api/wallet-bridge',
-            },
-          ],
-        },
-        {
           text: 'ERTP API',
           link: '/reference/ertp-api/',
           collapsed: true,
@@ -371,25 +356,6 @@ export default defineConfig({
               text: 'ERTP Data Types',
               link: '/reference/ertp-api/ertp-data-types',
             },
-          ],
-        },
-        {
-          text: 'REPL API',
-          link: '/reference/repl/',
-          collapsed: true,
-          items: [
-            { text: 'Agoric REPL', link: '/reference/repl/' },
-            {
-              text: 'Timer Services',
-              link: '/reference/repl/timerServices',
-            },
-            { text: 'The Agoric Board', link: '/reference/repl/board' },
-            { text: 'Network API', link: '/reference/repl/networking' },
-            {
-              text: 'Price Authority',
-              link: '/reference/repl/priceAuthority',
-            },
-            { text: 'Scratch', link: '/reference/repl/scratch' },
           ],
         },
         {

--- a/main/.vitepress/themeConfig/nav.js
+++ b/main/.vitepress/themeConfig/nav.js
@@ -20,11 +20,6 @@ export const nav = [
         link: '/guides/getting-started/contract-rpc',
       },
       {
-        text: 'Deploying Smart Contracts',
-        ariaLabel: 'Deploying Menu',
-        link: '/guides/getting-started/deploying',
-      },
-      {
         text: 'Permissioned Contract Deployment',
         ariaLabel: 'Permissioned Contract Deployment',
         link: '/guides/coreeval/',
@@ -44,11 +39,6 @@ export const nav = [
         text: 'JavaScript Framework',
         ariaLabel: 'JavaScript Framework',
         link: '/guides/js-programming/',
-      },
-      {
-        text: 'Wallet',
-        ariaLabel: 'Wallet',
-        link: '/guides/wallet/',
       },
       {
         text: 'ERTP',
@@ -71,9 +61,9 @@ export const nav = [
         link: '/guides/zoe/actual-contracts/',
       },
       {
-        text: 'Agoric Dapps',
-        ariaLabel: 'Agoric Dapps',
-        link: '/guides/dapps/',
+        text: 'Smart Wallet Dapp Architecture',
+        ariaLabel: 'Smart Wallet Dapp Architecture Menu',
+        link: '/guides/getting-started/contract-rpc',
       },
     ],
   },
@@ -82,19 +72,9 @@ export const nav = [
     ariaLabel: 'API Reference Menu',
     items: [
       {
-        text: 'Wallet API',
-        ariaLabel: 'Wallet API Menu',
-        link: '/reference/wallet-api/',
-      },
-      {
         text: 'ERTP API',
         ariaLabel: 'ERTP API Menu',
         link: '/reference/ertp-api/',
-      },
-      {
-        text: 'REPL API',
-        ariaLabel: 'REPL API Menu',
-        link: '/reference/repl/',
       },
       {
         text: 'Zoe API',


### PR DESCRIPTION
Lots of material (/guides/wallet/ etc.) documents the ag-solo / mailbox architecture... the beta preview of our eventual permissionless contract deployment model, extending our Distributed Computing Framework to a stateful peer on end-user machines.

That material is a distraction to folks building for what's in production in the mainnet-1B VM.

So demote it from navigation menus, at least.

refs #973