### PR TITLE
docs: getPayout() throws if there's no payment for the keyword

### DIFF
--- a/main/reference/zoe-api/user-seat.md
+++ b/main/reference/zoe-api/user-seat.md
@@ -66,6 +66,9 @@ redirecting escrowed assets in accordance with the result of the transaction.
 
 The promise will be resolved promptly once the seat exits.
 
+If there is no payment corresponding to the keyword, an error will be
+thrown.
+
 ## E(UserSeat).getOfferResult()
 
 - Returns: **Promise&lt;OfferResult>**


### PR DESCRIPTION
Issue [8610](https://github.com/Agoric/agoric-sdk/issues/8610) pointed out that `E(zoeSeat).getPayout('foo');` returned undefined when the keyword was unknown, while the types claimed that it always returned a Payment. 

[10738](https://github.com/Agoric/agoric-sdk/issues/10738) changed Zoe to throw if the Payment didn't exist. This PR updates the documentation to mention that error.

