### PR TITLE
docs: adding smart contract entry to glossary

### DIFF
--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -587,7 +587,7 @@ the [UserSeat documentation](/reference/zoe-api/user-seat).
 ## Semi-fungible
 
 A semi-fungible asset is one that has distinct forms which are not interchangeable
-with each other, but in which instances of a single form may interchangeable with
+with each other, but in which instances of a single form may be interchangeable with
 other instances of the same form.
 As a variation on the [non-fungible](#non-fungible) theater ticket example, tickets
 might specify only a section, where the holder may sit in any seat of that section.

--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -604,24 +604,11 @@ An imaginary currency Agoric documentation uses in examples.
 
 ## Smart Contract
 
-A smart contract is a self-executing contract with the terms of the agreement directly written into lines of code. These contracts are stored and executed on a blockchain network. Smart contracts automatically enforce and execute the terms of a contract when predefined conditions are met, eliminating the need for intermediaries and reducing the risk of human error or manipulation. Like user accounts on a chain, smart contracts can "own" or hold digital assets themselves.
+A smart contract is a contract-​like arrangement expressed in code, where the behavior of the program enforces the terms of the contract. Smart contracts are able to solve some of the fundamental social problems that have traditionally been solved by legal contracts. For example, commerce often involves an exchange of one thing for another. However, the party that transfers their assets first leaves themselves vulnerable to the other party’s opportunism: the second party can simply walk away from the exchange with both parties’ assets. 
 
-Key Characteristics:
+Smart contracts solve this problem of opportunism during an exchange by providing an [escrow mechanism](#escrow) for the assets from both parties, only dispersing the assets after both parties have contributed. There is no need for a human intermediary to perform the escrow; the smart contract itself holds the assets. Because the behavior of the smart contract is fully described by its code, and that code runs on a decentralized blockchain with high integrity execution, the parties can be assured that the code describes exactly what will happen. As such, smart contracts hold the promise of being a market-​based solution for the opportunism problem that does not rely on State intervention.
 
-- Automated Execution: Smart contracts automatically execute actions when the conditions specified in the code are satisfied.
-- Transparency: The contract's code is usually transparent and accessible to all participants on the blockchain.
-- Immutability: Once deployed on the blockchain, the contract code cannot be altered, ensuring that the terms remain consistent and tamper-proof.
-- Trustless Transactions: Smart contracts operate in a decentralized manner, reducing the need for trust between parties as the contract enforces the terms.
-
-Applications:
-
-- Finance: Automating transactions, loan agreements, and insurance claims.
-- Supply Chain: Tracking goods and verifying authenticity.
-- Real Estate: Simplifying property transfers and rental agreements.
-- Voting Systems: Ensuring secure and transparent voting processes.
-
-In the context of the Agoric blockchain, smart contracts are written using JavaScript and leverage Agoric's secure environment to build and deploy reliable decentralized applications.
-
+In the context of the Agoric blockchain, smart contracts are written using JavaScript and leverage Agoric's [secure environment](#offer-safety) to build and deploy reliable decentralized applications.
 
 ## Terms
 

--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -605,20 +605,7 @@ An imaginary currency Agoric documentation uses in examples.
 ## Smart Contract
 
 A smart contract is a contract-​like arrangement expressed in code, where the behavior of the 
-program enforces the terms of the contract. Smart contracts are able to solve some of the
-fundamental social problems that have traditionally been solved by legal contracts. For example,
-commerce often involves an exchange of one thing for another. However, the party that transfers
-their assets first leaves themselves vulnerable to the other party’s opportunism: the second party
-can simply walk away from the exchange with both parties’ assets. 
-
-Smart contracts solve this problem of opportunism during an exchange by providing an 
-[escrow mechanism](#escrow) for the assets from both parties, only dispersing the assets after both
-parties have contributed. There is no need for a human intermediary to perform the escrow; the smart
-contract itself holds the assets. Because the behavior of the smart contract is fully described by
-its code, and that code runs on a decentralized blockchain with high integrity execution, the
-parties can be assured that the code describes exactly what will happen. As such, smart contracts
-hold the promise of being a market-​based solution for the opportunism problem that does not rely on
-State intervention.
+program enforces the terms of the contract.
 
 In the context of the Agoric blockchain, smart contracts are written using JavaScript and leverage
 Agoric's [secure environment](#offer-safety) to build and deploy reliable decentralized applications.

--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -604,11 +604,24 @@ An imaginary currency Agoric documentation uses in examples.
 
 ## Smart Contract
 
-A smart contract is a contract-​like arrangement expressed in code, where the behavior of the program enforces the terms of the contract. Smart contracts are able to solve some of the fundamental social problems that have traditionally been solved by legal contracts. For example, commerce often involves an exchange of one thing for another. However, the party that transfers their assets first leaves themselves vulnerable to the other party’s opportunism: the second party can simply walk away from the exchange with both parties’ assets. 
+A smart contract is a contract-​like arrangement expressed in code, where the behavior of the 
+program enforces the terms of the contract. Smart contracts are able to solve some of the
+fundamental social problems that have traditionally been solved by legal contracts. For example,
+commerce often involves an exchange of one thing for another. However, the party that transfers
+their assets first leaves themselves vulnerable to the other party’s opportunism: the second party
+can simply walk away from the exchange with both parties’ assets. 
 
-Smart contracts solve this problem of opportunism during an exchange by providing an [escrow mechanism](#escrow) for the assets from both parties, only dispersing the assets after both parties have contributed. There is no need for a human intermediary to perform the escrow; the smart contract itself holds the assets. Because the behavior of the smart contract is fully described by its code, and that code runs on a decentralized blockchain with high integrity execution, the parties can be assured that the code describes exactly what will happen. As such, smart contracts hold the promise of being a market-​based solution for the opportunism problem that does not rely on State intervention.
+Smart contracts solve this problem of opportunism during an exchange by providing an 
+[escrow mechanism](#escrow) for the assets from both parties, only dispersing the assets after both
+parties have contributed. There is no need for a human intermediary to perform the escrow; the smart
+contract itself holds the assets. Because the behavior of the smart contract is fully described by
+its code, and that code runs on a decentralized blockchain with high integrity execution, the
+parties can be assured that the code describes exactly what will happen. As such, smart contracts
+hold the promise of being a market-​based solution for the opportunism problem that does not rely on
+State intervention.
 
-In the context of the Agoric blockchain, smart contracts are written using JavaScript and leverage Agoric's [secure environment](#offer-safety) to build and deploy reliable decentralized applications.
+In the context of the Agoric blockchain, smart contracts are written using JavaScript and leverage
+Agoric's [secure environment](#offer-safety) to build and deploy reliable decentralized applications.
 
 ## Terms
 

--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -645,7 +645,7 @@ For more information, see the [Vat section in the Distributed JS Programming doc
 The concept of a vat is metaphorically inspired by the philosophical experiment known as “Brain in a Vat.” This thought experiment, explored in philosophy, posits a scenario in which a brain is sustained in a vat and connected to a computer that simulates reality, raising questions about knowledge, reality, and perception. Similarly, in the context of distributed systems, a vat isolates and encapsulates its contents, maintaining strict boundaries on synchronous and asynchronous communication, much like the hypothetical brain’s isolated and controlled environment. For more details, see the Wikipedia page on [Brain in a Vat](https://en.wikipedia.org/wiki/Brain_in_a_vat).
 
 
-# Vow
+## Vow
 
 Vows are objects that represent promises that can be stored durably. Native promises are not compatible with Agoric's durable stores, which means that on the Agoric platform, such promises disconnect their clients when their creator vat is upgraded.  
 

--- a/main/glossary/index.md
+++ b/main/glossary/index.md
@@ -602,6 +602,27 @@ Secure ECMAScript has been renamed to [Hardened JavaScript](#hardened-javascript
 
 An imaginary currency Agoric documentation uses in examples.
 
+## Smart Contract
+
+A smart contract is a self-executing contract with the terms of the agreement directly written into lines of code. These contracts are stored and executed on a blockchain network. Smart contracts automatically enforce and execute the terms of a contract when predefined conditions are met, eliminating the need for intermediaries and reducing the risk of human error or manipulation. Like user accounts on a chain, smart contracts can "own" or hold digital assets themselves.
+
+Key Characteristics:
+
+- Automated Execution: Smart contracts automatically execute actions when the conditions specified in the code are satisfied.
+- Transparency: The contract's code is usually transparent and accessible to all participants on the blockchain.
+- Immutability: Once deployed on the blockchain, the contract code cannot be altered, ensuring that the terms remain consistent and tamper-proof.
+- Trustless Transactions: Smart contracts operate in a decentralized manner, reducing the need for trust between parties as the contract enforces the terms.
+
+Applications:
+
+- Finance: Automating transactions, loan agreements, and insurance claims.
+- Supply Chain: Tracking goods and verifying authenticity.
+- Real Estate: Simplifying property transfers and rental agreements.
+- Voting Systems: Ensuring secure and transparent voting processes.
+
+In the context of the Agoric blockchain, smart contracts are written using JavaScript and leverage Agoric's secure environment to build and deploy reliable decentralized applications.
+
+
 ## Terms
 
 Contract instances have associated terms, gotten via [`E(zoe).getTerms(instance)`](/reference/zoe-api/zoe#e-zoe-getterms-instance),


### PR DESCRIPTION
Adding a glossary entry for smart contracts.


**ref(s):**
[https://papers.agoric.com/smart-contracts-encyclopedia-entry/](https://papers.agoric.com/smart-contracts-encyclopedia-entry/)
[https://github.com/Agoric/documentation/issues/62](https://github.com/Agoric/documentation/issues/62)
[https://github.com/Agoric/agoric-sdk/issues/244](https://github.com/Agoric/agoric-sdk/issues/244)