### PR TITLE
lint: highlight `yarn format` usage on errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint-fix": "yarn lint --fix",
     "lint": "eslint 'snippets/**/*.js'",
     "format": "node scripts/markdown-js-snippets-linter.mjs 'main/**/*.md' --fix && prettier --write '**/*.md' --config .prettierrc.json",
-    "lint:format": "node scripts/markdown-js-snippets-linter.mjs 'main/**/*.md' && prettier --check '**/*.md' --config .prettierrc.json",
+    "lint:format": "node scripts/format.mjs",
     "build": "exit 0"
   },
   "packageManager": "yarn@4.5.0",

--- a/scripts/format.mjs
+++ b/scripts/format.mjs
@@ -1,0 +1,12 @@
+import { exec } from 'child_process';
+
+exec('node scripts/markdown-js-snippets-linter.mjs "main/**/*.md" && prettier --check "**/*.md" --config .prettierrc.json', (err, stdout, stderr) => {
+  if (err) {
+    const modifiedStderr = stderr.replace(
+      'Run Prettier with --write to fix',
+      'Run `yarn format` to fix'
+    );
+    console.warn(modifiedStderr);
+    process.exit(1);
+  }
+});

--- a/scripts/markdown-js-snippets-linter.mjs
+++ b/scripts/markdown-js-snippets-linter.mjs
@@ -206,7 +206,7 @@ const processFiles = async (globPattern, fix = false) => {
       if (fix) {
         console.log("All matching files have been updated with the necessary changes.");
       } else {
-        console.error("Run with --fix to automatically fix these errors and replace \`\`\`javascript with \`\`\`js.");
+        console.error("Run `yarn format` to automatically fix these errors");
       }
     } else {
       console.log("No errors found in any of the matching files.");


### PR DESCRIPTION
### Description

In an effort to address visibility issues regarding what command to run to fix lint errors, this PR highlights the usage of `yarn format` on encountering lint errors. [Relevant thread](https://agoricopco.slack.com/archives/C03G190GBHP/p1733339480648079).