### PR TITLE
adding a3p to glossary

### DIFF
--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -6,6 +6,9 @@ sidebar: auto
 
 This page lists words, expressions, or concepts used by the Agoric technology stack.
 
+## a3p (Agoric-3 Proposal)
+Acronym to refer to a proposal submitted on the agoric-3 mainnet
+
 ## Agoric CLI
 
 A command line interface for initializing, deploying, and starting Agoric projects, as well as installing dependencies. See the [Agoric CLI documentation](/guides/agoric-cli/) for more information.

--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -6,8 +6,9 @@ sidebar: auto
 
 This page lists words, expressions, or concepts used by the Agoric technology stack.
 
-## a3p (Agoric-3 Proposal)
-Acronym to refer to a proposal submitted on the agoric-3 mainnet
+## a3p
+
+A short form of [agoric-3-proposals](https://github.com/Agoric/agoric-3-proposals/), a repository containing "Proposals run or planned for Mainnet (agoric-3)". The resulting docker images supply a test network environment for dapps, as discussed in [getting started](/guides/getting-started/).
 
 ## Agoric CLI
 


### PR DESCRIPTION
adding a3p definition into glossary. Assuming it should go first 