### PR TITLE
fix: include reference material in left nav bar

### DIFF
--- a/main/.vitepress/config.mjs
+++ b/main/.vitepress/config.mjs
@@ -371,8 +371,6 @@ export default defineConfig({
           collapsed: true,
           items: [],
         },
-      ],
-      '/reference/': [
         {
           text: 'Wallet API',
           link: '/reference/wallet-api/',


### PR DESCRIPTION
refs #1005

kind of a kludge: removes separation between guides and reference

is there a better way?

cc @kbennett2000 