### PR TITLE
fix: broken internal links at multiple pages issue #1071

### DIFF
--- a/main/guides/agoric-cli/agd-query-tx.md
+++ b/main/guides/agoric-cli/agd-query-tx.md
@@ -9,7 +9,7 @@ This section focusses on commands relevant to developing and deploying smart con
 
 - [Validators topics \- Agoric Community Forum](https://community.agoric.com/c/validators/9)
 - [Governance topics \- Agoric Community Forum](https://community.agoric.com/c/governance/6)
-- [Delegator Guide \(CLI\) \| Cosmos Hub](https://hub.cosmos.network/main/delegators/delegator-guide-cli.html)
+- [Delegator Guide \(CLI\) \| Cosmos Hub](https://hub.cosmos.network/delegators/delegator-guide-cli.html)
 
 :::
 

--- a/main/guides/coreeval/index.md
+++ b/main/guides/coreeval/index.md
@@ -4,7 +4,7 @@ Until mainnet enters the Mainnet-3 phase of the [multi-phase mainnet rollout](ht
 permissionless [contract installation with Zoe](/guides/zoe/#contract-installation)
 is limited to development environments.
 
-Until then, permission to deploy contracts can be granted using an Agoric extension to [Cosmos SDK Governance](https://hub.cosmos.network/main/delegators/delegator-guide-cli.html#participating-in-governance) called `swingset.CoreEval`. As discussed in [governance using Hardened JavaScript: swingset\.CoreEval](https://community.agoric.com/t/bld-staker-governance-using-hardened-javascript-swingset-coreeval/99),
+Until then, permission to deploy contracts can be granted using an Agoric extension to [Cosmos SDK Governance](https://hub.cosmos.network/delegators/delegator-guide-cli.html#participating-in-governance) called `swingset.CoreEval`. As discussed in [governance using Hardened JavaScript: swingset\.CoreEval](https://community.agoric.com/t/bld-staker-governance-using-hardened-javascript-swingset-coreeval/99),
 if such a proposal passes, its JavaScript code is run with ocaps extracted using the proposal's permitted capabilities, which the code can combine to perform privileged tasks.
 
 To make a proposal to deploy a contract:

--- a/main/guides/coreeval/proposal.md
+++ b/main/guides/coreeval/proposal.md
@@ -122,7 +122,7 @@ There are also several more promise spaces one level down, including:
 - `powers.issuer`
 - `powers.brand`
 
-The `installContract` helper calls `E(zoe).installBundleID(bundleID)` to create an `Installation`, much like our earlier discussion of [Contract installation](http://localhost:8080/guides/zoe/#contract-installation).
+The `installContract` helper calls `E(zoe).installBundleID(bundleID)` to create an `Installation`, much like our earlier discussion of [Contract installation](../zoe/#contract-installation).
 It also calls `powers.installation[name].resolve(installation)`.
 
 ```js

--- a/main/guides/integration/chain-integration.md
+++ b/main/guides/integration/chain-integration.md
@@ -9,13 +9,8 @@ This section points at relevant reference documentation for the underlying `cosm
 
 The Agoric Network currently uses `cosmos-sdk` v0.45. The general Cosmos documentation for this version can be [found here](https://docs.cosmos.network/v0.45/), including structure and`golang` documentation, and REST API documentation. 
 
-Use the [v0.45.1 version of the  REST API](https://v1.cosmos.network/rpc/v0.45.1) for accessing the chain. To use the "Try it out" functionality, change the Base URL to `agoric-api.polkachu.com`:
 
-
-| ![Alt name of image](./assets/cosmos-api.png) |
-|-|
-
-The chain can also be accessed via JavaScript using the [`cosmjs` library](https://github.com/cosmos/cosmjs) (and [associated tutorials](https://tutorials.cosmos.network/tutorials/7-cosmjs/1-cosmjs-intro.html)), or using [CosmosKit](https://cosmoskit.com/).
+The chain can also be accessed via JavaScript using the [`cosmjs` library](https://github.com/cosmos/cosmjs) (and [associated tutorials](https://tutorials.cosmos.network/tutorials/7-cosmjs/1-cosmjs-intro.html)), or using [CosmosKit](https://cosmology.zone/products/cosmos-kit).
 
 ## Chain resources
 
@@ -25,14 +20,6 @@ The chain can also be accessed via JavaScript using the [`cosmjs` library](https
 - The base unit for staking is `ubld` (corresponding to `uatom` for Cosmos Hub)
 - The command utility of the agoric chain is `agd` (corresponding to [`simd` for the Cosmos Hub](https://docs.cosmos.network/v0.45/run-node/interact-node.html)). 
 ---
-# Tools
-## Building `agd`
-
-The `agd` command line tool can be built as described in the Agoric [getting-started documentation](https://docs.agoric.com/guides/getting-started#build-the-cosmic-swingset-package). The linked step builds `agd`. To confirm that `agd` is in your `$PATH`, execute
-```
-agd version --long
-```
-
 # FAQ
 
 - How are transactions encoded?

--- a/main/guides/integration/chain-integration.md
+++ b/main/guides/integration/chain-integration.md
@@ -9,8 +9,13 @@ This section points at relevant reference documentation for the underlying `cosm
 
 The Agoric Network currently uses `cosmos-sdk` v0.45. The general Cosmos documentation for this version can be [found here](https://docs.cosmos.network/v0.45/), including structure and`golang` documentation, and REST API documentation. 
 
+Use the [v0.45.1 version of the  REST API](https://v1.cosmos.network/rpc/v0.45.1) for accessing the chain. To use the "Try it out" functionality, change the Base URL to `agoric-api.polkachu.com`:
 
-The chain can also be accessed via JavaScript using the [`cosmjs` library](https://github.com/cosmos/cosmjs) (and [associated tutorials](https://tutorials.cosmos.network/tutorials/7-cosmjs/1-cosmjs-intro.html)), or using [CosmosKit](https://cosmology.zone/products/cosmos-kit).
+
+| ![Alt name of image](./assets/cosmos-api.png) |
+|-|
+
+The chain can also be accessed via JavaScript using the [`cosmjs` library](https://github.com/cosmos/cosmjs) (and [associated tutorials](https://tutorials.cosmos.network/tutorials/7-cosmjs/1-cosmjs-intro.html)), or using [CosmosKit](https://cosmoskit.com/).
 
 ## Chain resources
 
@@ -20,6 +25,14 @@ The chain can also be accessed via JavaScript using the [`cosmjs` library](https
 - The base unit for staking is `ubld` (corresponding to `uatom` for Cosmos Hub)
 - The command utility of the agoric chain is `agd` (corresponding to [`simd` for the Cosmos Hub](https://docs.cosmos.network/v0.45/run-node/interact-node.html)). 
 ---
+# Tools
+## Building `agd`
+
+The `agd` command line tool can be built as described in the Agoric [getting-started documentation](https://docs.agoric.com/guides/getting-started#build-the-cosmic-swingset-package). The linked step builds `agd`. To confirm that `agd` is in your `$PATH`, execute
+```
+agd version --long
+```
+
 # FAQ
 
 - How are transactions encoded?

--- a/main/guides/zoe/contracts/otc-desk.md
+++ b/main/guides/zoe/contracts/otc-desk.md
@@ -8,8 +8,8 @@
 ![Building a Composable DeFi Contract](./assets/title.jpg)
 
 This is the OTC Desk contract from the "Building a
-Composable DeFi Contract" episode of Cosmos Code With
-Us workshop.
+Composable DeFi Contract" episode of [Cosmos Code With
+Us workshop](https://www.youtube.com/watch?v=e9dMkC2oFh8).
 
 [Watch the replay of the
 workshop](https://www.youtube.com/watch?v=faxrecQgEio):

--- a/main/guides/zoe/contracts/otc-desk.md
+++ b/main/guides/zoe/contracts/otc-desk.md
@@ -7,9 +7,9 @@
 
 ![Building a Composable DeFi Contract](./assets/title.jpg)
 
-This is the OTC Desk contract from the ["Building a
+This is the OTC Desk contract from the "Building a
 Composable DeFi Contract" episode of Cosmos Code With
-Us](https://cosmos.network/series/code-with-us/building-a-composable-defi-contract).
+Us workshop.
 
 [Watch the replay of the
 workshop](https://www.youtube.com/watch?v=faxrecQgEio):

--- a/main/reference/ertp-api/ertp-data-types.md
+++ b/main/reference/ertp-api/ertp-data-types.md
@@ -71,7 +71,7 @@ A **DisplayInfo** data type is associated with a **[Brand](./brand)** and gives 
 to display that **Brand**'s **[Amounts](#amount)**. **DisplayInfo** has one optional property,
 **decimalPlaces**, which takes a non-negative integer value.
 
-The **decimalPlaces** property tells the [display software](https://github.com/Agoric/agoric-sdk/tree/master/packages/ui-components)
+The **decimalPlaces** property tells the [display software](https://github.com/Agoric/ui-kit)
 how many places to move the decimal point over to the left so as to display the value
 in the commonly used denomination (e.g., display "10.00 dollars" rather than "1000 cents").
 

--- a/main/reference/zoe-api/zoe.md
+++ b/main/reference/zoe-api/zoe.md
@@ -364,8 +364,6 @@ Every **Keyword** in **give** must have a corresponding **payment**.
 const paymentKeywordRecord = harden({ Asset: quatloosPayment });
 ```
 
-<a href="offerargs"></a>
-
 ### Offer Arguments
 
 **offerArgs** is an optional CopyRecord that can be used to pass additional arguments to the

--- a/main/reference/zoe-api/zoe.md
+++ b/main/reference/zoe-api/zoe.md
@@ -364,6 +364,7 @@ Every **Keyword** in **give** must have a corresponding **payment**.
 const paymentKeywordRecord = harden({ Asset: quatloosPayment });
 ```
 
+<a id="offerargs"></a>
 ### Offer Arguments
 
 **offerArgs** is an optional CopyRecord that can be used to pass additional arguments to the


### PR DESCRIPTION
Fixed a few broken links (not all) [here](https://github.com/Agoric/documentation/issues/1071).

1. Link to https://hub.cosmos.network/delegators/delegator-guide-cli.html is fixed on two pages.
2. ~Removed parts of text with outdated links in `chain-integration` docs. @dtribble Let me know if you want me to keep these parts and fix them with by linking something.~
3. Broken link fixed in coreeval/proposal.md
4. Removed probably a typo link in zoe.md. @gibson042 Please confirm that it was a typo.
5. Text `display-software` in ertp-data-types.md was linked to `ui-component` package which has been removed from repo - linked it to `ui-kit` repo now. 
6.Link to page "Cosmos Code with Us workshop" is broken as page was removed from cosmos website. I removed the link but kept the text.

This should fix all the *internal* broken links except the ones in `chain-integration.md` mentioned in #1071. 