### PR TITLE
docs: GettingStarted Simplified

### DIFF
--- a/main/guides/getting-started/explainer-deploying-a-smart-contact.md
+++ b/main/guides/getting-started/explainer-deploying-a-smart-contact.md
@@ -20,7 +20,6 @@ Once again, we can reference the project's `package.json` file to learn a bit mo
     "docker:make": "cd contract; docker compose exec agd make -C /workspace/contract",
     "make:help": "make -C contract list",
     "start:contract": "cd contract && yarn start",
-    "print-key": "yarn docker:make print-acct",
     "start:ui": "cd ui && yarn dev",
     "lint": "yarn workspaces run lint",
     "test": "yarn workspaces run test",
@@ -37,7 +36,7 @@ Note the calling the `yarn start:contract` command is the same as running `yarn 
     "docker:bash": "docker compose exec agd bash",
     "docker:make": "docker compose exec agd make -C /workspace/contract",
     "make:help": "make list",
-    "start": "yarn docker:make clean start-contract print-key",
+    "start": "yarn docker:make clean start-contract",
     "build": "agoric run scripts/build-contract-deployer.js",
     "test": "ava --verbose",
     "lint": "eslint '**/*.js'",
@@ -45,7 +44,7 @@ Note the calling the `yarn start:contract` command is the same as running `yarn 
   },
 ```
 
-In the json snippet above note that the `start` command is running `yarn docker:make clean start-contract print-key`. 
+In the json snippet above note that the `start` command is running `yarn docker:make clean start-contract`. 
 
 ::: tip Video Walkthrough
 

--- a/main/guides/getting-started/explainer-how-to-start-a-local-chain.md
+++ b/main/guides/getting-started/explainer-how-to-start-a-local-chain.md
@@ -11,7 +11,6 @@ In the `dapp-offer-up` sample dapp, configuration for the Agoric containers is s
     "docker:make": "cd contract; docker compose exec agd make -C /workspace/contract",
     "make:help": "make -C contract list",
     "start:contract": "cd contract && yarn start",
-    "print-key": "yarn docker:make print-acct",
     "start:ui": "cd ui && yarn dev",
     "lint": "yarn workspaces run lint",
     "test": "yarn workspaces run test",

--- a/main/guides/getting-started/index.md
+++ b/main/guides/getting-started/index.md
@@ -32,7 +32,7 @@ Before getting started, there are some resources you might want to keep handy in
 
 Currently Agoric supports macOS and Linux (including [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about)). This tutorial is based on an installation of [Ubuntu 22.04 LTS](https://ubuntu.com/download/desktop). If you're using a different operating system, some variation may be required.
 
-## Installing Prerequisites
+## 1. Installing Prerequisites
 
 In this section you'll be installing prerequisite components into your environment. If you're working with your own environment rather than using a fresh Ubuntu install, you may already have some or all of these components already installed.
 
@@ -146,7 +146,7 @@ For more examples and ideas, visit:
 
 </details>
 
-## Creating Your Dapp From a Template
+## 2. Creating Your Dapp From a Template
 
 Now you'll use yarn to pull down the sample dapp. The sample dapp will be placed in a subfolder named `demo`.
 
@@ -154,7 +154,7 @@ Now you'll use yarn to pull down the sample dapp. The sample dapp will be placed
 yarn create @agoric/dapp demo
 ```
 
-## Installing Dapp Dependencies
+## 3. Installing Dapp Dependencies
 
 Now navigate to the `demo` directory and run the `yarn install` command to install any solution dependencies.
 
