### PR TITLE
Fix broken links in Price Authority documentation

### DIFF
--- a/main/reference/repl/priceAuthority.md
+++ b/main/reference/repl/priceAuthority.md
@@ -1,1 +1,1 @@
-see [Price Authority Guide](/guides/zoe/price-authority), [PriceAuthority API](../zoe-api/price-authority)
+see [Price Authority Guide](../../guides/zoe/price-authority.md), [PriceAuthority API](../zoe-api/price-authority.md)


### PR DESCRIPTION
## Description 
This PR addresses an issue with broken links in the Price Authority landing page documentation.

## Changes Made:

Corrected URLs that were previously leading to 404 errors.
Verified that the updated links now point to the appropriate resources.