### PR TITLE
Clean Internal Links

### DIFF
--- a/main/guides/coreeval/permissions.md
+++ b/main/guides/coreeval/permissions.md
@@ -49,7 +49,7 @@ In the top level promise space, we have:
   **Warning: this includes access to over-write previously allocated storage nodes.**
 
 - **chainTimerService**: for getting the current timer and setting timer wake-ups; for example, at the conclusion of a governance vote.
-  See [Timer Service API](../../reference/repl/timerServices).
+  See [Timer Service API](/reference/repl/timerServices).
   **Note: this includes access to schedule infinitely repeating events.**
 
 - **namesByAddress**: for [looking up objects published under an address](../integration/name-services#namesbyaddress-namesbyaddressadmin-and-depositfacet-per-account-namespace); in particular,
@@ -60,6 +60,6 @@ In the top level promise space, we have:
 
 - **priceAuthority**: access to get price quotes and triggers; see [Price Authority Guide](../zoe/price-authority).
 
-- **priceAuthorityAdmin**: access to add and replace sources of price quotes using [E(priceAuthorityAdmin).registerPriceAuthority()](../../reference/zoe-api/price-authority-admin#e-priceauthorityregistryadmin-registerpriceauthority-priceauthority-brandin-brandout-force)
+- **priceAuthorityAdmin**: access to add and replace sources of price quotes using [E(priceAuthorityAdmin).registerPriceAuthority()](/reference/zoe-api/price-authority-admin#e-priceauthorityregistryadmin-registerpriceauthority-priceauthority-brandin-brandout-force)
 
-- **zoe**: the [Zoe service](../../reference/zoe-api//zoe)
+- **zoe**: the [Zoe service](/reference/zoe-api/zoe)

--- a/main/guides/ertp/index.md
+++ b/main/guides/ertp/index.md
@@ -6,7 +6,7 @@ JavaScript. Using the [ERTP API](/reference/ertp-api/),
 you can easily create and use digital assets, all of which are
 transferred exactly the same way and with exactly the same security properties.
 
-ERTP uses [OCaps (object capabilities)](../../glossary/#object-capabilities)
+ERTP uses [OCaps (object capabilities)](/glossary/#object-capabilities)
 to enforce access control. If your program has a reference to an
 object, it can call methods on that object. If it doesn't have a
 reference, it can't. For more on object capabilities, see
@@ -17,9 +17,9 @@ reference, it can't. For more on object capabilities, see
 ### Asset
 
 There are three kinds of assets:
-[fungible](../../glossary/#fungible),
-[non-fungible](../../glossary/#non-fungible), and
-[semi-fungible](../../glossary/#semi-fungible).
+[fungible](/glossary/#fungible),
+[non-fungible](/glossary/#non-fungible), and
+[semi-fungible](/glossary/#semi-fungible).
 
 Fungible assets are interchangeable. For example, if you have 100
 one-dollar bills and need to pay someone 5 dollars, it doesn't matter
@@ -191,7 +191,7 @@ her rather than someone else.
 
 Assume Alice already has a Quatloos `purse` of her own. To let other
 parties safely deposit Quatloos into it, she creates
-a [deposit facet](../../glossary/#deposit-facet) for that `purse`.
+a [deposit facet](/glossary/#deposit-facet) for that `purse`.
 Anyone who has access to a deposit facet can deposit
 assets to its `purse` but cannot either make a withdrawal from the `purse` or get its balance. It's like
 being able to send money to a friend via their email address; you can't then take money out
@@ -225,7 +225,7 @@ Things end up with your Quatloos `purse` having 2 Quatloos (7 - 5), Alice's Quat
 in it, and the 5 Quatloos `payment` consumed when the transfer happened.
 
 The `E()` notation is a local "bridge" that lets you invoke methods on remote objects.
-It takes a local representative (a [presence](../../glossary/#presence)) for a remote object
+It takes a local representative (a [presence](/glossary/#presence)) for a remote object
 as an argument and sends messages to the remote object. This is explained in more detail at the
 [`E()` section in the Distributed JavaScript page](../js-programming/eventual-send).
 
@@ -295,7 +295,7 @@ In the Agoric stack, assets of the exchange are escrowed with [Zoe](/guides/zoe/
 
 ## Object Capabilities and ERTP
 
-ERTP uses [object capabilities](../../glossary/#object-capabilities).
+ERTP uses [object capabilities](/glossary/#object-capabilities).
 You can only use an object and issue commands to it if you have access to that object, not
 just its human-readable name or similar. For example, I might know (or make a good guess),
 that the mint that makes Quatloos has the human-understandable alleged name of 'quatloos-mint'.
@@ -321,7 +321,7 @@ After a successful deposit, ERTP guarantees:
 When the `deposit` call throws an error (i.e. something went wrong), ERTP guarantees
 that neither the `purse` nor the alleged `payment` are affected by it.
 
-In addition, you can create a [deposit facet](../../glossary/#deposit-facet) for any `purse`. This is an object associated
+In addition, you can create a [deposit facet](/glossary/#deposit-facet) for any `purse`. This is an object associated
 with a specific `purse` that can be sent to another party instead of a reference to the `purse`.
 The security advantage is that the other party can only use the deposit facet to make deposits to the associated `purse`. They cannot use it to make a withdrawal from or ask about the balance of a `purse`.
 

--- a/main/guides/ertp/purses-and-payments.md
+++ b/main/guides/ertp/purses-and-payments.md
@@ -67,7 +67,7 @@ Unlike `payments`, `purses` are not meant to be sent to others. To transfer
 digital assets, you should withdraw a `payment` from a `purse` and send
 the `payment` to another party.
 
-You can create a [deposit facet](../../glossary/#deposit-facet) for a `purse`.
+You can create a [deposit facet](/glossary/#deposit-facet) for a `purse`.
 Deposit facets are either sent to other parties or made publicly known. Any party can deposit a `payment` into the
 deposit facet, which deposits it into its associated `purse`. However, no one can
 use a deposit facet to either make a withdrawal from its `purse` or get the `purse`'s balance.

--- a/main/guides/getting-started/contract-rpc.md
+++ b/main/guides/getting-started/contract-rpc.md
@@ -112,7 +112,7 @@ The [vstorage-viewer](https://vstorage.agoric.net/?path=published.agoricNames.or
 ## Specifying Offers
 
 Recall that for an agent within the JavaScript VM,
-[`E(zoe).offer(...)`](../../reference/zoe-api/zoe#e-zoe-offer-invitation-proposal-paymentpkeywordrecord-offerargs) takes an `Invitation` and optionally a `Proposal` with `{ give, want, exit }`, a `PaymentPKeywordRecord`, and `offerArgs`; it returns a `UserSeat` from which we can [getPayouts()](../../reference/zoe-api/user-seat#e-userseat-getpayouts).
+[`E(zoe).offer(...)`](/reference/zoe-api/zoe#e-zoe-offer-invitation-proposal-paymentpkeywordrecord-offerargs) takes an `Invitation` and optionally a `Proposal` with `{ give, want, exit }`, a `PaymentPKeywordRecord`, and `offerArgs`; it returns a `UserSeat` from which we can [getPayouts()](/reference/zoe-api/user-seat#e-userseat-getpayouts).
 
 ![Zoe API diagram, simplified](./assets/zoe-simp.svg)
 
@@ -195,7 +195,7 @@ To start with, amounts include `bigint`s. The `@endo/marshal` API handles those:
 To marshal brands and instances, recall from the discussion of [marshal in eventual send](../js-programming/eventual-send#e-and-marshal-a-closer-look)
 how remotables are marshalled with a translation table.
 
-The [Agoric Board](../../reference/repl/board) is a well-known name service that issues
+The [Agoric Board](/reference/repl/board) is a well-known name service that issues
 plain string identifiers for object identities and other passable _keys_ (that is: passable values excluding promises and errors).
 Contracts and other services can use its table of identifiers as a marshal
 translation table:

--- a/main/guides/getting-started/explainer-how-to-make-an-offer.md
+++ b/main/guides/getting-started/explainer-how-to-make-an-offer.md
@@ -2,7 +2,7 @@
 
 As you saw in the `dapp-offer-up` tutorial you could use the dapp UI to make an offer on up to three items.
 
-Take a look at our detailed [tutorial on how the UI for making offers](https://docs.agoric.com/guides/getting-started/ui-tutorial/making-an-offer.html) works in this dapp.
+Take a look at our detailed [tutorial on how the UI for making offers](/guides/getting-started/ui-tutorial/making-an-offer.html) works in this dapp.
 
 ### How it Looks
 

--- a/main/guides/getting-started/sell-concert-tickets-contract-explainer.md
+++ b/main/guides/getting-started/sell-concert-tickets-contract-explainer.md
@@ -37,12 +37,12 @@ const inventory = {
 ```
 
 Our contract takes the provided `inventory` object as a parameter to initiate the process.
-After the contract is initialized, a new [ERTP mint](https://docs.agoric.com/glossary/#mint) for the "Ticket" asset is created.
+After the contract is initialized, a new [ERTP mint](/glossary/#mint) for the "Ticket" asset is created.
 
 <details>
 <summary>Note: AssetKind expresses type of assets</summary>
 
-There are three types of [assets](https://docs.agoric.com/guides/ertp/#asset). You can determine the [type of your asset](https://docs.agoric.com/reference/ertp-api/ertp-data-types.html#assetkind) by referring to the provided documentation.
+There are three types of [assets](/guides/ertp/#asset). You can determine the [type of your asset](/reference/ertp-api/ertp-data-types.html#assetkind) by referring to the provided documentation.
 
 In our example, tickets are non-fungible and can have duplicates, meaning there can be many tickets of a single type. So, we are using `AssetKind.COPY_BAG`.
 
@@ -54,12 +54,12 @@ const { brand: ticketBrand } = ticketMint.getIssuerRecord();
 ```
 
 Once our asset is defined, we will mint our inventory at the start of our the smart contract and allocate it to our `inventorySeat` object.
-This also allows us to check if user is buying more than our inventory allows. This can be done using an [AmountMath API method](https://docs.agoric.com/reference/ertp-api/amount-math.html#amountmath-isgte-leftamount-rightamount-brand).
+This also allows us to check if user is buying more than our inventory allows. This can be done using an [AmountMath API method](/reference/ertp-api/amount-math.html#amountmath-isgte-leftamount-rightamount-brand).
 
 <details>
 <summary>To understand the code better:</summary>
 
-Take a look at [brand](https://docs.agoric.com/glossary/#brand), [AmountKeywordRecord](https://docs.agoric.com/reference/zoe-api/zoe-data-types.html#keywordrecord), [mintGains function](https://docs.agoric.com/reference/zoe-api/zcfmint.html#azcfmint-mintgains-gains-zcfseat) and [ZCFSeat](https://docs.agoric.com/reference/zoe-api/zcfseat.html#zcfseat-object).
+Take a look at [brand](/glossary/#brand), [AmountKeywordRecord](/reference/zoe-api/zoe-data-types.html#keywordrecord), [mintGains function](/reference/zoe-api/zcfmint.html#azcfmint-mintgains-gains-zcfseat) and [ZCFSeat](/reference/zoe-api/zcfseat.html#zcfseat-object).
 
 </details>
 
@@ -81,7 +81,7 @@ const inventorySeat = ticketMint.mintGains(toMint);
 
 ## Trading Tickets
 
-Customers who wish to purchase event tickets first [make an invitation](https://docs.agoric.com/reference/zoe-api/zoe-contract-facet.html#zcf-makeinvitation-offerhandler-description-customdetails-proposalshape) to trade for tickets using `makeTradeInvitation`.
+Customers who wish to purchase event tickets first [make an invitation](/reference/zoe-api/zoe-contract-facet.md#zcf-makeinvitation-offerhandler-description-customdetails-proposalshape) to trade for tickets using `makeTradeInvitation`.
 
 ```js
 const makeTradeInvitation = () =>
@@ -99,7 +99,7 @@ const tradeHandler = buyerSeat => {
 };
 ```
 
-- **proposalShape** (Optional): This object outlines the necessary and permissible elements of each [proposal](https://docs.agoric.com/reference/zoe-api/zoe-contract-facet.html#proposal-shapes). Here is the proposal shape for this contract.
+- **proposalShape** (Optional): This object outlines the necessary and permissible elements of each [proposal](/reference/zoe-api/zoe-contract-facet.html#proposal-shapes). Here is the proposal shape for this contract.
 
 ```js
 const proposalShape = harden({

--- a/main/guides/getting-started/ui-tutorial/agoric-provider.md
+++ b/main/guides/getting-started/ui-tutorial/agoric-provider.md
@@ -74,7 +74,7 @@ export default App;
 ```
 
 You may have noticed the `defaultChainName` prop points to a local chain. This assumes
-that you are still running the local chain from [Getting Started](../../getting-started/index.md) in Docker. If you're not, make sure to follow those steps before proceeding.
+that you are still running the local chain from [Getting Started](/guides/getting-started/index.md) in Docker. If you're not, make sure to follow those steps before proceeding.
 
 Note: If you see a type error on the `wallets` prop, this is likely because `@agoric/react-components` is using an older version of `cosmos-kit` than what was installed in your app. To fix this, you can add `resolutions` to your `package.json` like so:
 

--- a/main/guides/getting-started/ui-tutorial/connect-wallet.md
+++ b/main/guides/getting-started/ui-tutorial/connect-wallet.md
@@ -79,7 +79,7 @@ export const usePurse = (brandPetname: string) => {
 
 This provides a utility for looking up a user's purse by name. Notice how it accesses `purses` from `useAgoric()`.
 The `<AgoricProvider>` handles all the chain queries to fetch the purses, and automatically polls and
-updates `purses` whenever the balances change. It also coalesces ERTP purses with [VBank Assets and Cosmos Bank Balances](../../getting-started/contract-rpc.md#vbank-assets-and-cosmos-bank-balances) automatically. See [Smart Wallet VStorage Topics](../../getting-started/contract-rpc.md#smart-wallet-vstorage-topics)
+updates `purses` whenever the balances change. It also coalesces ERTP purses with [VBank Assets and Cosmos Bank Balances](/guides/getting-started/contract-rpc.md#vbank-assets-and-cosmos-bank-balances) automatically. See [Smart Wallet VStorage Topics](/guides/getting-started/contract-rpc.md#smart-wallet-vstorage-topics)
 for more details about where this data comes from.
 
 Next, we'll add a dependency on `@agoric/web-components`, which provides a utility for rendering

--- a/main/guides/getting-started/ui-tutorial/making-an-offer.md
+++ b/main/guides/getting-started/ui-tutorial/making-an-offer.md
@@ -177,7 +177,7 @@ Next, get the `makeOffer` function from the `useAgoric()` hook:
 const { makeOffer } = useAgoric();
 ```
 
-Now, create a function to submit the offer. For more details on how this works, see [making an offer](../../getting-started/explainer-how-to-make-an-offer.md):
+Now, create a function to submit the offer. For more details on how this works, see [making an offer](/guides/getting-started/explainer-how-to-make-an-offer.md):
 
 ```ts
 import { makeCopyBag } from '@agoric/store';
@@ -213,7 +213,7 @@ const submitOffer = () => {
 };
 ```
 
-For specifics on how offers work, see [Specifying Offers](../../getting-started/contract-rpc.md#specifying-offers). The `makeOffer` function allows you to specify an
+For specifics on how offers work, see [Specifying Offers](/guides/getting-started/contract-rpc.md#specifying-offers). The `makeOffer` function allows you to specify an
 `InvitationSpec`, automatically handles the marshalling aspect, and makes it easy to
 handle updates to the offer status.
 
@@ -244,7 +244,7 @@ Now, simply add a button to submit the offer:
 Upon clicking the offer, you should see a Keplr window pop up to approve the transaction with the "Give" and "Want"
 you selected. Try selecting 3 items, and giving 0.25 IST, and the offer should be accepted. See what happens
 if you select more than 3 items, or give less than 0.25 IST... it should reject the offer, and you should be
-refunded your IST (see [offer safety](../../../guides/zoe/offer-safety.md))
+refunded your IST (see [offer safety](/guides/zoe/offer-safety.md))
 
 ### Rendering the Items Purse
 
@@ -281,4 +281,4 @@ solution for this example, check out the [checkpoint-5](https://github.com/agori
 
 ### Result
 
-Curious to know how it looks after implementation? Check out our [guide](https://docs.agoric.com/guides/getting-started/explainer-how-to-make-an-offer.html) for the result.
+Curious to know how it looks after implementation? Check out our [guide](/guides/getting-started/explainer-how-to-make-an-offer.html) for the result.

--- a/main/guides/getting-started/ui-tutorial/querying-vstorage.md
+++ b/main/guides/getting-started/ui-tutorial/querying-vstorage.md
@@ -20,7 +20,7 @@ const { chainStorageWatcher } = useAgoric();
 ## Querying Vstorage
 
 In order to submit an offer to a contract, we need to look it up on-chain first.
-We'll find it in vstorage under `published.agoricNames.instance` (see: [vstorage reference](../../../reference/vstorage-ref.md)).
+We'll find it in vstorage under `published.agoricNames.instance` (see: [vstorage reference](/reference/vstorage-ref.md)).
 First, we'll create a new component that will look up the contract (eventually, it will sign and submit offers to it as well).
 
 Create a new file, `src/Trade.tsx`:
@@ -115,7 +115,7 @@ As you can see, this hook makes use of `chainStorageWatcher` to watch two vstora
 The `chainStorageWatcher` handles all the vstorage queries and marshalling for you, so
 you get convenient access to the data from your application. It automatically polls
 and emits updates when the data on-chain changes. For more details about vstorage, see
-[Querying VStorage](../../getting-started/contract-rpc.md#querying-vstorage) and [Publishing to Chain Storage](../../zoe/pub-to-storage.md)
+[Querying VStorage](/guides/getting-started/contract-rpc.md#querying-vstorage) and [Publishing to Chain Storage](/guides/zoe/pub-to-storage.md)
 
 Next, go ahead and add this hook to the `Trade` component you made before this:
 

--- a/main/guides/js-programming/notifiers.md
+++ b/main/guides/js-programming/notifiers.md
@@ -263,7 +263,7 @@ hang or miss values.
 
 For distributed operations, all the iteration values&mdash;non-final values,
 successful completion value, failure reason&mdash;must be _Passable_, which means they're values that
-can somehow be passed between [vats](../../glossary/index#vat). The rest of this doc assumes all these
+can somehow be passed between [vats](/glossary/index#vat). The rest of this doc assumes all these
 values are Passable.
 
 The `makeNotifierKit()` or `makeSubscriptionKit()` call makes the notifier/updater

--- a/main/guides/zoe/actual-contracts/index.md
+++ b/main/guides/zoe/actual-contracts/index.md
@@ -25,13 +25,13 @@ Other services run in vats that are not contracts.
 
 | vat            | services                                                                               |
 | -------------- | -------------------------------------------------------------------------------------- |
-| bootstrap      | initial vat. also runs [core eval scripts](../../coreeval/)                            |
-| vatAdmin       | creates, [upgrades](../../zoe/contract-upgrade), and terminates vats                   |
-| agoricNames    | the `agoricNames` [name service](../../integration/name-services)                      |
+| bootstrap      | initial vat. also runs [core eval scripts](/guides/coreeval/)                          |
+| vatAdmin       | creates, [upgrades](/guides/zoe/contract-upgrade), and terminates vats                 |
+| agoricNames    | the `agoricNames` [name service](/guides/integration/name-services)                    |
 | bank           | connects cosmos denoms with ERTP Brands/Issuers/Mints                                  |
-| board          | the `board` [name service](../../integration/name-services)                            |
+| board          | the `board` [name service](/guides/integration/name-services)                          |
 | bridge         | chainStorage etc.                                                                      |
 | priceAuthority | registers [Price Authorities](../price-authority) and routes requests for price quotes |
-| provisioning   | `namesByAddress` [name service](../../integration/name-services)                       |
+| provisioning   | `namesByAddress` [name service](/guides/integration/name-services)                     |
 | timer          | `chainTimerService`                                                                    |
 | zoe            | the Zoe Service                                                                        |

--- a/main/guides/zoe/contract-upgrade.md
+++ b/main/guides/zoe/contract-upgrade.md
@@ -177,7 +177,7 @@ Define all exo classes/kits before any incoming method calls from other vats -- 
 
 ### Baggage
 
-baggage is a MapStore that provides a way to preserve the state and behavior of objects between [smart contract upgrades](https://docs.agoric.com/guides/zoe/contract-upgrade) in a way that preserves the identity of objects as seen from other [vats](#vat). In the provided contract, baggage is used to ensure that the state of various components is maintained even after the contract is upgraded.
+baggage is a MapStore that provides a way to preserve the state and behavior of objects between [smart contract upgrades](/guides/zoe/contract-upgrade) in a way that preserves the identity of objects as seen from other [vats](#vat). In the provided contract, baggage is used to ensure that the state of various components is maintained even after the contract is upgraded.
 
 ```js
 export const start = async (zcf, privateArgs, baggage) => {

--- a/main/reference/repl/board.md
+++ b/main/reference/repl/board.md
@@ -1,1 +1,1 @@
-see [Board Name Service](../../guides/integration/name-services#the-board-publishing-under-arbitrary-names)
+see [Board Name Service](/guides/integration/name-services#the-board-publishing-under-arbitrary-names)

--- a/main/reference/repl/priceAuthority.md
+++ b/main/reference/repl/priceAuthority.md
@@ -1,1 +1,1 @@
-see [Price Authority Guide](../../guides/zoe/price-authority), [PriceAuthority API](../zoe-api/price-authority)
+see [Price Authority Guide](/guides/zoe/price-authority), [PriceAuthority API](../zoe-api/price-authority)

--- a/main/reference/vstorage-ref.md
+++ b/main/reference/vstorage-ref.md
@@ -3,7 +3,7 @@
 See also:
 
 - [Querying VStorage](/guides/getting-started/contract-rpc#querying-vstorage)
-- [Publishing to chainStorage](../guides/zoe/pub-to-storage)
+- [Publishing to chainStorage](/guides/zoe/pub-to-storage)
 - [x/vstorage module](https://github.com/Agoric/agoric-sdk/tree/003f0c2232815a8d64a3f9a5b05521a10160ce34/golang/cosmos/x/vstorage#readme)
 
 ## vstorage: top level keys
@@ -47,7 +47,7 @@ see also [Inter Protocol data](https://github.com/Agoric/agoric-sdk/tree/agoric-
 ## vstorage: agoricNames hubs
 
 agoricNames contains several other NameHubs.
-See also [agoricNames](https://docs.agoric.com/guides/integration/name-services.html#agoricnames-agoricnamesadmin-well-known-names).
+See also [agoricNames](/guides/integration/name-services.html#agoricnames-agoricnamesadmin-well-known-names).
 
 ```js
 ['brand', 'installation', 'instance', 'issuer', 'oracleBrand', 'vbankAsset'];
@@ -57,7 +57,7 @@ See also [agoricNames](https://docs.agoric.com/guides/integration/name-services.
 
 `published.agoricNames.installation` contains _Installations_ representing code of important contracts. The data at this key are the entries of the NameHub. Here we show the object comprised
 of those entries.
-See also [agoricNames in vstorage](https://docs.agoric.com/guides/integration/name-services.html#agoricnames-in-vstorage)
+See also [agoricNames in vstorage](/guides/integration/name-services.html#agoricnames-in-vstorage)
 regarding un-marshalling the data using board IDs.
 
 ```js


### PR DESCRIPTION
Mostly simplify internal links in docs. Clean, for example, `../../..` type links.