@@ -178,7 +178,7 @@ On macOS, be sure to install [Xcode](https://apps.apple.com/us/app/xcode/id49779
 
 </details>
 
-## Starting a Local Agoric Blockchain
+## 4. Starting a Local Agoric Blockchain
 
 Now go ahead and start a local Agoric blockchain using the `yarn start:docker` command. Note: This container is several gigabytes in size and may take a few minutes to download.
 
@@ -213,7 +213,7 @@ These are artifacts of replaying historical events.
 
 :::
 
-## Starting the Dapp Smart Contract
+## 5. Starting the Dapp Smart Contract
 
 Use control-C to exit the logs, then start the smart contract. Starting the contract may take a minute or two, so after running this command proceed to the next step.
 
@@ -233,7 +233,7 @@ This `start:contract` script will do a number of things that we will cover in mo
 
 While it's doing all that...
 
-## Setting up a Keplr Wallet Demo Account
+## 6. Setting up a Keplr Wallet Demo Account
 
 Next, ensure you have the [Keplr wallet plug-in](https://www.keplr.app/download) installed.
 
@@ -282,7 +282,7 @@ Click "Save".
 
 </details>
 
-## Starting the Dapp
+## 7. Starting the Dapp
 
 Start the UI for the sample dapp.
 
@@ -306,7 +306,7 @@ Like any [non-native chain](https://chains.keplr.app/), the first time you use t
 
 </details>
 
-## Making an Offer
+## 8. Making an Offer
 
 Once your wallet is connected, click on the "Make Offer" button to purchase 3 properties. Approve the transaction in your Keplr wallet.
 

--- a/main/guides/getting-started/index.md
+++ b/main/guides/getting-started/index.md
@@ -272,11 +272,12 @@ spike siege world rather ordinary upper napkin voice brush oppose junior route t
 
 <img alt="Pasting the mnemonic phrase" src="./assets/041.png" width="400" />
 
-<details><summary>As usual, give your new wallet a name and a password.</summary>
+<details><summary>Give your new wallet a name and a password. Click Next.</summary>
 
 ![Name the newly imported wallet](./assets/042.png)
+</details>
+<details><summary>In the next step, do not select any **chains** except for **Cosmos Hub**. Click "Save". </summary>
 
-Click "Save".
 
 ![Save](./assets/043.png)
 

--- a/main/guides/getting-started/index.md
+++ b/main/guides/getting-started/index.md
@@ -220,18 +220,18 @@ Use control-C to exit the logs, then start the smart contract. Starting the cont
 ```sh
 yarn start:contract
 ```
-
+<details>
+<summary>Behind the Scenes</summary>
 This `start:contract` script will do a number of things that we will cover in more detail later <small>(_[transaction commands](../agoric-cli/agd-query-tx#transaction-commands), [permissioned deployment](../coreeval/)_)</small>:
 
 1. Bundle the contract with `agoric run ...`
-2. Collect some ATOM with `agd tx bank send ...`.
+2. Collect some ATOM with `agd tx bank send ...`. *ATOM refers to the native cryptocurrency of the Cosmos Network.*
 3. Use the ATOM to open a vault to mint enough IST to pay to install the bundles on chain with `agops vaults open ...`.
 4. Install the bundles on chain with `agd tx swingset install-bundle ...`.
 5. Collect enough BLD to pay for a governance deposit with `agd tx bank send ...`
 6. Make a governance proposal to start the contract with `agd tx gov submit-proposal swingset-core-eval ...`.
 7. Vote for the proposal; wait for it to pass.
-
-While it's doing all that...
+</details>
 
 ## 6. Setting up a Keplr Wallet Demo Account
 


### PR DESCRIPTION
I am changing documentation pages for the Getting Started dapp. Here is a summary:

1. The headings/steps on the index page look cluttered (a sentiment shared by multiple new devs), so I have numbered them as a first step.
2. After the `start-contract` command step, there is an explanation of what is happening under the hood. This seems unnecessary; therefore, I am hiding it in `<details>` tag. 
3. In the Keplr installation, there is a missing step regarding `selecting chains` (or rather not selecting them) that confuses some people, so I am adding it.
4. `print-key` has been removed from the code but there are still some references in the docs so I am removing them.