### PR TITLE
Elaborate Contract Basics based on new developer experience

### DIFF
--- a/main/guides/zoe/contract-basics.md
+++ b/main/guides/zoe/contract-basics.md
@@ -35,6 +35,11 @@ Following these `import` statements, we write a simple test that validates that 
 
 <<< @/../snippets/zoe/contracts/test-zoe-hello.js#test1
 
+
+Putting it all together:
+
+<<< @/../snippets/zoe/contracts/test-zoe-01-hello.js#test-01-hello
+
 Let's save this code in a file named `test-hello.js` and run the following command to execute the test:
 
 ```sh

--- a/main/guides/zoe/contract-basics.md
+++ b/main/guides/zoe/contract-basics.md
@@ -1,22 +1,21 @@
 # Smart Contract Basics
 
 Before we look at how to make a contract such as the one in [the
-basic dapp](../getting-started/) in the previous section, let's cover some basics by writing a simple contract that returns a greetings message. We will simply call it _greetings smart contract_. 
+basic dapp](../getting-started/) in the previous section, let's cover some basics by writing a simple contract that returns a greetings message. We will simply call it _hello-world smart contract_. 
 
-A contract is defined by a JavaScript module that exports a `start` function. For our greetings smart contract, the declaration of `start` function looks like this:
+A contract is defined by a JavaScript module that exports a `start` function. For our hello-world smart contract, the declaration of `start` function looks like this:
 
 <<< @/../snippets/zoe/src/01-hello.js#start
 
-For the greetings smart contract, we will have a simple `greet` function apart from `start` function. The `greet` function takes a string as a parameter (for example, name of the person calling the function) and returns a customized greeting message.
+For the hello-world smart contract, we will have a simple `greet` function apart from `start` function. The `greet` function takes a string as a parameter (for example, name of the person calling the function) and returns a customized greeting message.
 
 <<< @/../snippets/zoe/src/01-hello.js#greet
 
-The `greet` function, along with any other public function, must be made accessible through the `publicFacet` of the contract. The `start` function returns an object with a `publicFacet` property. In the greeting contract, the `start` function exposes the `greet` function by defining it as a method of the contract's `publicFacet`, as shown below:
+The `greet` function, along with any other public function, must be made accessible through the `publicFacet` of the contract. The `start` function returns an object with a `publicFacet` property. In the hello-world contract, the `start` function exposes the `greet` function by defining it as a method of the contract's `publicFacet`, as shown below:
 
 <<< @/../snippets/zoe/src/01-hello.js#publicFacet
 
-We wrap the `greet` function in a `Far(...)` call to safely expose it as a remote object, accessible from outside the contract.
-We also give it a suggestive interface name `Hello` for debugging.
+We wrap the value of the `publicFacet` property in a `Far(...)` call to safely expose it as a remote object, accessible from outside the contract. This also gives it a suggestive interface name `Hello` for debugging.
 _We'll discuss [Far in more detail](../js-programming/far) later._
 
 Putting it all together:
@@ -26,7 +25,7 @@ Putting it all together:
 Let us save this code to a file named `01-hello.js` inside `src` directory. 
 ## Using, testing a contract
 
-Before we deploy or start our contract, it is usually a good idea to run a few tests to validate its correctness. Agoric contracts are typically tested using the [ava](https://github.com/avajs/ava) framework. The test file begins with an `import @endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment. We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._ Following these `import` statements, we write a simple test that validates that the `greet` method works as expected.
+Agoric contracts are typically tested using the [ava](https://github.com/avajs/ava) framework. The test file begins with an `import @endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment. We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._ Following these `import` statements, we write a simple test that validates that the `greet` method works as expected.
 
 Putting it all together:
 

--- a/main/guides/zoe/contract-basics.md
+++ b/main/guides/zoe/contract-basics.md
@@ -23,29 +23,30 @@ Putting it all together:
 
 <<< @/../snippets/zoe/src/01-hello.js#contract
 
+Let us save this code to a file named `01-hello.js` inside `src` directory. 
 ## Using, testing a contract
 
 Before we deploy or start our contract, it is usually a good idea to run a few tests that validate its correctness. Agoric contracts are typically tested using the [ava](https://github.com/avajs/ava) framework. They start with `@endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment as below:
 
-<<< @/../snippets/zoe/contracts/test-zoe-hello.js#test-imports
+<<< @/../snippets/zoe/contracts/test-zoe-01-hello.js#test-imports
 
 We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._ Also note the `eslint-disable-next-line` command in the comment on line 3; this is needed in order to suppress an error that arises due to a known issue in `ava`.
 
 Following these `import` statements, we write a simple test that validates that the `greet` method works as expected as below:
 
-<<< @/../snippets/zoe/contracts/test-zoe-hello.js#test1
+<<< @/../snippets/zoe/contracts/test-zoe-01-hello.js#test1
 
 
 Putting it all together:
 
 <<< @/../snippets/zoe/contracts/test-zoe-01-hello.js#test-01-hello
 
-Let's save this code in a file named `test-hello.js` and run the following command to execute the test:
+Let's save this code in a file named `test-01-hello.js` in a `test` directory. Both `src` and `test` directories should lie in the same `contract` directory. Let us run the following command to execute the test:
 
 ```sh
 npx ava --match="contract greets by name"
 ```
-You should see the following output towards the end:
+You should see the following line towards the end of the output:
 ```
 1 test passed
 ```

--- a/main/guides/zoe/contract-basics.md
+++ b/main/guides/zoe/contract-basics.md
@@ -25,7 +25,7 @@ Putting it all together:
 Let us save this code to a file named `01-hello.js` inside `src` directory. 
 ## Using, testing a contract
 
-Agoric contracts are typically tested using the [ava](https://github.com/avajs/ava) framework. The test file begins with an `import @endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment. We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._ Following these `import` statements, we write a simple test that validates that the `greet` method works as expected.
+Agoric contracts are typically tested using the [ava](https://github.com/avajs/ava) framework -  follow the instructions there to install `ava`. The test file begins with an `import @endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment. We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._ Following these `import` statements, we write a simple test that validates that the `greet` method works as expected.
 
 Putting it all together:
 

--- a/main/guides/zoe/contract-basics.md
+++ b/main/guides/zoe/contract-basics.md
@@ -11,7 +11,7 @@ For the greetings smart contract, we will have a simple `greet` function apart f
 
 <<< @/../snippets/zoe/src/01-hello.js#greet
 
-The `greet` function, along with any other public function, must be made accessible through the `publicFacet` of the contract. The `publicFacet` is returned by the `start` function, which initializes the contract. In the greeting contract, the `start` function exposes the `greet` function by defining it as a method of the contract's `publicFacet`, as shown below:
+The `greet` function, along with any other public function, must be made accessible through the `publicFacet` of the contract. The `start` function returns an object with a `publicFacet` property. In the greeting contract, the `start` function exposes the `greet` function by defining it as a method of the contract's `publicFacet`, as shown below:
 
 <<< @/../snippets/zoe/src/01-hello.js#publicFacet
 
@@ -30,7 +30,7 @@ Before we deploy or start our contract, it is usually a good idea to run a few t
 
 <<< @/../snippets/zoe/contracts/test-zoe-01-hello.js#test-imports
 
-We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._ Also note the `eslint-disable-next-line` comment on line 3; this is needed in order to suppress an error that arises due to a known issue in `ava`.
+We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._
 
 Following these `import` statements, we write a simple test that validates that the `greet` method works as expected as below:
 
@@ -44,13 +44,13 @@ Putting it all together:
 Let's save this code in a file named `test-01-hello.js` in a `test` directory. Both `src` and `test` directories should lie in the same `contract` directory. Let us run the following command to execute the test:
 
 ```sh
-npx ava --match="contract greets by name"
+ava --match="contract greets by name"
 ```
 You should see the following line towards the end of the output:
 ```
 1 test passed
 ```
-Congratulations! You have written and tested your first smart contract. Our next goal is to deploy this contract on the local blockchain and make it more interesting by adding some business logic.
+Congratulations! You have written and tested your first smart contract. Our next goal is to learn about the state of a smart contract.
 
 See also:
 

--- a/main/guides/zoe/contract-basics.md
+++ b/main/guides/zoe/contract-basics.md
@@ -7,11 +7,11 @@ A contract is defined by a JavaScript module that exports a `start` function. Fo
 
 <<< @/../snippets/zoe/src/01-hello.js#start
 
-Apart from `start`, we can have extra functions in our contract. These functions may be defined outside or within the `start` function depending on whether they need access to the variables defined in the `start` function.  For the greetings smart contract, we will have a simple `greet` function (outside `start`) that takes a string as a parameter (for example, name of the person calling the function) and returns a customized greeting message.
+For the greetings smart contract, we will have a simple `greet` function apart from `start` function. The `greet` function takes a string as a parameter (for example, name of the person calling the function) and returns a customized greeting message.
 
 <<< @/../snippets/zoe/src/01-hello.js#greet
 
-The `greet` function, along with any other public function, must be made accessible through the `publicFacet` of the contract. The publicFacet is returned by the start function, which initializes the contract. In the greeting contract, the `start` function exposes the `greet` function by defining it as a method of the contract's `publicFacet`, as shown below:
+The `greet` function, along with any other public function, must be made accessible through the `publicFacet` of the contract. The `publicFacet` is returned by the `start` function, which initializes the contract. In the greeting contract, the `start` function exposes the `greet` function by defining it as a method of the contract's `publicFacet`, as shown below:
 
 <<< @/../snippets/zoe/src/01-hello.js#publicFacet
 

--- a/main/guides/zoe/contract-basics.md
+++ b/main/guides/zoe/contract-basics.md
@@ -1,25 +1,22 @@
 # Smart Contract Basics
 
 Before we look at how to make a contract such as the one in [the
-basic dapp](../getting-started/) in the previous section, let's cover some basics.
+basic dapp](../getting-started/) in the previous section, let's cover some basics by writing a simple contract that returns a greetings message. We will simply call it _greetings smart contract_. 
 
-A contract is defined by a JavaScript module that exports a `start` function
-that implements the contract's API.
+A contract is defined by a JavaScript module that exports a `start` function. For our greetings smart contract, the declaration of `start` function looks like this:
 
 <<< @/../snippets/zoe/src/01-hello.js#start
 
-Let's start with a contract with a simple `greet` function:
+Apart from `start`, we can have extra functions in our contract. These functions may be defined outside or within the `start` function depending on whether they need access to the variables defined in the `start` function.  For the greetings smart contract, we will have a simple `greet` function (outside `start`) that takes a string as a parameter (for example, name of the person calling the function) and returns a customized greeting message.
 
 <<< @/../snippets/zoe/src/01-hello.js#greet
 
-The `start` function can expose the `greet` function
-as part of the contract API by making it
-a method of the contract's `publicFacet`:
+The `greet` function, along with any other function besides `start`, must be exposed through the `start` function before it can be called. This is accomplished using a special object called `publicFacet`, which is returned by the `start` function. In the greeting contract, the `start` function exposes the `greet` function by defining it as a method of the contract's `publicFacet`, as shown below:
 
 <<< @/../snippets/zoe/src/01-hello.js#publicFacet
 
-We mark it `Far(...)` to allow callers to use it from outside the contract
-and give it a suggestive interface name for debugging.
+We wrap the reference to `greet` function in a `Far(...)` function call. This will allow callers to use it from outside the contract.
+We also give it a suggestive interface name `Hello` for debugging.
 _We'll discuss [Far in more detail](../js-programming/far) later._
 
 Putting it all together:

--- a/main/guides/zoe/contract-basics.md
+++ b/main/guides/zoe/contract-basics.md
@@ -25,19 +25,26 @@ Putting it all together:
 
 ## Using, testing a contract
 
-Let's use some tests to explore how a contract is used.
-
-Agoric contracts are typically tested
-using the [ava](https://github.com/avajs/ava) framework.
-They start with `@endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment:
+Before we deploy or start our contract, it is usually a good idea to run a few tests that validate its correctness. Agoric contracts are typically tested using the [ava](https://github.com/avajs/ava) framework. They start with `@endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment as below:
 
 <<< @/../snippets/zoe/contracts/test-zoe-hello.js#test-imports
 
-_We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._
+We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._ Also note the `eslint-disable-next-line` command in the comment on line 3; this is needed in order to suppress an error that arises due to a known issue in `ava`.
 
-A test that the `greet` method works as expected looks like:
+Following these `import` statements, we write a simple test that validates that the `greet` method works as expected as below:
 
 <<< @/../snippets/zoe/contracts/test-zoe-hello.js#test1
+
+Let's save this code in a file named `test-hello.js` and run the following command to execute the test:
+
+```sh
+npx ava --match="contract greets by name"
+```
+You should see the following output towards the end:
+```
+1 test passed
+```
+Congratulations! You have written and tested your first smart contract. Our next goal is to deploy this contract on the local blockchain and make it more interesting by adding some business logic to it.
 
 See also:
 

--- a/main/guides/zoe/contract-basics.md
+++ b/main/guides/zoe/contract-basics.md
@@ -11,11 +11,11 @@ Apart from `start`, we can have extra functions in our contract. These functions
 
 <<< @/../snippets/zoe/src/01-hello.js#greet
 
-The `greet` function, along with any other function besides `start`, must be exposed through the `start` function before it can be called. This is accomplished using a special object called `publicFacet`, which is returned by the `start` function. In the greeting contract, the `start` function exposes the `greet` function by defining it as a method of the contract's `publicFacet`, as shown below:
+The `greet` function, along with any other function besides `start`, must be exposed before it can be called. This is accomplished using a special object called `publicFacet`, which is returned by the `start` function. In the greeting contract, the `start` function exposes the `greet` function by defining it as a method of the contract's `publicFacet`, as shown below:
 
 <<< @/../snippets/zoe/src/01-hello.js#publicFacet
 
-We wrap the reference to `greet` function in a `Far(...)` function call. This will allow callers to use it from outside the contract.
+We wrap the `greet` function in a `Far(...)` call to safely expose it as a remote object, accessible from outside the contract.
 We also give it a suggestive interface name `Hello` for debugging.
 _We'll discuss [Far in more detail](../js-programming/far) later._
 
@@ -26,7 +26,7 @@ Putting it all together:
 Let us save this code to a file named `01-hello.js` inside `src` directory. 
 ## Using, testing a contract
 
-Before we deploy or start our contract, it is usually a good idea to run a few tests that validate its correctness. Agoric contracts are typically tested using the [ava](https://github.com/avajs/ava) framework. They start with `@endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment as below:
+Before we deploy or start our contract, it is usually a good idea to run a few tests to validate its correctness. Agoric contracts are typically tested using the [ava](https://github.com/avajs/ava) framework. The test file begins with an `import @endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment as below:
 
 <<< @/../snippets/zoe/contracts/test-zoe-01-hello.js#test-imports
 
@@ -50,7 +50,7 @@ You should see the following line towards the end of the output:
 ```
 1 test passed
 ```
-Congratulations! You have written and tested your first smart contract. Our next goal is to deploy this contract on the local blockchain and make it more interesting by adding some business logic to it.
+Congratulations! You have written and tested your first smart contract. Our next goal is to deploy this contract on the local blockchain and make it more interesting by adding some business logic.
 
 See also:
 

--- a/main/guides/zoe/contract-basics.md
+++ b/main/guides/zoe/contract-basics.md
@@ -25,7 +25,7 @@ Putting it all together:
 Let us save this code to a file named `01-hello.js` inside `src` directory. 
 ## Using, testing a contract
 
-Agoric contracts are typically tested using the [ava](https://github.com/avajs/ava) framework -  follow the instructions there to install `ava`. The test file begins with an `import @endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment. We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._ Following these `import` statements, we write a simple test that validates that the `greet` method works as expected.
+Agoric contracts are typically tested using the [ava](https://github.com/avajs/ava) framework. The test file begins with an `import @endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment. We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._ Following these `import` statements, we write a simple test that validates that the `greet` method works as expected.
 
 Putting it all together:
 
@@ -34,7 +34,7 @@ Putting it all together:
 Let's save this code in a file named `test-01-hello.js` in a `test` directory. Both `src` and `test` directories should lie in the same `contract` directory. Let us run the following command to execute the test:
 
 ```sh
-ava --match="contract greets by name"
+yarn ava --match="contract greets by name"
 ```
 You should see the following line towards the end of the output:
 ```

--- a/main/guides/zoe/contract-basics.md
+++ b/main/guides/zoe/contract-basics.md
@@ -26,16 +26,7 @@ Putting it all together:
 Let us save this code to a file named `01-hello.js` inside `src` directory. 
 ## Using, testing a contract
 
-Before we deploy or start our contract, it is usually a good idea to run a few tests to validate its correctness. Agoric contracts are typically tested using the [ava](https://github.com/avajs/ava) framework. The test file begins with an `import @endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment as below:
-
-<<< @/../snippets/zoe/contracts/test-zoe-01-hello.js#test-imports
-
-We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._
-
-Following these `import` statements, we write a simple test that validates that the `greet` method works as expected as below:
-
-<<< @/../snippets/zoe/contracts/test-zoe-01-hello.js#test1
-
+Before we deploy or start our contract, it is usually a good idea to run a few tests to validate its correctness. Agoric contracts are typically tested using the [ava](https://github.com/avajs/ava) framework. The test file begins with an `import @endo/init` to establish a [Hardened JavaScript](../js-programming/hardened-js) environment. We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._ Following these `import` statements, we write a simple test that validates that the `greet` method works as expected.
 
 Putting it all together:
 

--- a/main/guides/zoe/contract-basics.md
+++ b/main/guides/zoe/contract-basics.md
@@ -11,7 +11,7 @@ Apart from `start`, we can have extra functions in our contract. These functions
 
 <<< @/../snippets/zoe/src/01-hello.js#greet
 
-The `greet` function, along with any other function besides `start`, must be exposed before it can be called. This is accomplished using a special object called `publicFacet`, which is returned by the `start` function. In the greeting contract, the `start` function exposes the `greet` function by defining it as a method of the contract's `publicFacet`, as shown below:
+The `greet` function, along with any other public function, must be made accessible through the `publicFacet` of the contract. The publicFacet is returned by the start function, which initializes the contract. In the greeting contract, the `start` function exposes the `greet` function by defining it as a method of the contract's `publicFacet`, as shown below:
 
 <<< @/../snippets/zoe/src/01-hello.js#publicFacet
 
@@ -30,7 +30,7 @@ Before we deploy or start our contract, it is usually a good idea to run a few t
 
 <<< @/../snippets/zoe/contracts/test-zoe-01-hello.js#test-imports
 
-We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._ Also note the `eslint-disable-next-line` command in the comment on line 3; this is needed in order to suppress an error that arises due to a known issue in `ava`.
+We also import `E()` in order to make asynchronous method calls and `test` function from `ava`. _We'll talk more about [using `E()` for async method calls](../js-programming/eventual-send) later._ Also note the `eslint-disable-next-line` comment on line 3; this is needed in order to suppress an error that arises due to a known issue in `ava`.
 
 Following these `import` statements, we write a simple test that validates that the `greet` method works as expected as below:
 

--- a/snippets/zoe/contracts/test-zoe-01-hello.js
+++ b/snippets/zoe/contracts/test-zoe-01-hello.js
@@ -5,8 +5,6 @@ import { E } from '@endo/far';
 // eslint-disable-next-line import/no-unresolved -- https://github.com/avajs/ava/issues/2951
 import test from 'ava';
 // #endregion test-imports
-import * as state from '../src/02-state.js';
-import * as access from '../src/03-access.js';
 // #region test1
 import { start } from '../src/01-hello.js';
 

--- a/snippets/zoe/contracts/test-zoe-01-hello.js
+++ b/snippets/zoe/contracts/test-zoe-01-hello.js
@@ -1,0 +1,19 @@
+// #region test-01-hello
+// #region test-imports
+import '@endo/init';
+import { E } from '@endo/far';
+// eslint-disable-next-line import/no-unresolved -- https://github.com/avajs/ava/issues/2951
+import test from 'ava';
+// #endregion test-imports
+import * as state from '../src/02-state.js';
+import * as access from '../src/03-access.js';
+// #region test1
+import { start } from '../src/01-hello.js';
+
+test('contract greets by name', async t => {
+  const { publicFacet } = start();
+  const actual = await E(publicFacet).greet('Bob');
+  t.is(actual, 'Hello, Bob!');
+});
+// #endregion test1
+// #endregion test-01-hello


### PR DESCRIPTION
This pull request includes changes to the `contract-basics.md` file, which generates the documentation page titled `Smart Contract Basics`. Here's a summary of the modifications:

1. I have revised the language used in the section introducing the greetings smart contract. The wording is now more formal and easier to follow.
2. I've added additional text to the testing section of the contract basics to enhance readability.
3. I've removed extraneous code from the `test-zoe-hello.js` file, specifically code unrelated to the greetings smart contract. To maintain existing links and references, I've preserved the original file without alterations. Additionally, I've created a new file named `test-zoe-01-hello.js`, which will be used in the contract basics documentation.
4. The docs in the first part of `contract-basics` links/makes references to only `test-zoe-01-hello.js` file.

