### PR TITLE
prefer makeInvitation(..., proposalShape) to assertProposalShape

### DIFF
--- a/main/.vitepress/config.mjs
+++ b/main/.vitepress/config.mjs
@@ -391,7 +391,7 @@ export default defineConfig({
                   link: '/reference/zoe-api/user-seat',
                 },
                 {
-                  text: 'Zoe Contract Facet',
+                  text: 'Zoe Contract Facet (ZCF)',
                   link: '/reference/zoe-api/zoe-contract-facet',
                 },
                 { text: 'ZCFSeat Object', link: '/reference/zoe-api/zcfseat' },

--- a/main/reference/zoe-api/zoe-contract-facet.md
+++ b/main/reference/zoe-api/zoe-contract-facet.md
@@ -1,4 +1,4 @@
-# Zoe Contract Facet
+# Zoe Contract Facet (ZCF)
 
 <Zoe-Version/>
 

--- a/main/reference/zoe-api/zoe-helpers.md
+++ b/main/reference/zoe-api/zoe-helpers.md
@@ -82,8 +82,7 @@ changes has any effect. The constraints are as follows.
 - All the mentioned seats are still live.
 - There aren't any outstanding stagings for any of the mentioned seats.
 
-      	Stagings are a reallocation mechanism that has been
-
+  Stagings are a reallocation mechanism that has been
   deprecated in favor of this **atomicRearrange()** function.
   To prevent confusion, each reallocation can only be
   expressed in the old way or the new way, but not a mixture.

--- a/main/reference/zoe-api/zoe-helpers.md
+++ b/main/reference/zoe-api/zoe-helpers.md
@@ -226,6 +226,10 @@ Checks the seat's proposal against the _proposalShape_ argument. If the proposal
 - **expected**: **ExpectedRecord**
 - Returns: None.
 
+**Note: Most uses of `assertProposalShape` are better
+expressed using the `proposalShape` argument
+of [zcf.makeInvitation()](./zoe-contract-facet#zcf-makeinvitation-offerhandler-description-customdetails-proposalshape)**.
+
 Checks the seat's proposal against an _expected_ record that says
 what shape of proposal is acceptable.
 


### PR DESCRIPTION
follow-up to #951

drive-by: Make it easier to find ZCF APIs