### PR TITLE
fix: bad link in core-eval proposal section

### DIFF
--- a/main/guides/coreeval/index.md
+++ b/main/guides/coreeval/index.md
@@ -1,7 +1,7 @@
 # Permissioned Contract Deployment
 
 Until mainnet enters the Mainnet-3 phase of the [multi-phase mainnet rollout](https://agoric.com/blog/announcements/mainnet-phase-0-launch),
-permissionless [contract installation with Zoe](/guides/zoe/#contract-installation)
+permissionless [contract installation with Zoe](/guides/zoe/contract-walkthru#contract-installation)
 is limited to development environments.
 
 Until then, permission to deploy contracts can be granted using an Agoric extension to [Cosmos SDK Governance](https://hub.cosmos.network/delegators/delegator-guide-cli.html#participating-in-governance) called `swingset.CoreEval`. As discussed in [governance using Hardened JavaScript: swingset\.CoreEval](https://community.agoric.com/t/bld-staker-governance-using-hardened-javascript-swingset-coreeval/99),

--- a/main/guides/coreeval/proposal.md
+++ b/main/guides/coreeval/proposal.md
@@ -122,7 +122,7 @@ There are also several more promise spaces one level down, including:
 - `powers.issuer`
 - `powers.brand`
 
-The `installContract` helper calls `E(zoe).installBundleID(bundleID)` to create an `Installation`, much like our earlier discussion of [Contract installation](../zoe/#contract-installation).
+The `installContract` helper calls `E(zoe).installBundleID(bundleID)` to create an `Installation`, much like our earlier discussion of [Contract installation](/guides/zoe/contract-walkthru#contract-installation).
 It also calls `powers.installation[name].resolve(installation)`.
 
 ```js


### PR DESCRIPTION
Contract Installation link in https://docs.agoric.com/guides/coreeval/proposal.html
points to: 
https://docs.agoric.com/guides/zoe/#contract-installation

There is no discussion about contract installation on that page. It seems that intended page with the 
relevant section is: https://docs.agoric.com/guides/zoe/contract-walkthru.html

I am fixing the link.
