### PR TITLE
chore: specify yarn version in getting started

### DIFF
--- a/main/guides/getting-started/index.md
+++ b/main/guides/getting-started/index.md
@@ -101,6 +101,12 @@ corepack enable
 yarn --version # for verification
 ```
 
+This app uses Yarn 1, so running the above command will show a version in the format ```1.x.x```. If you are using a different version of ```yarn```, you can use ```yarn set version <version>``` to switch like in the example below.
+
+```sh
+yarn set version 1.22.5
+```
+
 ### Installing Docker
 
 <details>


### PR DESCRIPTION
Refs: https://github.com/Agoric/documentation/issues/1174

`Installing Yarn` section in getting started docs does not specify a version. We currently only support Yarn 1 and this PR updates the docs to explicitly specify that. 