### PR TITLE
docs: update parameter type for getProposalShapeForInvitation()

### DIFF
--- a/main/reference/zoe-api/zoe.md
+++ b/main/reference/zoe-api/zoe.md
@@ -197,9 +197,9 @@ these methods:
 const instance = await E(Zoe).getInstance(invitation);
 ```
 
-## E(Zoe).getProposalShapeForInvitation(invitation)
+## E(Zoe).getProposalShapeForInvitation(invitationHandle)
 
-- **invitation**: **[Invitation](./zoe-data-types#invitation)**
+- **invitationHandle**: **[Handle](./zoe-data-types#handle)**
 - Returns: **Promise&lt;[Pattern](https://github.com/endojs/endo/tree/master/packages/patterns#readme)>**
 
 Returns a **Promise** for the **Pattern** that the **Invitation's** **Proposal** adheres to.


### PR DESCRIPTION
I included a test for `getProposalShapeForInvitation()` in a more general test for invitation guards, and discovered that the docs were incorrect. This corrects them.