### PR TITLE
ci: update cf pages user agent name

### DIFF
--- a/.github/workflows/cf-logs-fetcher.yml
+++ b/.github/workflows/cf-logs-fetcher.yml
@@ -4,7 +4,7 @@ on:
     types: [created, edited]
 jobs:
   fetch_comment_log:
-    if: ${{ (github.event.issue.pull_request) && (github.event.comment.user.login == 'cloudflare-pages[bot]' ) }}
+    if: ${{ (github.event.issue.pull_request) && (github.event.comment.user.login == 'cloudflare-workers-and-pages[bot]' ) }}
     runs-on: [ubuntu-latest]
     steps:
       - name: Fetch & Print The Deployment Logs


### PR DESCRIPTION
### Description

When working on sites deployed via CF Pages, devs have been having issues trying to debug build failures. We have a custom action that fetches build logs from CF and displays them in a github workflow by posting a comment with an easy to access logs link.

The root cause was a change in user agent name (presumably from CF's side). Have verified this is a user agent mismatch by forking this repo to my personal account, and adding relevant debug info. [github triggers `issue_comment` triggered workflows from the default branch hence the workaround for debugging]

Can verify name mismatch [here](https://github.com/mujahidkay/documentation/actions/runs/11305324030/job/31444695341)

```
Debugging information:
Is Pull Request: true
Comment Author: cloudflare-workers-and-pages[bot]
Condition Met: false
```