### PR TITLE
Adding Baggage-Exo-ICA-Orchestration-Zones to Glossary 

### DIFF
--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -323,6 +323,10 @@ Guide](https://github.com/endojs/endo/blob/HEAD/packages/ses/docs/guide.md) for 
 The Inter-Blockchain Communication protocol, used by blockchains to communicate with each other.
 For more details, see [What developers need to know about inter-blockchain communication](https://www.computerweekly.com/blog/Open-Source-Insider/What-developers-need-to-know-about-inter-blockchain-communication).
 
+## Intercahin Account (ICA)
+
+Interchain accounts on Agoric enable an Agoric smart contract to control an account on another blockchain within the Cosmos ecosystem facilitated by [Agoric Orchestration API](#orchestration). This feature leverages the [Inter-Blockchain Communication (IBC)](#ibc) protocol to facilitate interactions and transactions across different blockchains seamlessly.
+
 ## Invitation
 
 A [payment](#payment) whose amount represents (and is required for) participation in a contract instance.

--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -100,6 +100,10 @@ For more information, see the [ERTP documentation's AmountValue section](/guides
 [Purses](#purse) and [payments](#payment) are AssetHolders. These are objects that contain
 digital assets in the quantity specified by an [amount](#amount).
 
+## Baggage
+
+`baggage` is a `MapStore` that provides a way to preserve state and behavior of objects between smart [contract upgrades](guides/zoe/contract-upgrade) in a way that preserves identity of objects as seen from other [vats](#vat).
+
 ## BigInt
 
 In [ERTP AmountMath](/guides/ertp/amount-math), we use the JavaScript [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) type for the `value` of fungible amounts in order to avoid overflow risks from using the usual JavaScript `Number` type.

--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -463,6 +463,15 @@ the user either gets what they said they wanted, or gets back what they original
 escrowed (a refund). One reason this is possible is if a [proposal](#proposal) doesn't match what the contract expects to do, it
 can immediately cause the [seat](#seat) to exit, getting back the amount it offered.
 
+## Orchestration 
+
+Orchestration API is a tool to help developers build seamless applications out of disparate interoperable chains and services.
+This composability allows for the development of user-centric applications
+ that leverage the unique strengths of different blockchain ecosystems.
+Orchestration integrates with existing Agoric components ([SwingSet](/guides/platform/#swingset), Cosmos modules) and introduces
+ vat-orchestration. This [vat](/glossary/#vat) manages Inter-Chain Account (ICA) identities and connections to host
+  chains, ensuring proper transaction authorization.
+
 ## Passable
 
 A _passable_ is something that can be sent to and from remote objects.

--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -278,7 +278,7 @@ For details, see [`E(zoe).offer(...)`](/reference/zoe-api/zoe#proposals).
 
 ## Exo
 
-An Exo object is an exposed Remotable object with methods (aka a `Far` object) which is 
+An Exo object is an exposed Remotable object with methods (aka a [`Far`](/guides/js-programming/far) object) which is 
 normally defined with an `InterfaceGuard` as a protective outer layer, providing the first
  layer of defensiveness.
 
@@ -339,7 +339,7 @@ For more details, see [What developers need to know about inter-blockchain commu
 
 ## Intercahin Account (ICA)
 
-Interchain accounts on Agoric enable an Agoric smart contract to control an account on another blockchain within the Cosmos ecosystem facilitated by [Agoric Orchestration API](#orchestration). This feature leverages the [Inter-Blockchain Communication (IBC)](#ibc) protocol to facilitate interactions and transactions across different blockchains seamlessly.
+Interchain Accounts are an [IBC](#ibc) feature used in Agoric's [Orchestration API](#orchestration) to enable an Agoric smart contract to control an account on another blockchain within the Cosmos ecosystem. This feature leverages the [Inter-Blockchain Communication (IBC)](#ibc) protocol to facilitate interactions and transactions across different blockchains seamlessly.
 
 ## Invitation
 
@@ -487,8 +487,9 @@ Orchestration API is a tool to help developers build seamless applications out o
 This composability allows for the development of user-centric applications
  that leverage the unique strengths of different blockchain ecosystems.
 Orchestration integrates with existing Agoric components ([SwingSet](/guides/platform/#swingset), Cosmos modules) and introduces
- vat-orchestration. This [vat](/glossary/#vat) manages Inter-Chain Account (ICA) identities and connections to host
+ vat-orchestration. This [vat](/glossary/#vat) manages [Inter-Chain Account (ICA)](#intercahin-account-ica) identities and connections to host
   chains, ensuring proper transaction authorization.
+  For more information, see the [Orchestration API](/guides/orchestration/).
 
 ## Passable
 

--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -102,7 +102,7 @@ digital assets in the quantity specified by an [amount](#amount).
 
 ## Baggage
 
-`baggage` is a `MapStore` that provides a way to preserve state and behavior of objects between smart [contract upgrades](guides/zoe/contract-upgrade) in a way that preserves identity of objects as seen from other [vats](#vat).
+`baggage` is a `MapStore` that provides a way to preserve state and behavior of objects between smart [contract upgrades](/guides/zoe/contract-upgrade) in a way that preserves identity of objects as seen from other [vats](#vat).
 
 ## BigInt
 

--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -647,3 +647,10 @@ patterns into reusable helpers. See the [Zoe Helpers API](/reference/zoe-api/zoe
 ## Zoe Service
 
 A set of API methods for deploying and working with smart contracts. See [Zoe Service API](/reference/zoe-api/zoe).
+
+## Zones
+
+Each Zone provides an API that allows the allocation of [Exo objects](#exo) and [Stores (object collections)](https://github.com/Agoric/agoric-sdk/tree/master/packages/store/README.md) which use the same underlying persistence mechanism.  This allows library code to be agnostic to whether its objects are backed purely by the JS heap (ephemeral), pageable out to disk (virtual) or can be revived after a vat upgrade (durable).
+
+See [SwingSet vat upgrade documentation](https://github.com/Agoric/agoric-sdk/tree/master/packages/SwingSet/docs/vat-upgrade.md) for more example use of the zone API.
+

--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -276,6 +276,16 @@ See [`E()`](#e) above.
 An object specifying how an [offer](#offer) can be cancelled, such as on demand or by a deadline.
 For details, see [`E(zoe).offer(...)`](/reference/zoe-api/zoe#proposals).
 
+## Exo
+
+An Exo object is an exposed Remotable object with methods (aka a `Far` object) which is 
+normally defined with an `InterfaceGuard` as a protective outer layer, providing the first
+ layer of defensiveness.
+
+This [`@endo/exo` package](https://github.com/endojs/endo/tree/master/packages/exo) defines 
+the APIs for making Exo objects, and for defining ExoClasses and ExoClassKits for making Exo
+ objects.
+
 ## Facet
 
 A _facet_ is an object that exposes an API or particular view of some larger entity, which may be an object itself.

--- a/main/guides/orchestration/index.md
+++ b/main/guides/orchestration/index.md
@@ -5,12 +5,12 @@ This composability allows for the development of user-centric applications
  that leverage the unique strengths of different blockchain ecosystems.
 
 The Agoric Orchestration API simplifies interactions between multiple networks, particularly those
- using the Inter-Blockchain Communication (IBC) protocol within Cosmos. The API acts as an 
+ using the [Inter-Blockchain Communication (IBC)](/glossary/#ibc) protocol within Cosmos. The API acts as an 
  abstraction layer, streamlining multi-step processes.
 
 
-Orchestration integrates with existing Agoric components (SwingSet, Cosmos modules) and introduces
- vat-orchestration. This vat manages Inter-Chain Account (ICA) identities and connections to host
+Orchestration integrates with existing Agoric components ([SwingSet](/guides/platform/#swingset), Cosmos modules) and introduces
+ vat-orchestration. This [vat](/glossary/#vat) manages Inter-Chain Account (ICA) identities and connections to host
   chains, ensuring proper transaction authorization.
 
 The orchestration client handles asynchronous tasks and complex workflows, including those 

--- a/main/guides/orchestration/index.md
+++ b/main/guides/orchestration/index.md
@@ -24,7 +24,7 @@ user-controlled environment on the Agoric platform.
 
 ```javascript
 const amount = coins(100, 'utia');
-const celestiaChain = await orchestration.getChain('celestia');
+const celestiaChain = await orchestrator.getChain('celestia');
 const icaCelestia = await celestiaChain.createAccount();
 await icaOsmosis.transfer(icaCelestia.getAddress(), amount);
 await E(timerService).delay(600n);


### PR DESCRIPTION
Added entries for 

- Baggage
- Exo
- Interchain Accounts (ICA)
- Orchestration
- Zones

to glossary. Most of the text added was pulled from corresponding readme files.