### PR TITLE
build(ci): relax node version constraint

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.17.x]
+        node-version: [18.x]
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/test-snippets.yml
+++ b/.github/workflows/test-snippets.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.17.x]
+        node-version: [18.x]
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
avoid:

error typescript-eslint@7.3.1: The engine "node" is incompatible with this module. Expected version "^18.18.0 || >=20.0.0". Got "18.17.1"