### PR TITLE
docs: re-focus main page on orchestration

### DIFF
--- a/main/index.md
+++ b/main/index.md
@@ -28,7 +28,7 @@ hero:
 features:
   - icon: ❓
     title: What is Agoric?
-    details: An overview of the Agoric chain and platform
+    details: The Agoric chain, tech stack, and ecosystem
     link: /what-is-agoric
 
   - icon: 🧑‍🎓️

--- a/main/index.md
+++ b/main/index.md
@@ -6,8 +6,8 @@ titleTemplate: Secured, Distributed JavaScript
 
 hero:
   name: Agoric
-  text: JavaScript-Powered Smart Contract Platform
-  tagline: Secure, adaptable, and approachable. Discover the blockchain framework tailored for JavaScript developers.
+  text: Orchestrate the Web3 Economy
+  tagline: Build feature-rich applications that seamlessly manage assets and services across multiple blockchains.
   actions:
     - theme: brand
       text: Get Started


### PR DESCRIPTION
In discussion with Santi, I updated the docs homepage to be more consistent with the main message on the Agoric homepage.

screenshot:

![image](https://github.com/user-attachments/assets/372f1cb9-40f1-4765-aadc-3371379bb71e)
