### PR TITLE
chore(actual-contracts): prune irrelevant Zoe-Version

### DIFF
--- a/main/guides/zoe/actual-contracts/index.md
+++ b/main/guides/zoe/actual-contracts/index.md
@@ -1,7 +1,5 @@
 # Deployed Zoe Contracts
 
-<Zoe-Version/>
-
 In the [mainnet-1B release of agoric-sdk](https://github.com/Agoric/agoric-sdk/releases/tag/mainnet1B-rc3), the chain is configured to automatically deploy the following Zoe contracts. A [community post on Inter Protocol Vaults Contract Implementations](https://community.agoric.com/t/inter-protocol-vaults-contract-implementations/261) has a high level description.
 
 | Contract | Description |


### PR DESCRIPTION
The Dec 2022 date from the <Zoe-Version/> component is not relevant to the deployed contracts.