### PR TITLE
fix: restore Hardened JavaScript etc. to nav

### DIFF
--- a/main/.vitepress/config.mjs
+++ b/main/.vitepress/config.mjs
@@ -180,6 +180,25 @@ export default defineConfig({
               text: 'JavaScript Framework',
               ariaLabel: 'JavaScript Framework',
               link: '/guides/js-programming/',
+              collapsed: true,
+              items: [
+                {
+                  text: 'Hardened JavaScript',
+                  link: '/guides/js-programming/hardened-js',
+                },
+                {
+                  text: 'Eventual Send with E()',
+                  link: '/guides/js-programming/eventual-send',
+                },
+                {
+                  text: 'Far(), Remotable, and Marshaling',
+                  link: '/guides/js-programming/far',
+                },
+                {
+                  text: 'Notifiers and Subscriptions',
+                  link: '/guides/js-programming/notifiers',
+                },
+              ],
             },
             {
               text: 'Papers',


### PR DESCRIPTION
I don't think we meant to take this out of the left nav bar (and "next page" links) in #1018 .