### PR TITLE
fix tutorial index links

### DIFF
--- a/main/guides/getting-started/tutorial/index.md
+++ b/main/guides/getting-started/tutorial/index.md
@@ -4,12 +4,12 @@ Here you will find tutorials to implement different types of dApp using Agoric.
 
 ## Your First Agoric Dapp
 
-If you are just starting with Agoric, refer to our guide on creating [your first Agoric dApp](https://docs.agoric.com/guides/zoe/contract-basics.html).
+If you are just starting with Agoric, refer to our guide on creating [your first Agoric dApp](../).
 
 ## UI Tutorial
 
-If you have already developed your smart contract, you can explore our detailed guide on [how to build your own dApp UI](https://docs.agoric.com/guides/getting-started/ui-tutorial/).
+If you have already developed your smart contract, you can explore our detailed guide on [how to build your own dApp UI](../ui-tutorial/).
 
 ## Dapp Basics
 
-Explore our [dapp-agoric-basics tutorial](https://docs.agoric.com/guides/getting-started/tutorial-dapp-agoric-basics.html) for more detailed examples of Agoric dApps.
+Explore our [dapp-agoric-basics tutorial](../tutorial-dapp-agoric-basics.html) for more detailed examples of Agoric dApps.


### PR DESCRIPTION
the "your first dapp" link went to contract basics

and it opened in a new window because it was absolute. Links within the docs are relative.