### PR TITLE
Updated getting started guide to use Node v18.18.0

### DIFF
--- a/main/guides/getting-started/index.md
+++ b/main/guides/getting-started/index.md
@@ -56,7 +56,7 @@ source ~/.bashrc
 Finally, install Node with the command:
 
 ```sh
-nvm install --lts
+nvm install v18.18.0
 ```
 
 </details>


### PR DESCRIPTION
Updated getting started guide to use Node v18.18.0 instead of LTS.

