### PR TITLE
docs: consolidate proposal shapes; shorten zoe overview

### DIFF
--- a/main/reference/zoe-api/zoe-contract-facet.md
+++ b/main/reference/zoe-api/zoe-contract-facet.md
@@ -106,22 +106,15 @@ The optional **customDetails** argument is included in the **Invitation**'s
 **amount** and not otherwise relied on by Zoe.
 
 The optional **proposalShape** argument can be used to describe the required and allowed components of each proposal.
+
+### Proposal Shapes
+
 Proposals that don't match the pattern will be rejected by Zoe without even being sent to the contract.
 
-Patterns are constructed using the
+Patterns are often constructed using the
 **[M](https://endojs.github.io/endo/interfaces/_endo_patterns.PatternMatchers.html)** (for '**M**atcher') object.
 **proposalShape**s are usually built from [`M.splitRecord(required, optional, rest)`](https://endojs.github.io/endo/interfaces/_endo_patterns.PatternMatchers.html#splitRecord).
-
-```
-  M.splitRecord({
-    give: {
-      Collateral: makeNatAmountShape(collateralBrand),
-    },
-    want: {
-      Minted: makeNatAmountShape(debtBrand),
-    },
-  }),
-```
+For example, when making a covered call, to express that the offering party can't cancel:
 
 ```js
 import { M } from '@endo/patterns';
@@ -140,6 +133,55 @@ const creatorInvitation = zcf.makeInvitation(
   undefined,
   waivedExitProposalShape,
 );
+```
+
+Full details are in the [@endo/patterns](https://endojs.github.io/endo/modules/_endo_patterns.html) package. Here's a handy reference:
+
+```js
+interface PatternMatchers {
+    and: ((...subPatts) => Matcher);
+    any: (() => Matcher);
+    array: ((limits?) => Matcher);
+    arrayOf: ((subPatt?, limits?) => Matcher);
+    bag: ((limits?) => Matcher);
+    bagOf: ((keyPatt?, countPatt?, limits?) => Matcher);
+    bigint: ((limits?) => Matcher);
+    boolean: (() => Matcher);
+    eq: ((key) => Matcher);
+    eref: ((subPatt) => any);
+    error: (() => Matcher);
+    gt: ((rightOperand) => Matcher);
+    gte: ((rightOperand) => Matcher);
+    key: (() => Matcher);
+    kind: ((kind) => Matcher);
+    lt: ((rightOperand) => Matcher);
+    lte: ((rightOperand) => Matcher);
+    map: ((limits?) => Matcher);
+    mapOf: ((keyPatt?, valuePatt?, limits?) => Matcher);
+    nat: ((limits?) => Matcher);
+    neq: ((key) => Matcher);
+    not: ((subPatt) => Matcher);
+    null: (() => null);
+    number: (() => Matcher);
+    opt: ((subPatt) => any);
+    or: ((...subPatts) => Matcher);
+    partial: ((basePatt, rest?) => Matcher);
+    pattern: (() => Matcher);
+    promise: (() => Matcher);
+    record: ((limits?) => Matcher);
+    recordOf: ((keyPatt?, valuePatt?, limits?) => Matcher);
+    remotable: ((label?) => Matcher);
+    scalar: (() => Matcher);
+    set: ((limits?) => Matcher);
+    setOf: ((keyPatt?, limits?) => Matcher);
+    split: ((basePatt, rest?) => Matcher);
+    splitArray: ((required, optional?, rest?) => Matcher);
+    splitRecord: ((required, optional?, rest?) => Matcher);
+    string: ((limits?) => Matcher);
+    symbol: ((limits?) => Matcher);
+    tagged: ((tagPatt?, payloadPatt?) => Matcher);
+    undefined: (() => Matcher);
+}
 ```
 
 ## zcf.makeEmptySeatKit()

--- a/main/reference/zoe-api/zoe-contract-facet.md
+++ b/main/reference/zoe-api/zoe-contract-facet.md
@@ -11,6 +11,7 @@ the **zcf** object during that launch (see [Contract Requirements](/guides/zoe/c
 In the operations below, **instance** is the handle for the running contract instance.
 
 ## zcf.makeZCFMint(keyword, assetKind?, displayInfo?)
+
 - **keyword**: **[Keyword](./zoe-data-types#keyword)**
 - **assetKind**: **[AssetKind](/reference/ertp-api/ertp-data-types#assetkind)** - Optional, defaults to **AssetKind.NAT**.
 - **displayInfo**: **[DisplayInfo](/reference/ertp-api/ertp-data-types#displayinfo)** - Optional, defaults to **undefined**.
@@ -18,8 +19,8 @@ In the operations below, **instance** is the handle for the running contract ins
 
 Creates a synchronous Zoe mint, allowing users to mint and reallocate digital assets synchronously
 instead of relying on an asynchronous ERTP **[Mint](/reference/ertp-api/mint)**.
-The optional *displayInfo* parameter takes values
-like **decimalPlaces: 16** that tell the UI how to display values associated with the created mint's 
+The optional _displayInfo_ parameter takes values
+like **decimalPlaces: 16** that tell the UI how to display values associated with the created mint's
 brand. It defaults to undefined.
 
 **Important**: **ZCFMints** do **not** have the same methods as an ERTP **Mint**. Do not try to use
@@ -41,6 +42,7 @@ mySynchronousMint.mintGains({ myKeyword: amount }, seat);
 ```
 
 ## zcf.getInvitationIssuer()
+
 - Returns: **Promise&lt;[InvitationIssuer](./zoe-data-types#invitationissuer)>**
 
 Returns the **InvitationIssuer** for the Zoe instance.
@@ -50,12 +52,13 @@ const invitationIssuer = await zcf.getInvitationIssuer();
 ```
 
 ## zcf.saveIssuer(issuer, keyword)
+
 - **issuer**: **[Issuer](/reference/ertp-api/issuer)**
 - **keyword**: **[Keyword](./zoe-data-types#keyword)**
 - Returns: **Promise&lt;IssuerRecord>**
 
 Informs Zoe about an **Issuer** and returns a promise for acknowledging
-when the **Issuer** is added and ready. The *keyword* is the one associated
+when the **Issuer** is added and ready. The _keyword_ is the one associated
 with the new **Issuer**. This method returns a promise for an **IssuerRecord** of the new **Issuer**
 
 This saves an **Issuer** in Zoe's records for this contract **instance**.
@@ -71,7 +74,9 @@ await zcf.saveIssuer(secondaryIssuer, keyword);
 ```
 
 <a id="zcf-makeinvitation-offerhandler-description-customproperties-proposalshape"></a>
+
 ## zcf.makeInvitation(offerHandler, description, customDetails?, proposalShape?)
+
 - **offerHandler**: **(seat: ZCFSeat, offerArgs?: CopyRecord) => any**
 - **description**: **String**
 - **customDetails**: **Object** - Optional.
@@ -81,6 +86,7 @@ await zcf.saveIssuer(secondaryIssuer, keyword);
 Uses the Zoe **[InvitationIssuer](./zoe-data-types#invitationissuer)** to _mint_
 a credible **Invitation** for a smart contract.
 The returned **Invitation**'s **amount** specifies:
+
 - The specific contract **instance**.
 - The Zoe **installation**.
 - A unique **[Handle](./zoe-data-types#handle)**.
@@ -118,7 +124,7 @@ Patterns are constructed using the
 ```
 
 ```js
-import { M } from "@endo/patterns";
+import { M } from '@endo/patterns';
 
 const waivedExitProposalShape = M.splitRecord(
   // required properties
@@ -128,11 +134,16 @@ const waivedExitProposalShape = M.splitRecord(
   // unknown properties
   M.record(),
 );
-const creatorInvitation =
-  zcf.makeInvitation(makeCallOption, 'makeCallOption', undefined, waivedExitProposalShape);
+const creatorInvitation = zcf.makeInvitation(
+  makeCallOption,
+  'makeCallOption',
+  undefined,
+  waivedExitProposalShape,
+);
 ```
 
 ## zcf.makeEmptySeatKit()
+
 - Returns: **[ZCFSeat](./zcfseat), Promise&lt;[UserSeat](./user-seat)>**
 
 Returns an empty **ZCFSeat** and a **Promise** for a **UserSeat**
@@ -140,43 +151,51 @@ Returns an empty **ZCFSeat** and a **Promise** for a **UserSeat**
 Zoe uses **seats** to represent offers, and has two seat facets (a
 particular view or API of an object;
 there may be multiple such facets per object) a **ZCFSeat** and a **UserSeat**.
+
 ```js
 const { zcfSeat: mySeat } = zcf.makeEmptySeatKit();
 ```
 
 ## zcf.getInstance()
+
 - Returns: **[Instance](./zoe-data-types#instance)**
 
 The contract code can request its own current instance, so it can be sent elsewhere.
 
 ## zcf.getBrandForIssuer(issuer)
+
 - **issuer**: **[Issuer](/reference/ertp-api/issuer)**
 - Returns: **[Brand](/reference/ertp-api/brand)**
 
-Returns the **Brand** associated with the *issuer*.
+Returns the **Brand** associated with the _issuer_.
 
 ## zcf.getIssuerForBrand(brand)
+
 - **brand**: **[Brand](/reference/ertp-api/brand)**
 - Returns: **[Issuer](/reference/ertp-api/issuer)**
 
-Returns the **Issuer** of the *brand* argument.
+Returns the **Issuer** of the _brand_ argument.
 
 ## zcf.getAssetKind(brand)
+
 - **brand**: **[Brand](/reference/ertp-api/brand)**
 - Returns: **[AssetKind](/reference/ertp-api/ertp-data-types#assetkind)**
 
-Returns the **AssetKind** associated with the *brand* argument.
+Returns the **AssetKind** associated with the _brand_ argument.
+
 ```js
 const quatloosAssetKind = zcf.getAssetKind(quatloosBrand);
 ```
 
 ## zcf.stopAcceptingOffers()
+
 - Returns: None.
 
-The contract requests Zoe to not accept offers for this contract instance. 
+The contract requests Zoe to not accept offers for this contract instance.
 It can't be called from outside the contract unless the contract explicitly makes it accessible.
 
 ## zcf.shutdown(completion)
+
 - **completion**: **Usually (but not always) a String**
 - Returns: None.
 
@@ -186,19 +205,22 @@ All open **seats** associated with the current **instance** have **fail()**
 called on them.
 
 Call when:
+
 - You want nothing more to happen in the contract, and
 - You don't want to take any more offers
 
-The *completion* argument is usually a **String**, but this 
+The _completion_ argument is usually a **String**, but this
 is not required. It is used for the notification sent to the
 contract instance's **done()** function. Any still open seats or
-other outstanding promises are closed with a generic 'vat terminated' 
+other outstanding promises are closed with a generic 'vat terminated'
 message.
+
 ```js
 zcf.shutdown();
 ```
 
 ## zcf.shutdownWithFailure(reason)
+
 - **reason**: **Error**
 - Returns: None.
 
@@ -207,10 +229,10 @@ Shuts down the entire vat and contract instance due to an error.
 All open **seats** associated with the current **instance** have **fail()**
 called on them.
 
-The *reason* argument is a JavaScript error object. 
+The _reason_ argument is a JavaScript error object.
 It is used for the notification sent to the
 contract instance's **done()** function. Any still open seats or
-other outstanding promises are closed with the relevant 
+other outstanding promises are closed with the relevant
 error message.
 
 ```js
@@ -218,11 +240,13 @@ zcf.shutdownWithFailure();
 ```
 
 ## zcf.getTerms()
+
 - Returns: **Object**
 
 Returns the **[Issuers](/reference/ertp-api/issuer)**, **[Brands](/reference/ertp-api/brand)**, and custom **terms** the current contract **instance** was instantiated with.
 
 The returned values look like:
+
 ```js
 { brands, issuers, customTermA, customTermB ... }
 // where brands and issuers are keywordRecords, like:
@@ -239,15 +263,18 @@ Note that there is also an **E(zoe).getTerms(instance)**. Often the choice of wh
 to use, but which of Zoe Service or ZCF you have access to. On the contract side, you more easily have access
 to **zcf**, and **zcf** already knows what instance is running. So in contract code, you use **zcf.getTerms()**. From
 a user side, with access to Zoe Service, you use **E(zoe).getTerms()**.
+
 ```js
-const { brands, issuers, maths, terms } = zcf.getTerms()
+const { brands, issuers, maths, terms } = zcf.getTerms();
 ```
 
 ## zcf.getZoeService()
+
 - Returns: [ZoeService](./zoe)
 
 This is the only way to get the user-facing [Zoe Service API](./zoe) to
 the contract code as well.
+
 ```js
 // Making an offer to another contract instance in the contract.
 const zoeService = zcf.getZoeService();
@@ -255,17 +282,20 @@ E(zoeService).offer(creatorInvitation, proposal, paymentKeywordRecord);
 ```
 
 ## zcf.assertUniqueKeyword(keyword)
+
 - **keyword**: **[Keyword](./zoe-data-types#keyword)**
 - Returns: **Undefined**
 
 Checks if a **Keyword** is valid and not already used as a **Brand** in this **Instance** (i.e., unique)
 and could be used as a new **Brand** to make an **Issuer**. Throws an appropriate error if it's not
 a valid **Keyword**, or is not unique.
+
 ```js
 zcf.assertUniqueKeyword(keyword);
 ```
 
 ## zcf.setOfferFilter(strings)
+
 - **strings**: **Array&lt;String>**
 - Returns: None.
 
@@ -279,9 +309,10 @@ intended to be used by **governance** in a legible way, so that the contract's
 governance process can take emergency action in order to stop processing when necessary.
 
 Note that blocked strings can be re-enabled by calling this method again and simply not
-including that string in the *strings* argument.
+including that string in the _strings_ argument.
 
 ## zcf.getOfferFilter()
+
 - Returns: **Array&lt;String>**
 
 Returns all the strings that have been disabled for use in invitations, if any.
@@ -289,33 +320,35 @@ A contract's invitations may be disabled using the
 **[zcf.setOfferFilter()](#zcf-setofferfilter-strings)** method when governance determines
 that they provide a vulnerability.
 
-
 ::: warning DEPRECATED
+
 ## zcf.reallocate(seats)
+
 - **seats**: **[ZCFSeats](./zcfseat)[]** (at least two)
 - Returns: None.
 
 **zcf.reallocate()** commits the staged allocations for each of its seat arguments,
 making their staged allocations their current allocations. **zcf.reallocate()** then
-transfers the assets escrowed in Zoe from one seat to another. Importantly, the assets 
+transfers the assets escrowed in Zoe from one seat to another. Importantly, the assets
 stay escrowed, with only the internal Zoe accounting of each seat's allocation changed.
 
 There must be at least two **ZCFSeats** in the array argument. Every **ZCFSeat**
 with a staged allocation must be included in the argument array or an error
 is thrown. If any seat in the argument array does not have a staged allocation,
-an error is thrown. 
+an error is thrown.
 
-On commit, the staged allocations become the seats' current allocations and 
+On commit, the staged allocations become the seats' current allocations and
 the staged allocations are deleted.
 
-Note: **reallocate()** is an *atomic operation*. To enforce offer safety, 
-it will never abort part way through. It will completely succeed or it will 
+Note: **reallocate()** is an _atomic operation_. To enforce offer safety,
+it will never abort part way through. It will completely succeed or it will
 fail before any seats have their current allocation changed.
 
 The reallocation only succeeds if it:
+
 1. Conserves rights (the specified **[Amounts](/reference/ertp-api/ertp-data-types#amount)** have the same total value as the
-  current total amount)
-2. Is 'offer-safe' for all parties involved. 
+   current total amount)
+2. Is 'offer-safe' for all parties involved.
 
 The reallocation is partial, only applying to the **seats** in the
 argument array. By induction, if rights conservation and
@@ -327,6 +360,7 @@ those **seats**, and since rights are conserved for the change, overall
 rights are unchanged.
 
 **zcf.reallocate()** throws this error:
+
 - **reallocating must be done over two or more seats**
 
 ```js
@@ -337,5 +371,3 @@ zcf.reallocate(buyerSeat, sellerSeat);
 
 **Note**: This method has been deprecated. Use **[atomicRearrange()](./zoe-helpers#atomicrearrange-zcf-transfers)** instead.
 :::
-
-

--- a/main/reference/zoe-api/zoe.md
+++ b/main/reference/zoe-api/zoe.md
@@ -204,6 +204,7 @@ const instance = await E(Zoe).getInstance(invitation);
 - Returns: **Promise&lt;[Pattern](https://github.com/endojs/endo/tree/master/packages/patterns#readme)>**
 
 Returns a **Promise** for the **Pattern** that the **Invitation's** **Proposal** adheres to.
+See also [Proposal Shapes](./zoe-contract-facet#proposal-shapes).
 
 ## E(Zoe).getInstallation(invitation)
 
@@ -350,14 +351,8 @@ the Keywords might be "Asset" and "Bid".
   (Some timers use Unix epoch time, while others count block height.)
   For more details, see [Timer Services](/reference/repl/timerServices).
 
-### Proposal Shape
-
-A contract can avoid invalid proposals
-
-using the
-**[M](https://endojs.github.io/endo/interfaces/_endo_patterns.PatternMatchers.html)** (for '**M**atcher') object from `@endo/patterns`.
-
-For example, a contract holding an auction might require that all offers include an `afterDeadline` exit rule with a timestamp in the future.
+A contract can avoid invalid proposals;
+see [Proposal Shapes](./zoe-contract-facet#proposal-shapes).
 
 ### Payments
 

--- a/main/reference/zoe-api/zoe.md
+++ b/main/reference/zoe-api/zoe.md
@@ -21,10 +21,11 @@ For more information about using **E**, see the [Agoric's JavaScript Distributed
 :::
 
 ## E(Zoe).getBrands(instance)
+
 - **instance**: **[Instance](./zoe-data-types#instance)**
 - Returns: **Promise&lt;BrandKeywordRecord>**
 
-Returns a **Promise** for a **BrandKeywordRecord** containing all **[Brands](/reference/ertp-api/brand)** defined in the *instance* argument.
+Returns a **Promise** for a **BrandKeywordRecord** containing all **[Brands](/reference/ertp-api/brand)** defined in the _instance_ argument.
 
 A **BrandKeywordRecord** is an object where the keys are **[Keywords](./zoe-data-types#keyword)**,
 and the values are the **Brands** for particular **[Issuers](/reference/ertp-api/issuer)**.
@@ -44,10 +45,11 @@ const brandKeywordRecord = await E(Zoe).getBrands(instance);
 ```
 
 ## E(Zoe).getIssuers(instance)
+
 - **instance**: **[Instance](./zoe-data-types#instance)**
 - Returns: **Promise&lt;IssuerKeywordRecord>**
 
-Returns a **Promise** for an **IssuerKeywordRecord** containing all **[Issuers](/reference/ertp-api/issuer)** defined in the *instance* argument.
+Returns a **Promise** for an **IssuerKeywordRecord** containing all **[Issuers](/reference/ertp-api/issuer)** defined in the _instance_ argument.
 
 An **IssuerKeywordRecord** is an object where the keys are **[Keywords](./zoe-data-types#keyword)**,
 and the values are **Issuers**.
@@ -66,10 +68,11 @@ const issuerKeywordRecord = await E(Zoe).getIssuers(instance);
 ```
 
 ## E(Zoe).getTerms(instance)
+
 - **instance**: **[Instance](./zoe-data-types#instance)**
 - Returns: **Promise&lt;Object>**
 
-Returns a **Promise** for the terms of the *instance* argument, including its **[Brands](/reference/ertp-api/brand)**, **[Issuers](/reference/ertp-api/issuer)**, and any
+Returns a **Promise** for the terms of the _instance_ argument, including its **[Brands](/reference/ertp-api/brand)**, **[Issuers](/reference/ertp-api/issuer)**, and any
 custom terms. The returned values look like:
 
 ```js
@@ -82,16 +85,17 @@ custom terms. The returned values look like:
   // All other customTerms
 };
 ```
- 
+
 ```js
 const terms = await E(Zoe).getTerms(instance);
 ```
 
 ## E(Zoe).getPublicFacet(instance)
+
 - **instance**: **[Instance](./zoe-data-types#instance)**
 - Returns: **Promise&lt;PublicFacet>**
 
-Returns a **Promise** for the **PublicFacet** defined for the *instance* argument.
+Returns a **Promise** for the **PublicFacet** defined for the _instance_ argument.
 
 A contract instance's **PublicFacet** is an object available via Zoe to anyone knowing that **Instance**.
 You use it for general queries and actions, such as getting a current price or creating public **[Invitations](./zoe-data-types#invitation)**.
@@ -103,6 +107,7 @@ const ticketSalesPublicFacet = await E(Zoe).getPublicFacet(sellItemsInstance);
 ```
 
 ## E(Zoe).getInvitationIssuer()
+
 - Returns: **Promise&lt;[InvitationIssuer](./zoe-data-types#invitationissuer)>**
 
 Returns a **Promise** for the **InvitationIssuer** for the Zoe instance.
@@ -113,11 +118,13 @@ const invitationIssuer = await E(Zoe).getInvitationIssuer();
 // Bob uses the trusted **InvitationIssuer** from Zoe to
 // transform the untrusted invitation to a trusted one
 const trustedInvitation = await invitationIssuer.claim(untrustedInvitation);
-const { value: invitationValue } =
-  await E(invitationIssuer).getAmountOf(trustedInvitation);
+const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
+  trustedInvitation,
+);
 ```
 
 ## E(Zoe).getInvitationDetails(invitation)
+
 - **invitation**: **[Invitation](./zoe-data-types#invitation)**
 - Returns **Promise&lt;Object>**
 
@@ -128,7 +135,7 @@ details about the **Invitation**:
 - **instance**: **[Instance](./zoe-data-types#instance)**: The contract instance this invitation is for.
 - **invitationHandle**: **[Handle](./zoe-data-types#handle)**: A **Handle** used to refer to this **Invitation**.
 - **description**: **String**: Describes the purpose of this **Invitation**. Use it
-   to match the invitation to the role it plays in the contract.
+  to match the invitation to the role it plays in the contract.
 
 ```js
 const invitation = await invitationIssuer.claim(untrustedInvitation);
@@ -136,6 +143,7 @@ const invitationValue = await E(Zoe).getInvitationDetails(invitation);
 ```
 
 ## E(Zoe).install(bundle)
+
 - **bundle**: **SourceBundle**
 - Returns: **Promise&lt;Installation>**
 
@@ -151,6 +159,7 @@ const installationP = await E(Zoe).install(bundle);
 ```
 
 ## E(Zoe).getConfiguration()
+
 - Returns: **Promise&lt;Object>**
 
 Returns a **Promise** for information about the feeIssuer.
@@ -158,17 +167,20 @@ Returns a **Promise** for information about the feeIssuer.
 It consists of the issuer's name, assetKind, and displayInfo.
 
 ## E(Zoe).getFeeIssuer()
+
 - Returns: **Promise&lt;[Issuer](/reference/ertp-api/issuer)>**
 
 Returns a **Promise** for the **Issuer** whose associated **[Mint](/reference/ertp-api/mint)** can mint IST.
 
 ## E(Zoe).getOfferFilter(instance)
+
 - **instance**: **[Instance](./zoe-data-types#instance)**
 - Returns: **Array&lt;String>**
 
 Returns all the offer **[Keywords](./zoe-data-types#keyword)** that have been disabled, if any. Offer **Keywords** may be disabled if they prove problematic in some fashion, or to debug undesired behavior.
 
 ## E(Zoe).getInstance(invitation)
+
 - **invitation**: **[Invitation](./zoe-data-types#invitation)**
 - Returns: **Promise&lt;[Instance](./zoe-data-types#instance)>**
 
@@ -186,13 +198,15 @@ these methods:
 const instance = await E(Zoe).getInstance(invitation);
 ```
 
-## E(Zoe).getProposalShapeForInvitation(invitation) 
+## E(Zoe).getProposalShapeForInvitation(invitation)
+
 - **invitation**: **[Invitation](./zoe-data-types#invitation)**
 - Returns: **Promise&lt;[Pattern](https://github.com/endojs/endo/tree/master/packages/patterns#readme)>**
 
 Returns a **Promise** for the **Pattern** that the **Invitation's** **Proposal** adheres to.
 
 ## E(Zoe).getInstallation(invitation)
+
 - **invitation**: **[Invitation](./zoe-data-types#invitation)**
 - Returns: **Promise&lt;Installation>**
 
@@ -203,6 +217,7 @@ const installation = await E(Zoe).getInstallation(invitation);
 ```
 
 ## E(Zoe).getInstallationForInstance(instance)
+
 - **instance**: **[Instance](./zoe-data-types#instance)**
 - Returns **Promise&lt;Installation>**
 
@@ -217,6 +232,7 @@ const installation = await E(Zoe).getInstallationForInstance(instance);
 ```
 
 ## E(Zoe).startInstance(installation, issuerKeywordRecord?, terms?, privateArgs?)
+
 - **installation**: **ERef&lt;Installation>**
 - **issuerKeywordRecord**: **IssuerKeywordRecord** - Optional.
 - **terms**: **Object** - Optional.
@@ -224,10 +240,10 @@ const installation = await E(Zoe).getInstallationForInstance(instance);
 - Returns: **Promise&lt;StartInstanceResult>**
 
 Creates an instance of the installed smart contract specified by
-the *installation* argument. All contracts each run in a new vat with their own version of the
+the _installation_ argument. All contracts each run in a new vat with their own version of the
 Zoe Contract Facet. There is one vat that contains the Zoe Service.
 
-The *issuerKeywordRecord* is an optional object mapping **[Keywords](./zoe-data-types#keyword)**
+The _issuerKeywordRecord_ is an optional object mapping **[Keywords](./zoe-data-types#keyword)**
 to **[Issuers](/reference/ertp-api/issuer)**, such as **FirstCurrency: quatlooIssuer**.
 Parties to the contract will use the **Keywords** to index their proposal and their payments.
 
@@ -254,9 +270,10 @@ It returns a **Promise** for a **StartInstanceResult** object. The object consis
 - **creatorInvitation**: **Payment | undefined**
 
 The **adminFacet** has one method:
-- **getVatShutdownPromise()**    
-  - Returns a promise that resolves to reason (the value passed to **fail(reason)**) or 
-    completion (the value passed to **exit(completion)**) when this newly started instance terminates. 
+
+- **getVatShutdownPromise()**
+  - Returns a promise that resolves to reason (the value passed to **fail(reason)**) or
+    completion (the value passed to **exit(completion)**) when this newly started instance terminates.
 
 A **publicFacet** is an object available via Zoe to anyone knowing
 the instance they are associated with. The **publicFacet** is used for general queries
@@ -275,19 +292,22 @@ It is usually used in contracts where the creator immediately sells
 something (auctions, swaps, etc.), so it's helpful for the creator to have
 an **Invitation** to escrow and sell goods. Remember that Zoe **Invitations** are
 represented as a **Payment**.
+
 ```js
 const issuerKeywordRecord = {
   Asset: moolaIssuer,
   Price: quatlooIssuer,
 };
 const terms = { numBids: 3 };
-const { creatorFacet, publicFacet, creatorInvitation } =
-  await E(Zoe).startInstance(installation, issuerKeywordRecord, terms);
+const { creatorFacet, publicFacet, creatorInvitation } = await E(
+  Zoe,
+).startInstance(installation, issuerKeywordRecord, terms);
 ```
 
 <a id="e-zoe-offer-invitation-proposal-paymentkeywordrecord-offerargs"></a>
 
 ## E(Zoe).offer(invitation, proposal?, paymentPKeywordRecord?, offerArgs?)
+
 - **invitation**: **[Invitation](./zoe-data-types#invitation) | Promise&lt;[Invitation](./zoe-data-types#invitation)>**
 - **proposal**: **[Proposal](/glossary/#proposal)** - Optional.
 - **paymentPKeywordRecord**: **[PaymentPKeywordRecord](./zoe-data-types#keywordrecord)** - Optional.
@@ -297,6 +317,7 @@ const { creatorFacet, publicFacet, creatorInvitation } =
 Used to make an offer to the contract that created the **invitation**.
 
 <a id="proposals-and-payments"></a>
+
 ### Proposals
 
 **proposal** must be either `undefined` or a record with **give**, **want**, and/or **exit** properties
@@ -320,6 +341,7 @@ In the example above, "Asset" and "Price" are the Keywords. However, in an aucti
 the Keywords might be "Asset" and "Bid".
 
 **exit** specifies how the offer can be cancelled. It must conform to one of three shapes:
+
 - `{ onDemand: null }`: (Default) The offering party can cancel on demand.
 - `{ waived: null }`: The offering party can't cancel and relies entirely on the smart contract to complete (finish or fail) their offer.
 - `{ afterDeadline: deadlineDetails }`: The offer is automatically cancelled after a deadline,
@@ -330,11 +352,12 @@ the Keywords might be "Asset" and "Bid".
 
 ### Proposal Shape
 
-A contract can enforce a certain proposal shape using the
+A contract can avoid invalid proposals
+
+using the
 **[M](https://endojs.github.io/endo/interfaces/_endo_patterns.PatternMatchers.html)** (for '**M**atcher') object from `@endo/patterns`.
 
 For example, a contract holding an auction might require that all offers include an `afterDeadline` exit rule with a timestamp in the future.
-
 
 ### Payments
 
@@ -347,6 +370,7 @@ const paymentKeywordRecord = harden({ Asset: quatloosPayment });
 ```
 
 <a href="offerargs"></a>
+
 ### Offer Arguments
 
 **offerArgs** is an optional CopyRecord that can be used to pass additional arguments to the
@@ -355,14 +379,15 @@ const paymentKeywordRecord = harden({ Asset: quatloosPayment });
 Each contract can define the properties it supports and which are required.
 
 ## E(Zoe).installBundleID(bundleId)
+
 - bundleId: **BundleId**
 - Returns: **Promise&lt;Installation>**
 
 Reserved for future use.
 
-## E(Zoe).getBundleIDFromInstallation(installation) 
+## E(Zoe).getBundleIDFromInstallation(installation)
+
 - **installation**: **Installation**
 - Returns: **Promise&lt;BundleId>**
 
 Reserved for future use.
-


### PR DESCRIPTION
fixes #951
closes #739
closes #880

Turns out [Proposal Shape](https://docs.agoric.com/reference/zoe-api/zoe.html#proposal-shape) was documented already, under `E(zoe).offer(...)`. And the endo reference docs cover Pattern Matchers pretty well.

It was also mentioned under [zcf.makeInvitation](https://docs.agoric.com/reference/zoe-api/zoe-contract-facet.html#zcf-makeinvitation-offerhandler-description-customdetails-proposalshape). Since this is the more directly relevant API, I moved the material here and cross-referenced it.

And I copied the `Matchers` interface that gives all the methods of `M`.

My editor does markdown lint on save; I hope it's not too distracting that I mixed in work on #945 here. I did put it in separate commits.
