### PR TITLE
docs: deprecate methods for issuer

### DIFF
--- a/main/guides/ertp/issuers-and-mints.md
+++ b/main/guides/ertp/issuers-and-mints.md
@@ -59,24 +59,26 @@ API Reference](/reference/ertp-api/).
   - [anIssuer.burn(payment, optAmount)](/reference/ertp-api/issuer#anissuer-burn-payment-optamount)
     - Destroy all of the digital assets in the `payment`.
     - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#burn
-  - [anIssuer.claim(payment, optAmount)](/reference/ertp-api/issuer#anissuer-claim-payment-optamount)
-    - Transfer all digital assets from `payment` to a new Payment.
-    - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#claim
-  - [anIssuer.combine(paymentsArray)](/reference/ertp-api/issuer#anissuer-combine-paymentsarray-opttotalamount)
-    - Combine multiple Payments into one new Payment.
-    - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#combine
   - [anIssuer.getAmountOf(payment)](/reference/ertp-api/issuer#anissuer-getamountof-payment)
     - Describe the `payment`'s balance as an Amount.
     - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#getAmountOf
   - [anIssuer.isLive(payment)](/reference/ertp-api/issuer#anissuer-islive-payment)
     - Return `true` if the `payment` was created by the issuer and is available for use (has not been consumed or burned).
     - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#isLive
+::: warning DEPRECATED
   - [anIssuer.split(payment, paymentAmountA)](/reference/ertp-api/issuer#anissuer-split-payment-paymentamounta)
     - Split a single `payment` into two new Payments.
     - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#split
   - [anIssuer.splitMany(payment, paymentAmountArray)](/reference/ertp-api/issuer#anissuer-splitmany-payment-amountarray)
     - Split a single `payment` into multiple Payments.
     - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#splitMany
+- [anIssuer.claim(payment, optAmount)](/reference/ertp-api/issuer#anissuer-claim-payment-optamount)
+    - Transfer all digital assets from `payment` to a new Payment.
+    - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#claim
+  - [anIssuer.combine(paymentsArray)](/reference/ertp-api/issuer#anissuer-combine-paymentsarray-opttotalamount)
+    - Combine multiple Payments into one new Payment.
+    - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#combine
+:::
 
 
 **Related Methods:**

--- a/main/guides/ertp/purses-and-payments.md
+++ b/main/guides/ertp/purses-and-payments.md
@@ -153,23 +153,11 @@ API Reference](/reference/ertp-api/index).
 - [anIssuer.burn(payment, optAmount)](/reference/ertp-api/issuer#anissuer-burn-payment-optamount)
   - Destroy all of the digital assets in the `payment`.
   - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#burn
-- [anIissuer.claim(payment, optAmount)](/reference/ertp-api/issuer#anissuer-claim-payment-optamount)
-  - Transfer all digital assets from `payment` to a new Payment.
-  - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#claim
-- [anIssuer.combine(paymentsArray)](/reference/ertp-api/issuer#anissuer-combine-paymentsarray-opttotalamount)
-  - Combine multiple Payments into one new Payment.
-  - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#combine
 - [anIssuer.getAmountOf(payment)](/reference/ertp-api/issuer#anissuer-getamountof-payment)
   - Describe the `payment`'s balance as an Amount.
   - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#getAmountOf
 - [anIssuer.isLive(payment)](/reference/ertp-api/issuer#anissuer-islive-payment)
   - Return `true` if the `payment` was created by the issuer and is available for use (has not been consumed or burned).
-- [anIssuer.split(payment, paymentAmountA)](/reference/ertp-api/issuer#anissuer-split-payment-paymentamounta)
-  - Split a single `payment` into two new Payments.
-  - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#split
-- [anIssuer.splitMany(payment, amountArray)](/reference/ertp-api/issuer#anissuer-splitmany-payment-amountarray)
-  - Split a single `payment` into multiple Payments.
-  - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#splitManyConcise
 - [aMint.mintPayment(newAmount)](/reference/ertp-api/mint#amint-mintpayment-newamount)
   - Create new digital assets of the `mint`'s associated `brand`.
   - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#mintMintPayment
@@ -182,6 +170,20 @@ API Reference](/reference/ertp-api/index).
 - [aPurse.withdraw(amount)](/reference/ertp-api/purse#apurse-withdraw-amount)
   - Withdraw the `amount` of specified digital assets from `purse` into a new `payment`.
   - <<< @/../snippets/ertp/guide/test-purses-and-payments.js#withdraw
+::: warning DEPRECATED
+- [anIssuer.combine(paymentsArray)](/reference/ertp-api/issuer#anissuer-combine-paymentsarray-opttotalamount)
+  - Combine multiple Payments into one new Payment.
+  - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#combine
+- [anIissuer.claim(payment, optAmount)](/reference/ertp-api/issuer#anissuer-claim-payment-optamount)
+  - Transfer all digital assets from `payment` to a new Payment.
+  - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#claim
+- [anIssuer.splitMany(payment, amountArray)](/reference/ertp-api/issuer#anissuer-splitmany-payment-amountarray)
+  - Split a single `payment` into multiple Payments.
+  - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#splitManyConcise
+- [anIssuer.split(payment, paymentAmountA)](/reference/ertp-api/issuer#anissuer-split-payment-paymentamounta)
+  - Split a single `payment` into two new Payments.
+  - <<< @/../snippets/ertp/guide/test-issuers-and-mints.js#split
+:::
 
 ## Purse and Payment Example
 

--- a/main/reference/ertp-api/issuer.md
+++ b/main/reference/ertp-api/issuer.md
@@ -200,6 +200,16 @@ const originalPayment = quatloosMint.mintPayment(amountExpectedToTransfer);
 
 const newPayment = quatloosIssuer.claim(originalPayment, amountToTransfer);
 ```
+## anIssuer.isLive(payment)
+- **payment**: **[Payment](./payment)**
+- Returns: **Boolean**
+
+Returns **true** if the *payment* was created by the **Issuer** and is available for use 
+(i.e., it hasn't been consumed).
+
+If *payment* is a promise, the method proceeds after it resolves to a **Payment**.
+
+::: warning DEPRECATED
 
 ## anIssuer.combine(paymentsArray, optTotalAmount?)
 - **paymentsArray**: **Array&lt;[Payment](./payment)>**
@@ -286,12 +296,4 @@ const badAmounts = Array(2).fill(AmountMath.make(quatloosBrand, 10n));
 // 20n does not equal 1000n, so throws error
 quatloosIssuer.splitMany(payment, badAmounts);
 ```
-
-## anIssuer.isLive(payment)
-- **payment**: **[Payment](./payment)**
-- Returns: **Boolean**
-
-Returns **true** if the *payment* was created by the **Issuer** and is available for use 
-(i.e., it hasn't been consumed).
-
-If *payment* is a promise, the method proceeds after it resolves to a **Payment**.
+:::

--- a/main/reference/ertp-api/issuer.md
+++ b/main/reference/ertp-api/issuer.md
@@ -177,6 +177,17 @@ const paymentToBurn = quatloosMint.mintPayment(amountToBurn);
 const burntAmount = quatloosIssuer.burn(paymentToBurn, amountToBurn);
 ```
 
+## anIssuer.isLive(payment)
+- **payment**: **[Payment](./payment)**
+- Returns: **Boolean**
+
+Returns **true** if the *payment* was created by the **Issuer** and is available for use 
+(i.e., it hasn't been consumed).
+
+If *payment* is a promise, the method proceeds after it resolves to a **Payment**.
+
+::: warning DEPRECATED
+
 ## anIssuer.claim(payment, optAmount?)
 - **payment**: **[Payment](./payment)**
 - **optAmount**: **[Amount](./ertp-data-types#amount)** - Optional.
@@ -200,16 +211,6 @@ const originalPayment = quatloosMint.mintPayment(amountExpectedToTransfer);
 
 const newPayment = quatloosIssuer.claim(originalPayment, amountToTransfer);
 ```
-## anIssuer.isLive(payment)
-- **payment**: **[Payment](./payment)**
-- Returns: **Boolean**
-
-Returns **true** if the *payment* was created by the **Issuer** and is available for use 
-(i.e., it hasn't been consumed).
-
-If *payment* is a promise, the method proceeds after it resolves to a **Payment**.
-
-::: warning DEPRECATED
 
 ## anIssuer.combine(paymentsArray, optTotalAmount?)
 - **paymentsArray**: **Array&lt;[Payment](./payment)>**

--- a/main/reference/ertp-api/payment.md
+++ b/main/reference/ertp-api/payment.md
@@ -51,8 +51,6 @@ on or return a **Payment**.
 
 - [**anIssuer.burn()**](./issuer#anissuer-burn-payment-optamount)
   - Destroys all of the digital assets in the **Payment**.
-- [**anIssuer.combine()**](./issuer#anissuer-combine-paymentsarray-opttotalamount)
-  - Combines multiple **Payments** into one new **Payment**.
 - [**anIssuer.getAmountOf()**](./issuer#anissuer-getamountof-payment)
   - Describes the **Payment**'s balance as an **Amount**.
 - [**anIssuer.isLive()**](./issuer#anissuer-islive-payment)
@@ -72,4 +70,6 @@ on or return a **Payment**.
   - Split a single **Payment** into multiple **Payments**.
 - [**anIssuer.claim()**](./issuer#anissuer-claim-payment-optamount)
   - Transfers all digital assets from *payment* to a new **Payment**.
+- [**anIssuer.combine()**](./issuer#anissuer-combine-paymentsarray-opttotalamount)
+  - Combines multiple **Payments** into one new **Payment**.
 :::

--- a/main/reference/ertp-api/payment.md
+++ b/main/reference/ertp-api/payment.md
@@ -51,18 +51,12 @@ on or return a **Payment**.
 
 - [**anIssuer.burn()**](./issuer#anissuer-burn-payment-optamount)
   - Destroys all of the digital assets in the **Payment**.
-- [**anIssuer.claim()**](./issuer#anissuer-claim-payment-optamount)
-  - Transfers all digital assets from *payment* to a new **Payment**.
 - [**anIssuer.combine()**](./issuer#anissuer-combine-paymentsarray-opttotalamount)
   - Combines multiple **Payments** into one new **Payment**.
 - [**anIssuer.getAmountOf()**](./issuer#anissuer-getamountof-payment)
   - Describes the **Payment**'s balance as an **Amount**.
 - [**anIssuer.isLive()**](./issuer#anissuer-islive-payment)
   - Returns **true** if the **Payment** was created by the **Issuer** and is available for use (i.e., has not been consumed or burned).
-- [**anIssuer.split()**](./issuer#anissuer-split-payment-paymentamounta)
-  - Splits a single **Payment** into two new **Payments**.
-- [**anIssuer.splitMany()**](./issuer#anissuer-splitmany-payment-amountarray)
-  - Split a single **Payment** into multiple **Payments**.
 - [**aMint.mintPayment()**](./mint#amint-mintpayment-newamount)
   - Create new digital assets of the **Mint**'s associated **Brand**.
 - [**aPurse.deposit()**](./purse#apurse-deposit-payment-optamount)
@@ -71,3 +65,11 @@ on or return a **Payment**.
   - Creates and returns a new deposit-only facet of the **Purse** that allows arbitrary other parties to deposit **Payments** into the **Purse**.
 - [**aPurse.withdraw()**](./purse#apurse-withdraw-amount)
   - Withdraws the *amount* of specified digital assets from **Purse** into a new **Payment**.
+::: warning DEPRECATED
+- [**anIssuer.split()**](./issuer#anissuer-split-payment-paymentamounta)
+  - Splits a single **Payment** into two new **Payments**.
+- [**anIssuer.splitMany()**](./issuer#anissuer-splitmany-payment-amountarray)
+  - Split a single **Payment** into multiple **Payments**.
+- [**anIssuer.claim()**](./issuer#anissuer-claim-payment-optamount)
+  - Transfers all digital assets from *payment* to a new **Payment**.
+:::


### PR DESCRIPTION
The PR marks `split()`, `combine()`, `claim()`, and `splitMany()` methods of an issuer object as deprecated in various sections of the documentation where they've been documented.  

Routes to verify:
- [Issuer](https://80bc127d.documentation-7tp.pages.dev/reference/ertp-api/issuer.html)
- [Payment](https://80bc127d.documentation-7tp.pages.dev/reference/ertp-api/payment.html)
- [Purses and Payments](https://80bc127d.documentation-7tp.pages.dev/guides/ertp/purses-and-payments.html)
- [Issuers and Mints](https://80bc127d.documentation-7tp.pages.dev/guides/ertp/issuers-and-mints.html)